### PR TITLE
Improve password security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "bootsnap", require: false
 gem "config"
 gem "cssbundling-rails"
 gem "devise"
+gem "devise-pwned_password"
 gem "faker", github: "misaka/faker", branch: "add_alternative_name"
 gem "fhir_client"
 gem "good_job"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,6 +158,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-pwned_password (0.1.10)
+      devise (~> 4)
+      pwned (~> 2.0.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
     dockerfile-rails (1.5.10)
@@ -374,6 +377,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.1)
       activesupport (>= 3.0.0)
+    pwned (2.0.2)
     raabro (1.4.0)
     racc (1.7.1)
     rack (2.2.8)
@@ -590,6 +594,7 @@ DEPENDENCIES
   cuprite
   debug
   devise
+  devise-pwned_password
   dockerfile-rails (>= 1.0.0)
   factory_bot_rails
   faker!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ApplicationRecord
          :timeoutable,
          :recoverable,
          :validatable
+  devise :pwned_password unless Rails.env.test?
 
   has_and_belongs_to_many :teams
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -63,3 +63,4 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      pwned_password: "This password appeared in a data breach. Choose a different password"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,7 +183,7 @@ en:
               blank: Enter an email address
             password:
               blank: Enter a password
-              too_short: Enter a password that is at least 6 characters long
+              too_short: Enter a password that is at least 8 characters long
               too_long: Enter a password that is less than 128 characters long
             password_confirmation:
               confirmation: The password and confirmation do not match

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,6 +27,6 @@ FactoryBot.define do
     full_name { |n| "Test User #{n}" }
     email { |n| "test-#{n}@localhost" }
     teams { [Team.first || create(:team)] }
-    password { "rosebud" }
+    password { "rosebud1" }
   end
 end


### PR DESCRIPTION
Bump the minimum character requirement to 8 characters as per the [design system guidance](https://design-system.service.gov.uk/patterns/passwords/).

Integrate the [devise-pwned_password](https://github.com/michaelbanfield/devise-pwned_password) gem to check that user-submitted passwords haven't been found in any previous security breaches.

The gem has an implicit timeout of 5 seconds, and is also designed to work as a progressive enhancement, so it [won't block our users if the HaveIBeenPwned API goes down](https://github.com/michaelbanfield/devise-pwned_password#considerations):

> The gem is designed to silently swallows errors if the PwnedPasswords service is unavailable, allowing users to use compromised passwords during the time when it is unavailable.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/84bf97d5-52af-44d7-8037-d36e1dbd66b5)

