### PR TITLE
Implement email and phone validator

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -97,6 +97,7 @@ class ConsentForm < ApplicationRecord
                 presence: true,
                 if: :parent_relationship_other?
       validates :parent_email, presence: true, email: true
+      validates :parent_phone, phone_number: true, if: :parent_phone?
     end
 
     with_options if: -> { required_for_step?(:contact_method) } do

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -96,7 +96,7 @@ class ConsentForm < ApplicationRecord
       validates :parent_relationship_other,
                 presence: true,
                 if: :parent_relationship_other?
-      validates :parent_email, presence: true
+      validates :parent_email, presence: true, email: true
     end
 
     with_options if: -> { required_for_step?(:contact_method) } do

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,0 +1,34 @@
+class EmailValidator < ActiveModel::EachValidator
+  VALID_LOCAL_CHARS = 'a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-'.freeze
+  EMAIL_REGEX_PATTERN = /^[#{VALID_LOCAL_CHARS}]+@([^.@][^@\s]+)$/
+  HOSTNAME_PART = /^(xn|[a-z0-9]+)(-?-[a-z0-9]+)*$/i
+  TLD_PART = /^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$/i
+
+  def validate_each(record, attribute, value)
+    match = EMAIL_REGEX_PATTERN.match(value)
+
+    if !match || value.length > 320 || value.include?("..")
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    hostname = match[1]
+
+    parts = hostname.split(".")
+
+    if hostname.length > 253 || parts.length < 2
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    unless parts.all? { |part| HOSTNAME_PART.match?(part) }
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    unless TLD_PART.match?(parts.last)
+      record.errors.add(attribute, :invalid)
+      return # rubocop:disable Style/RedundantReturn
+    end
+  end
+end

--- a/app/validators/phone_number_validator.rb
+++ b/app/validators/phone_number_validator.rb
@@ -1,0 +1,34 @@
+class PhoneNumberValidator < ActiveModel::EachValidator
+  UK_PREFIX = "44".freeze
+  ALL_WHITESPACE = " \t\r\n".freeze
+
+  def validate_each(record, attribute, value)
+    number = value.to_s.tr("#{ALL_WHITESPACE}()\\-+", "")
+    unless number =~ /\A\d+\z/
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    number = number.sub(/^0+/, "").delete_prefix(UK_PREFIX).delete_prefix("0")
+
+    unless number.start_with?("7")
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    if number.length > 10
+      record.errors.add(attribute, :invalid)
+      return
+    end
+
+    if number.length < 10
+      record.errors.add(attribute, :invalid)
+      return # rubocop:disable Style/RedundantReturn
+    end
+  end
+
+  private
+
+  def normalise_phone_number(number)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -157,6 +157,9 @@ en:
               blank: Enter your relationship
             parent_email:
               blank: Enter your email address
+              invalid: Enter a valid email address, such as j.doe@gmail.com
+            parent_phone:
+              invalid: Enter a valid phone number, like 07632 960 001
             contact_method:
               inclusion: Choose a contact method
             contact_method_other:

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -137,6 +137,9 @@ RSpec.describe ConsentForm, type: :model do
       it { should validate_presence_of(:parent_relationship).on(:update) }
       it { should validate_presence_of(:parent_email).on(:update) }
 
+      it { should_not allow_value("invalid").for(:parent_email).on(:update) }
+      it { should allow_value("foo@foo.com").for(:parent_email).on(:update) }
+
       context "when parent_relationship is 'other'" do
         let(:parent_relationship) { "other" }
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -140,6 +140,8 @@ RSpec.describe ConsentForm, type: :model do
       it { should_not allow_value("invalid").for(:parent_email).on(:update) }
       it { should allow_value("foo@foo.com").for(:parent_email).on(:update) }
 
+      it { should_not allow_value("invalid").for(:parent_phone).on(:update) }
+
       context "when parent_relationship is 'other'" do
         let(:parent_relationship) { "other" }
 

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -226,16 +226,8 @@ RSpec.describe ConsentForm, type: :model do
       it { should validate_presence_of(:address_town).on(:update) }
       it { should validate_presence_of(:address_postcode).on(:update) }
 
-      it "validates the postcode" do
-        consent_form =
-          build(
-            :consent_form,
-            address_postcode: "asdf",
-            form_step: :address,
-            response: "given"
-          )
-        expect(consent_form.valid?(:update)).to be_falsey
-        expect(consent_form.errors[:address_postcode]).to be_present
+      it do
+        should_not allow_value("invalid").for(:address_postcode).on(:update)
       end
     end
   end

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+RSpec.describe EmailValidator do
+  subject(:model) do
+    cls =
+      Class.new do
+        include ActiveModel::Validations
+        attr_accessor :email
+        validates :email, email: true
+      end
+    cls.new
+  end
+
+  let(:valid_email_addresses) do
+    [
+      "email@domain.com",
+      "email@domain.COM",
+      "firstname.lastname@domain.com",
+      "firstname.o'lastname@domain.com",
+      "email@subdomain.domain.com",
+      "firstname+lastname@domain.com",
+      "1234567890@domain.com",
+      "email@domain-one.com",
+      "_______@domain.com",
+      "email@domain.name",
+      "email@domain.superlongtld",
+      "email@domain.co.jp",
+      "firstname-lastname@domain.com",
+      # "info@german-financial-services.vermögensberatung",
+      "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
+      # "japanese-info@例え.テスト",
+      "email@double--hyphen.com"
+    ]
+  end
+
+  let(:invalid_email_addresses) do
+    [
+      "email@123.123.123.123",
+      "email@[123.123.123.123]",
+      "plainaddress",
+      "@no-local-part.com",
+      "Outlook Contact <outlook-contact@domain.com>",
+      "no-at.domain.com",
+      "no-tld@domain",
+      ";beginning-semicolon@domain.co.uk",
+      "middle-semicolon@domain.co;uk",
+      "trailing-semicolon@domain.com;",
+      '"email+leading-quotes@domain.com',
+      'email+middle"-quotes@domain.com',
+      '"quoted-local-part"@domain.com',
+      '"quoted@domain.com"',
+      "lots-of-dots@domain..gov..uk",
+      "two-dots..in-local@domain.com",
+      "multiple@domains@domain.com",
+      "spaces in local@domain.com",
+      "spaces-in-domain@dom ain.com",
+      "underscores-in-domain@dom_ain.com",
+      "pipe-in-domain@example.com|gov.uk",
+      "comma,in-local@gov.uk",
+      "comma-in-domain@domain,gov.uk",
+      "pound-sign-in-local£@domain.com",
+      "local-with-’-apostrophe@domain.com",
+      "local-with-”-quotes@domain.com",
+      "domain-starts-with-a-dot@.domain.com",
+      "brackets(in)local@domain.com",
+      "email-too-long-#{"a" * 320}@example.com",
+      "incorrect-punycode@xn---something.com"
+    ]
+  end
+
+  it "validates valid email addresses" do
+    valid_email_addresses.each do |email|
+      model.email = email
+      expect(model).to be_valid
+    end
+  end
+
+  it "does not validate invalid email addresses" do
+    invalid_email_addresses.each do |email|
+      model.email = email
+      expect(model).not_to be_valid
+    end
+  end
+end

--- a/spec/validators/phone_number_validator_spec.rb
+++ b/spec/validators/phone_number_validator_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe PhoneNumberValidator do
+  subject do
+    cls =
+      Class.new do
+        include ActiveModel::Model
+        attr_accessor :phone_number
+
+        def self.model_name
+          ActiveModel::Name.new(self, nil, "temp")
+        end
+
+        validates :phone_number, phone_number: true
+      end
+    cls.new
+  end
+
+  describe "valid phone numbers" do
+    it "should be valid" do
+      [
+        "7123456789",
+        "07123456789",
+        "07123 456789",
+        "07123-456-789",
+        "00447123456789",
+        "00 44 7123456789",
+        "+447123456789",
+        "+44 7123 456 789",
+        "+44 (0)7123 456 789"
+        # "\u200B\t\t+44 (0)7123 \uFEFF 456 789 \r\n"
+      ].each do |valid_number|
+        subject.phone_number = valid_number
+        expect(subject).to be_valid
+      end
+    end
+  end
+
+  describe "invalid phone numbers" do
+    [
+      [
+        "is invalid", # "is too long",
+        [
+          "712345678910",
+          "0712345678910",
+          "0044712345678910",
+          "+44 (0)7123 456 789 10"
+        ]
+      ],
+      [
+        "is invalid", # "is too short",
+        ["0712345678", "00447123456", "004471234567", "+44 (0)7123 456 78"]
+      ],
+      [
+        "is invalid", # "does not look like a UK mobile number",
+        [
+          "08081 570364",
+          "+44 8081 570364",
+          "0117 496 0860",
+          "+44 117 496 0860",
+          "020 7946 0991",
+          "+44 20 7946 0991"
+        ]
+      ],
+      [
+        "is invalid", # "can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
+        [
+          "07890x32109",
+          "07123 456789...",
+          "07123 ☟☜⬇⬆☞☝",
+          "07123☟☜⬇⬆☞☝",
+          '07";DROP TABLE;"',
+          "+44 07ab cde fgh",
+          "ALPHANUM3R1C"
+        ]
+      ]
+    ].each do |error_message, invalid_numbers|
+      context "when #{error_message}" do
+        it "should be invalid" do
+          invalid_numbers.each do |invalid_number|
+            subject.phone_number = invalid_number
+            expect(subject).not_to be_valid
+            expect(subject.errors[:phone_number]).to include(error_message)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR contains an email and phone validator that's implemented to a similar spec as the GOVUK Notify one. This reduces the chance that emails entered by our users will be rejected by Notify.

It follows their implementation and implements their test cases:

- https://github.com/alphagov/notifications-utils/blob/9311851c105237dc5d770c9f1c0a5ad4c2acb380/notifications_utils/recipients.py#L622
- https://github.com/alphagov/notifications-utils/blob/9311851c105237dc5d770c9f1c0a5ad4c2acb380/notifications_utils/__init__.py#L14
- https://github.com/alphagov/notifications-utils/blob/9311851c105237dc5d770c9f1c0a5ad4c2acb380/tests/test_recipient_validation.py#L118

For the email validator, International Domain Names (IDNs) are not currently implemented. The two test cases with non-UTF-8 characters are commented out.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/ee898da3-97af-4586-8c8b-afce36893d4d)
