### PR TITLE
Fix heroku release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -2,7 +2,7 @@
 
 set -e
 
-if [[ "$IS_REVIEW" == "true" && `bin/rails db:version` == "Current version: 0" ]]; then
+if [[ "$IS_REVIEW" == "true" && `bin/rails db:version | grep version` == "Current version: 0" ]]; then
   bin/rails db:schema:load
 else
   bin/rails db:migrate


### PR DESCRIPTION
Since updating to 7.1, the `STDOUT` of `bin/rails db:version` has changed to include the current database being used:

```
$ bin/rails db:version
database: manage_vaccinations_development
Current version: 0
```

Before, it was just `Current version: 0`.