### PR TITLE
Add consent form confirmation page and email

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -156,3 +156,19 @@ $color_app-pale-blue: #ccdff1;
     margin-bottom: 0;
   }
 }
+
+.nhsuk-panel {
+  @extend .govuk-panel;
+
+  &--confirmation {
+    @extend .govuk-panel--confirmation;
+  }
+
+  &__title {
+    @extend .govuk-panel__title;
+  }
+}
+
+.app-panel h1 {
+  @include nhsuk-font(32, $weight: bold);
+}

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -41,5 +41,7 @@ class ConsentFormsController < ConsentForms::BaseController
     @consent_form.update!(recorded_at: Time.zone.now)
 
     session.delete(:consent_form_id)
+
+    ConsentFormMailer.confirmation(@consent_form).deliver_later
   end
 end

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -41,7 +41,5 @@ class ConsentFormsController < ConsentForms::BaseController
     @consent_form.update!(recorded_at: Time.zone.now)
 
     session.delete(:consent_form_id)
-
-    redirect_to "/"
   end
 end

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -1,0 +1,18 @@
+class ConsentFormMailer < ApplicationMailer
+  def confirmation(consent_form)
+    template_mail(
+      "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
+      to: consent_form.parent_email,
+      personalisation: {
+        short_date: consent_form.session.date.strftime("%-d %B"),
+        long_date: consent_form.session.date.strftime("%A %-d %B"),
+        parent_name: consent_form.parent_name,
+        patient_name: consent_form.full_name,
+        location_name: consent_form.session.location.name,
+        short_patient_name:
+          consent_form.common_name.presence || consent_form.first_name,
+        team_email: I18n.t("service.email")
+      }
+    )
+  end
+end

--- a/app/views/consent_forms/record.html.erb
+++ b/app/views/consent_forms/record.html.erb
@@ -1,0 +1,6 @@
+<% title = "#{ @consent_form.full_name } will get their nasal flu vaccination at school on #{ @session.date.to_fs(:nhsuk_date) }" %>
+<% content_for :page_title, title %>
+
+<%= govuk_panel(title_text: title, classes: "app-panel nhsuk-u-margin-bottom-6") %>
+
+<p>We’ve sent confirmation to <%= @consent_form.parent_email %></p>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,4 +61,8 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.action_mailer.default_url_options = { host: "localhost:4000" }
+  config.action_mailer.default_options = { from: "no-reply@nhs.net" }
+  config.action_mailer.delivery_method = :file
 end

--- a/tests/parental_consent.spec.ts
+++ b/tests/parental_consent.spec.ts
@@ -48,7 +48,7 @@ test("Parental consent", async ({ page }) => {
   await then_i_see_the_consent_confirm_page();
 
   await when_i_click_the_confirm_button();
-  await then_i_see_the_start_page();
+  await then_i_see_the_confirmation_page();
 });
 
 async function given_the_app_is_setup() {
@@ -94,9 +94,9 @@ async function then_i_see_the_consent_confirm_page() {
   await expect(p.locator("h1")).toContainText("Check your answers and confirm");
 }
 
-async function then_i_see_the_start_page() {
+async function then_i_see_the_confirmation_page() {
   await expect(p.locator("h1")).toContainText(
-    "Manage vaccinations for school-aged children",
+    "Joe Test will get their nasal flu vaccination",
   );
 }
 

--- a/tests/parental_consent_change_answers.spec.ts
+++ b/tests/parental_consent_change_answers.spec.ts
@@ -21,7 +21,7 @@ test("Parental consent change answers", async ({ page }) => {
   await and_i_see_the_answer_i_changed_is_yes();
 
   await when_i_click_the_confirm_button();
-  await then_i_see_the_start_page();
+  await then_i_see_the_confirmation_page();
 });
 
 async function given_the_app_is_setup() {
@@ -115,8 +115,8 @@ async function when_i_click_the_confirm_button() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
-async function then_i_see_the_start_page() {
+async function then_i_see_the_confirmation_page() {
   await expect(p.locator("h1")).toContainText(
-    "Manage vaccinations for school-aged children",
+    "Joe Test will get their nasal flu vaccination at school",
   );
 }


### PR DESCRIPTION
See commits.

TODO:

- [x] Send an email
- [x] Check if the prototype has different content when health questions have "yes" answers
- [x] Update the content design for the emails
- [ ] Add separate page/email for the consent refused scenario (separate PR)
- [ ] Add more tests for the various record pages and emails (separate PR)

### After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/d5bcd621-386d-4023-a838-369e5e96acf0)
