### PR TITLE
Update consent form confirmation mail

### DIFF
--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -1,17 +1,30 @@
 class ConsentFormMailer < ApplicationMailer
   def confirmation(consent_form)
+    if consent_form.common_name.present?
+      short_patient_name = consent_form.common_name
+      full_and_preferred_patient_name =
+        consent_form.full_name + " (known as #{consent_form.common_name})"
+    else
+      short_patient_name = consent_form.first_name
+      full_and_preferred_patient_name = consent_form.full_name
+    end
+    apos = "'"
+    apos += "s" unless short_patient_name.ends_with?("s")
+    short_patient_name_apos = short_patient_name + apos
+
     template_mail(
       "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
       to: consent_form.parent_email,
       personalisation: {
         short_date: consent_form.session.date.strftime("%-d %B"),
-        long_date: consent_form.session.date.strftime("%A %-d %B"),
         parent_name: consent_form.parent_name,
-        patient_name: consent_form.full_name,
         location_name: consent_form.session.location.name,
-        short_patient_name:
-          consent_form.common_name.presence || consent_form.first_name,
-        team_email: I18n.t("service.email")
+        long_date: consent_form.session.date.strftime("%A %-d %B"),
+        full_and_preferred_patient_name:,
+        short_patient_name:,
+        short_patient_name_apos:,
+        team_email: I18n.t("service.email"),
+        team_phone: I18n.t("service.temporary_cumbria_phone")
       }
     )
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
     warning: Warning
   service:
     email: england.manage-childrens-vaccinations@nhs.net
+    temporary_cumbria_phone: "01900 705 045"
   wicked:
     name: "name"
     date_of_birth: "date-of-birth"

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe ConsentFormMailer, type: :mailer do
+  describe "#confirmation" do
+    let(:notify_template_id) { "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73" }
+    let(:team_email) { "england.manage-childrens-vaccinations@nhs.net" }
+    let(:team_phone) { "01900 705 045" }
+
+    def consent_form(overrides = {})
+      @consent_form ||=
+        build(
+          :consent_form,
+          parent_email: "harry@hogwarts.edu",
+          parent_name: "Harry Potter",
+          first_name: "Albus",
+          last_name: "Potter",
+          common_name: "Severus",
+          **overrides
+        )
+    end
+
+    before do
+      allow_any_instance_of(Mail::Notify::Mailer).to receive(
+        :template_mail
+      ).with(notify_template_id, ->(options) { @template_options = options })
+    end
+
+    it "calls template_mail with correct personalisation" do
+      described_class.confirmation(consent_form).deliver_now
+
+      expect(@template_options).to include(
+        personalisation: {
+          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
+          location_name: consent_form.session.location.name,
+          long_date: consent_form.session.date.strftime("%A %-d %B"),
+          short_date: consent_form.session.date.strftime("%-d %B"),
+          parent_name: "Harry Potter",
+          short_patient_name: "Severus",
+          short_patient_name_apos: "Severus'",
+          team_email:,
+          team_phone:
+        },
+        to: "harry@hogwarts.edu"
+      )
+    end
+
+    it "calls template_mail correctly when common_name is nil" do
+      described_class.confirmation(consent_form(common_name: nil)).deliver_now
+
+      expect(@template_options[:personalisation]).to include(
+        full_and_preferred_patient_name: "Albus Potter",
+        short_patient_name: "Albus",
+        short_patient_name_apos: "Albus'"
+      )
+    end
+
+    it "calls template_mail correctly when first_name does not end in an s" do
+      described_class.confirmation(
+        consent_form(common_name: nil, first_name: "Harry")
+      ).deliver_now
+
+      expect(@template_options[:personalisation]).to include(
+        short_patient_name: "Harry",
+        short_patient_name_apos: "Harry's"
+      )
+    end
+  end
+end


### PR DESCRIPTION
We want to include a phone for the model office. But in the future, we'll need to add phones that are different per team.

Also update the passed in personalitation to include things like an apostrophed name and a conditional full name that contains an "(known as X)" variation.

### Screenshot from Notify

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/be0987fd-a846-457e-b55f-ad330153c1dc)
