### PR TITLE
Fix back buttons

### DIFF
--- a/app/helpers/consent_forms_helper.rb
+++ b/app/helpers/consent_forms_helper.rb
@@ -28,4 +28,37 @@ module ConsentFormsHelper
       "No"
     end
   end
+
+  def previous_question_number(consent_form, health_answer)
+    current_index =
+      consent_form.each_health_answer.find_index do |ha|
+        ha.id == health_answer.id
+      end
+    consent_form.each_health_answer.to_a[current_index - 1].id
+  end
+
+  def health_question_backlink_path(consent_form, health_answer)
+    follow_up_changes_start_page = session[:follow_up_changes_start_page]&.to_i
+    question_number = params[:question_number]&.to_i
+
+    if follow_up_changes_start_page &&
+         question_number == follow_up_changes_start_page
+      wizard_path(Wicked::FINISH_STEP)
+    elsif question_number&.positive?
+      wizard_path(
+        "health-question",
+        question_number: previous_question_number(consent_form, health_answer)
+      )
+    else
+      previous_wizard_path
+    end
+  end
+
+  def backlink_path
+    if params[:skip_to_confirm]
+      wizard_path(Wicked::FINISH_STEP)
+    else
+      previous_wizard_path
+    end
+  end
 end

--- a/app/views/consent_forms/edit/address.html.erb
+++ b/app/views/consent_forms/edit/address.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/consent.html.erb
+++ b/app/views/consent_forms/edit/consent.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/contact_method.html.erb
+++ b/app/views/consent_forms/edit/contact_method.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/date_of_birth.html.erb
+++ b/app/views/consent_forms/edit/date_of_birth.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/gp.html.erb
+++ b/app/views/consent_forms/edit/gp.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/health_question.html.erb
+++ b/app/views/consent_forms/edit/health_question.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: health_question_backlink_path(@consent_form, @health_answer),
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/injection.html.erb
+++ b/app/views/consent_forms/edit/injection.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/parent.html.erb
+++ b/app/views/consent_forms/edit/parent.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/reason.html.erb
+++ b/app/views/consent_forms/edit/reason.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/edit/school.html.erb
+++ b/app/views/consent_forms/edit/school.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-      href: previous_wizard_path,
+      href: backlink_path,
       name: "previous page"
   ) %>
 <% end %>

--- a/spec/helpers/consent_forms_helper_spec.rb
+++ b/spec/helpers/consent_forms_helper_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+RSpec.describe ConsentFormsHelper, type: :helper do
+  include ActionView::Helpers
+
+  describe "#health_question_backlink_path" do
+    let(:consent_form) do
+      create(:consent_form, :with_health_answers_asthma_branching)
+    end
+    let(:health_answer) { consent_form.health_answers.first }
+    let(:final_wizard_path) { double("final_wizard_path") }
+    let(:previous_wizard_path) { double("previous_wizard_path") }
+    let(:previous_health_question_wizard_path) do
+      double("previous_health_question_wizard_path")
+    end
+
+    before do
+      # For some reason the helper doesn't include this in the test environment.
+      # There may be some other way to achieve this, but this works for now.
+      ConsentFormsHelper.include Wicked::Controller::Concerns::Path
+
+      allow(helper).to receive(:wizard_path).with(
+        Wicked::FINISH_STEP
+      ).and_return(final_wizard_path)
+
+      allow(helper).to receive(:wizard_path).with(
+        "health-question",
+        { question_number: 2 }
+      ).and_return(previous_health_question_wizard_path)
+
+      allow(helper).to receive(:previous_wizard_path).and_return(
+        previous_wizard_path
+      )
+    end
+
+    context "answering the first health question" do
+      it "returns a link to the previous step" do
+        params[:question_number] = "0"
+
+        expect(
+          helper.health_question_backlink_path(consent_form, health_answer)
+        ).to eq previous_wizard_path
+      end
+    end
+
+    context "answering a follow-up health question" do
+      it "returns a link to the previous step" do
+        # question 1 is a follow-up in our test data
+        params[:question_number] = "1"
+
+        expect(
+          helper.health_question_backlink_path(consent_form, health_answer)
+        ).to eq previous_health_question_wizard_path
+      end
+    end
+
+    context "changing the answer to the first health question" do
+      it "returns a link to the finish step" do
+        params[:question_number] = "0"
+        session[:follow_up_changes_start_page] = "0"
+
+        expect(
+          helper.health_question_backlink_path(consent_form, health_answer)
+        ).to eq final_wizard_path
+      end
+    end
+
+    context "changing the answer to a follow-up health question" do
+      it "returns a link to the previous step" do
+        params[:question_number] = "1"
+        session[:follow_up_changes_start_page] = "0"
+
+        expect(
+          helper.health_question_backlink_path(consent_form, health_answer)
+        ).to eq previous_health_question_wizard_path
+      end
+    end
+  end
+
+  describe "#backlink_path" do
+    let(:consent_form) do
+      create(:consent_form, :with_health_answers_asthma_branching)
+    end
+    let(:health_answer) { consent_form.health_answers.first }
+    let(:final_wizard_path) { double("final_wizard_path") }
+    let(:previous_wizard_path) { double("previous_wizard_path") }
+
+    before do
+      allow(helper).to receive(:wizard_path).with(
+        Wicked::FINISH_STEP
+      ).and_return(final_wizard_path)
+
+      allow(helper).to receive(:previous_wizard_path).and_return(
+        previous_wizard_path
+      )
+    end
+
+    context "when skip_to_confirm is not set" do
+      it "returns a link to the previous step" do
+        expect(helper.backlink_path).to eq previous_wizard_path
+      end
+    end
+
+    context "when skip_to_confirm set" do
+      it "returns a link to the finish step" do
+        params[:skip_to_confirm] = "true"
+
+        expect(helper.backlink_path).to eq final_wizard_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes the back buttons which were broken for pretty much all health question steps (since the recent change to how they work) and for the "change answers from the confirmation page" journey for the rest of the questions.
