### PR TITLE
Update consent form confirmation page when consent needs triage

### DIFF
--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -28,6 +28,10 @@ class ConsentFormsController < ConsentForms::BaseController
 
     session.delete(:consent_form_id)
 
-    ConsentFormMailer.confirmation(@consent_form).deliver_later
+    if @consent_form.any_health_answers_truthy?
+      ConsentFormMailer.confirmation_needs_triage(@consent_form).deliver_later
+    else
+      ConsentFormMailer.confirmation(@consent_form).deliver_later
+    end
   end
 end

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -28,7 +28,7 @@ class ConsentFormsController < ConsentForms::BaseController
 
     session.delete(:consent_form_id)
 
-    if @consent_form.any_health_answers_truthy?
+    if @consent_form.needs_triage?
       ConsentFormMailer.confirmation_needs_triage(@consent_form).deliver_later
     else
       ConsentFormMailer.confirmation(@consent_form).deliver_later

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -28,4 +28,28 @@ class ConsentFormMailer < ApplicationMailer
       }
     )
   end
+
+  def confirmation_needs_triage(consent_form)
+    if consent_form.common_name.present?
+      short_patient_name = consent_form.common_name
+      full_and_preferred_patient_name =
+        consent_form.full_name + " (known as #{consent_form.common_name})"
+    else
+      short_patient_name = consent_form.first_name
+      full_and_preferred_patient_name = consent_form.full_name
+    end
+
+    template_mail(
+      "604ee667-c996-471e-b986-79ab98d0767c",
+      to: consent_form.parent_email,
+      personalisation: {
+        short_date: consent_form.session.date.strftime("%-d %B"),
+        parent_name: consent_form.parent_name,
+        location_name: consent_form.session.location.name,
+        long_date: consent_form.session.date.strftime("%A %-d %B"),
+        full_and_preferred_patient_name:,
+        short_patient_name:
+      }
+    )
+  end
 end

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -208,6 +208,12 @@ class ConsentForm < ApplicationRecord
       end
   end
 
+  def any_health_answers_truthy?
+    health_answers.to_set.any? do |health_answer|
+      health_answer.response == "yes"
+    end
+  end
+
   private
 
   def eligible_for_injection?

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -208,6 +208,10 @@ class ConsentForm < ApplicationRecord
       end
   end
 
+  def needs_triage?
+    any_health_answers_truthy?
+  end
+
   def any_health_answers_truthy?
     health_answers.to_set.any? do |health_answer|
       health_answer.response == "yes"

--- a/app/views/consent_forms/_confirmation_agreed.html.erb
+++ b/app/views/consent_forms/_confirmation_agreed.html.erb
@@ -1,0 +1,4 @@
+<% title = "#{ @consent_form.full_name } will get their nasal flu vaccination at school on #{ @session.date.to_fs(:nhsuk_date) }" %>
+<% content_for :page_title, title %>
+
+<%= govuk_panel(title_text: title, classes: "app-panel nhsuk-u-margin-bottom-6") %>

--- a/app/views/consent_forms/_confirmation_needs_triage.html.erb
+++ b/app/views/consent_forms/_confirmation_needs_triage.html.erb
@@ -1,0 +1,8 @@
+<%= h1 "You’ve given consent for your child to get a flu vaccination",
+  class: 'nhsuk-heading-l' %>
+
+<p>
+  As you answered ‘yes’ to some of the health questions, we need to check the
+  vaccination is suitable for <%= @consent_form.full_name %>. We’ll review your
+  answers and get in touch again soon.
+</p>

--- a/app/views/consent_forms/record.html.erb
+++ b/app/views/consent_forms/record.html.erb
@@ -1,4 +1,4 @@
-<% if @consent_form.any_health_answers_truthy? %>
+<% if @consent_form.needs_triage? %>
   <%= render "confirmation_needs_triage" %>
 <% else %>
   <%= render "confirmation_agreed" %>

--- a/app/views/consent_forms/record.html.erb
+++ b/app/views/consent_forms/record.html.erb
@@ -1,6 +1,3 @@
-<% title = "#{ @consent_form.full_name } will get their nasal flu vaccination at school on #{ @session.date.to_fs(:nhsuk_date) }" %>
-<% content_for :page_title, title %>
+<%= render "confirmation_agreed" %>
 
-<%= govuk_panel(title_text: title, classes: "app-panel nhsuk-u-margin-bottom-6") %>
-
-<p>We’ve sent confirmation to <%= @consent_form.parent_email %></p>
+<p>We’ve sent a confirmation to <%= @consent_form.parent_email %>.</p>

--- a/app/views/consent_forms/record.html.erb
+++ b/app/views/consent_forms/record.html.erb
@@ -1,3 +1,7 @@
-<%= render "confirmation_agreed" %>
+<% if @consent_form.any_health_answers_truthy? %>
+  <%= render "confirmation_needs_triage" %>
+<% else %>
+  <%= render "confirmation_agreed" %>
+<% end %>
 
 <p>We’ve sent a confirmation to <%= @consent_form.parent_email %>.</p>

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -1,29 +1,29 @@
 require "rails_helper"
 
 RSpec.describe ConsentFormMailer, type: :mailer do
+  def consent_form(overrides = {})
+    @consent_form ||=
+      build(
+        :consent_form,
+        parent_email: "harry@hogwarts.edu",
+        parent_name: "Harry Potter",
+        first_name: "Albus",
+        last_name: "Potter",
+        common_name: "Severus",
+        **overrides
+      )
+  end
+
+  before do
+    allow_any_instance_of(Mail::Notify::Mailer).to receive(
+      :template_mail
+    ).with(notify_template_id, ->(options) { @template_options = options })
+  end
+
   describe "#confirmation" do
     let(:notify_template_id) { "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73" }
     let(:team_email) { "england.manage-childrens-vaccinations@nhs.net" }
     let(:team_phone) { "01900 705 045" }
-
-    def consent_form(overrides = {})
-      @consent_form ||=
-        build(
-          :consent_form,
-          parent_email: "harry@hogwarts.edu",
-          parent_name: "Harry Potter",
-          first_name: "Albus",
-          last_name: "Potter",
-          common_name: "Severus",
-          **overrides
-        )
-    end
-
-    before do
-      allow_any_instance_of(Mail::Notify::Mailer).to receive(
-        :template_mail
-      ).with(notify_template_id, ->(options) { @template_options = options })
-    end
 
     it "calls template_mail with correct personalisation" do
       described_class.confirmation(consent_form).deliver_now
@@ -62,6 +62,27 @@ RSpec.describe ConsentFormMailer, type: :mailer do
       expect(@template_options[:personalisation]).to include(
         short_patient_name: "Harry",
         short_patient_name_apos: "Harry's"
+      )
+    end
+  end
+
+  describe "#confirmation_needs_triage" do
+    let(:notify_template_id) { "604ee667-c996-471e-b986-79ab98d0767c" }
+
+
+    it "calls template_mail with correct personalisation" do
+      described_class.confirmation_needs_triage(consent_form).deliver_now
+
+      expect(@template_options).to include(
+        personalisation: {
+          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
+          location_name: consent_form.session.location.name,
+          long_date: consent_form.session.date.strftime("%A %-d %B"),
+          short_date: consent_form.session.date.strftime("%-d %B"),
+          parent_name: "Harry Potter",
+          short_patient_name: "Severus"
+        },
+        to: "harry@hogwarts.edu"
       )
     end
   end

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -15,9 +15,10 @@ RSpec.describe ConsentFormMailer, type: :mailer do
   end
 
   before do
-    allow_any_instance_of(Mail::Notify::Mailer).to receive(
-      :template_mail
-    ).with(notify_template_id, ->(options) { @template_options = options })
+    allow_any_instance_of(Mail::Notify::Mailer).to receive(:template_mail).with(
+      notify_template_id,
+      ->(options) { @template_options = options }
+    )
   end
 
   describe "#confirmation" do
@@ -68,7 +69,6 @@ RSpec.describe ConsentFormMailer, type: :mailer do
 
   describe "#confirmation_needs_triage" do
     let(:notify_template_id) { "604ee667-c996-471e-b986-79ab98d0767c" }
-
 
     it "calls template_mail with correct personalisation" do
       described_class.confirmation_needs_triage(consent_form).deliver_now

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -468,4 +468,23 @@ RSpec.describe ConsentForm, type: :model do
       end
     end
   end
+
+  describe "#any_health_answers_truthy?" do
+    let(:consent_form) do
+      build(:consent_form, :with_health_answers_no_branching)
+    end
+
+    context "no responses are yes" do
+      it "returns false" do
+        expect(consent_form.any_health_answers_truthy?).to eq(false)
+      end
+    end
+
+    context "some responses are yes" do
+      it "returns true" do
+        consent_form.health_answers[0].response = "yes"
+        expect(consent_form.any_health_answers_truthy?).to eq(true)
+      end
+    end
+  end
 end

--- a/tests/parental_consent_change_answers.spec.ts
+++ b/tests/parental_consent_change_answers.spec.ts
@@ -26,7 +26,7 @@ test("Parental consent change answers", async ({ page }) => {
   await and_i_see_the_answer_i_changed_is_yes();
 
   await when_i_click_the_confirm_button();
-  await then_i_see_the_confirmation_page();
+  await then_i_see_the_needs_triage_confirmation_page();
 });
 
 async function given_the_app_is_setup() {
@@ -102,8 +102,8 @@ async function when_i_click_the_confirm_button() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
-async function then_i_see_the_confirmation_page() {
+async function then_i_see_the_needs_triage_confirmation_page() {
   await expect(p.locator("h1")).toContainText(
-    "Joe Test will get their nasal flu vaccination at school",
+    "You’ve given consent for your child to get a flu vaccination",
   );
 }


### PR DESCRIPTION
When submitting a consent form, there are 4 possible cases:

- Confirmed (done)
- **Confirmed, but needs triage** :point_left: this PR
- Confirmed, using injection
- Refused

Each case has slightly different content on the confirmation page, and a different email gets sent out to the parent.

See commits.

### Screenshots

#### Confirmation page

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/802b27af-d3ff-4f62-bd98-33ab32ae0d86)

#### New email

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/2aaeaf90-7b3a-49f1-bb15-c5d8859d6073)
