### PR TITLE
Add confirmation pages for offering injection and for refused consent

### DIFF
--- a/app/controllers/concerns/consent_form_mailer_concern.rb
+++ b/app/controllers/concerns/consent_form_mailer_concern.rb
@@ -1,0 +1,15 @@
+module ConsentFormMailerConcern
+  extend ActiveSupport::Concern
+
+  def send_record_mail(consent_form)
+    if consent_form.contact_injection?
+      ConsentFormMailer.confirmation_injection(consent_form).deliver_later
+    elsif consent_form.consent_refused?
+      ConsentFormMailer.confirmation_refused(consent_form).deliver_later
+    elsif consent_form.needs_triage?
+      ConsentFormMailer.confirmation_needs_triage(consent_form).deliver_later
+    else
+      ConsentFormMailer.confirmation(consent_form).deliver_later
+    end
+  end
+end

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -30,7 +30,9 @@ class ConsentFormsController < ConsentForms::BaseController
 
     session.delete(:consent_form_id)
 
-    if @consent_form.needs_triage?
+    if @consent_form.contact_injection?
+      ConsentFormMailer.confirmation_injection(@consent_form).deliver_later
+    elsif @consent_form.needs_triage?
       ConsentFormMailer.confirmation_needs_triage(@consent_form).deliver_later
     else
       ConsentFormMailer.confirmation(@consent_form).deliver_later

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -32,6 +32,8 @@ class ConsentFormsController < ConsentForms::BaseController
 
     if @consent_form.contact_injection?
       ConsentFormMailer.confirmation_injection(@consent_form).deliver_later
+    elsif @consent_form.consent_refused?
+      ConsentFormMailer.confirmation_refused(@consent_form).deliver_later
     elsif @consent_form.needs_triage?
       ConsentFormMailer.confirmation_needs_triage(@consent_form).deliver_later
     else

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -1,4 +1,6 @@
 class ConsentFormsController < ConsentForms::BaseController
+  include ConsentFormMailerConcern
+
   layout "two_thirds"
 
   skip_before_action :set_consent_form, only: %i[start create]
@@ -30,15 +32,7 @@ class ConsentFormsController < ConsentForms::BaseController
 
     session.delete(:consent_form_id)
 
-    if @consent_form.contact_injection?
-      ConsentFormMailer.confirmation_injection(@consent_form).deliver_later
-    elsif @consent_form.consent_refused?
-      ConsentFormMailer.confirmation_refused(@consent_form).deliver_later
-    elsif @consent_form.needs_triage?
-      ConsentFormMailer.confirmation_needs_triage(@consent_form).deliver_later
-    else
-      ConsentFormMailer.confirmation(@consent_form).deliver_later
-    end
+    send_record_mail(@consent_form)
   end
 
   private

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -4,6 +4,8 @@ class ConsentFormsController < ConsentForms::BaseController
   skip_before_action :set_consent_form, only: %i[start create]
   skip_before_action :authenticate_consent_form_user!, only: %i[start create]
 
+  before_action :clear_session_edit_variables, only: %i[confirm]
+
   def start
   end
 
@@ -33,5 +35,11 @@ class ConsentFormsController < ConsentForms::BaseController
     else
       ConsentFormMailer.confirmation(@consent_form).deliver_later
     end
+  end
+
+  private
+
+  def clear_session_edit_variables
+    session.delete(:follow_up_changes_start_page)
   end
 end

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -70,9 +70,34 @@ class ConsentFormMailer < ApplicationMailer
         location_name: consent_form.session.location.name,
         long_date: consent_form.session.date.strftime("%A %-d %B"),
         full_and_preferred_patient_name:,
-        reason_for_refusal: I18n.t(
-          "consent_form_mailer.reasons_for_refusal.#{consent_form.reason.to_s}"
-        ),
+        reason_for_refusal:
+          I18n.t(
+            "consent_form_mailer.reasons_for_refusal.#{consent_form.reason}"
+          )
+      }
+    )
+  end
+
+  def confirmation_refused(consent_form)
+    if consent_form.common_name.present?
+      short_patient_name = consent_form.common_name
+      full_and_preferred_patient_name =
+        consent_form.full_name + " (known as #{consent_form.common_name})"
+    else
+      short_patient_name = consent_form.first_name
+      full_and_preferred_patient_name = consent_form.full_name
+    end
+
+    template_mail(
+      "5a676dac-3385-49e4-98c2-fc6b45b5a851",
+      to: consent_form.parent_email,
+      personalisation: {
+        short_date: consent_form.session.date.strftime("%-d %B"),
+        parent_name: consent_form.parent_name,
+        location_name: consent_form.session.location.name,
+        long_date: consent_form.session.date.strftime("%A %-d %B"),
+        full_and_preferred_patient_name:,
+        short_patient_name:,
         team_email: I18n.t("service.email"),
         team_phone: I18n.t("service.temporary_cumbria_phone")
       }

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -52,4 +52,30 @@ class ConsentFormMailer < ApplicationMailer
       }
     )
   end
+
+  def confirmation_injection(consent_form)
+    full_and_preferred_patient_name =
+      if consent_form.common_name.present?
+        consent_form.full_name + " (known as #{consent_form.common_name})"
+      else
+        consent_form.full_name
+      end
+
+    template_mail(
+      "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
+      to: consent_form.parent_email,
+      personalisation: {
+        short_date: consent_form.session.date.strftime("%-d %B"),
+        parent_name: consent_form.parent_name,
+        location_name: consent_form.session.location.name,
+        long_date: consent_form.session.date.strftime("%A %-d %B"),
+        full_and_preferred_patient_name:,
+        reason_for_refusal: I18n.t(
+          "consent_form_mailer.reasons_for_refusal.#{consent_form.reason.to_s}"
+        ),
+        team_email: I18n.t("service.email"),
+        team_phone: I18n.t("service.temporary_cumbria_phone")
+      }
+    )
+  end
 end

--- a/app/views/consent_forms/_confirmation_injection.html.erb
+++ b/app/views/consent_forms/_confirmation_injection.html.erb
@@ -1,0 +1,4 @@
+<%= h1 "Your child will not get a nasal flu vaccination at school",
+  class: 'nhsuk-heading-l' %>
+
+<p>A nurse will be in touch to discuss them having an injection instead.</p>

--- a/app/views/consent_forms/_confirmation_refused.html.erb
+++ b/app/views/consent_forms/_confirmation_refused.html.erb
@@ -1,0 +1,2 @@
+<%= h1 "Your child will not get a nasal flu vaccination at school",
+  class: 'nhsuk-heading-l' %>

--- a/app/views/consent_forms/record.html.erb
+++ b/app/views/consent_forms/record.html.erb
@@ -1,4 +1,6 @@
-<% if @consent_form.needs_triage? %>
+<% if @consent_form.contact_injection? %>
+  <%= render "confirmation_injection" %>
+<% elsif @consent_form.needs_triage? %>
   <%= render "confirmation_needs_triage" %>
 <% else %>
   <%= render "confirmation_agreed" %>

--- a/app/views/consent_forms/record.html.erb
+++ b/app/views/consent_forms/record.html.erb
@@ -1,5 +1,7 @@
 <% if @consent_form.contact_injection? %>
   <%= render "confirmation_injection" %>
+<% elsif @consent_form.consent_refused? %>
+  <%= render "confirmation_refused" %>
 <% elsif @consent_form.needs_triage? %>
   <%= render "confirmation_needs_triage" %>
 <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,6 +28,14 @@ en:
               inclusion: Choose an answer
             notes:
               blank: Enter details
+  consent_form_mailer:
+    reasons_for_refusal:
+      contains_gelatine: "of the gelatine in the nasal spray"
+      already_received: "they have already received the vaccine"
+      given_elsewhere: "they will be given the vaccine elsewhere"
+      medical_reasons: "of medical reasons"
+      personal_choice: "of personal choice"
+      other: "of other reasons"
   activerecord:
     attributes:
       consent:

--- a/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/consent_form_mailer_concern_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+describe ConsentFormMailerConcern do
+  subject { Class.new { include ConsentFormMailerConcern }.new }
+
+  let(:consent_form) { build(:consent_form) }
+  let(:mail) { double(deliver_later: true) }
+
+  before do
+    allow(ConsentFormMailer).to receive_messages(
+      confirmation: mail,
+      confirmation_needs_triage: mail,
+      confirmation_injection: mail,
+      confirmation_refused: mail
+    )
+  end
+
+  describe "#send_record_mail" do
+    it "sends confirmation_injection mail when user agrees to be contacted" do
+      consent_form.contact_injection = true
+      subject.send_record_mail(consent_form)
+
+      expect(ConsentFormMailer).to have_received(:confirmation_injection).with(
+        consent_form
+      )
+      expect(mail).to have_received(:deliver_later)
+    end
+
+    it "sends confirmation_refused mail when user refuses consent" do
+      consent_form.response = :refused
+      subject.send_record_mail(consent_form)
+
+      expect(ConsentFormMailer).to have_received(:confirmation_refused).with(
+        consent_form
+      )
+      expect(mail).to have_received(:deliver_later)
+    end
+
+    it "sends confirmation_needs_triage mail when a health question is yes" do
+      consent_form.health_answers.last.response = "yes"
+      subject.send_record_mail(consent_form)
+
+      expect(ConsentFormMailer).to have_received(
+        :confirmation_needs_triage
+      ).with(consent_form)
+      expect(mail).to have_received(:deliver_later)
+    end
+
+    it "sends confirmation mail when user agrees to consent" do
+      subject.send_record_mail(consent_form)
+
+      expect(ConsentFormMailer).to have_received(:confirmation).with(
+        consent_form
+      )
+      expect(mail).to have_received(:deliver_later)
+    end
+  end
+end

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
 
 RSpec.describe ConsentFormMailer, type: :mailer do
+  let(:team_email) { "england.manage-childrens-vaccinations@nhs.net" }
+  let(:team_phone) { "01900 705 045" }
+
   def consent_form(overrides = {})
     @consent_form ||=
       build(
@@ -23,8 +26,6 @@ RSpec.describe ConsentFormMailer, type: :mailer do
 
   describe "#confirmation" do
     let(:notify_template_id) { "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73" }
-    let(:team_email) { "england.manage-childrens-vaccinations@nhs.net" }
-    let(:team_phone) { "01900 705 045" }
 
     it "calls template_mail with correct personalisation" do
       described_class.confirmation(consent_form).deliver_now
@@ -81,6 +82,28 @@ RSpec.describe ConsentFormMailer, type: :mailer do
           short_date: consent_form.session.date.strftime("%-d %B"),
           parent_name: "Harry Potter",
           short_patient_name: "Severus"
+        },
+        to: "harry@hogwarts.edu"
+      )
+    end
+  end
+
+  describe "#confirmation_injection" do
+    let(:notify_template_id) { "4d09483a-8181-4acb-8ba3-7abd6c8644cd" }
+
+    it "calls template_mail with correct personalisation" do
+      described_class.confirmation_injection(consent_form(reason: :contains_gelatine)).deliver_now
+
+      expect(@template_options).to include(
+        personalisation: {
+          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
+          location_name: consent_form.session.location.name,
+          long_date: consent_form.session.date.strftime("%A %-d %B"),
+          short_date: consent_form.session.date.strftime("%-d %B"),
+          parent_name: "Harry Potter",
+          reason_for_refusal: "of the gelatine in the nasal spray",
+          team_email:,
+          team_phone:
         },
         to: "harry@hogwarts.edu"
       )

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -92,7 +92,9 @@ RSpec.describe ConsentFormMailer, type: :mailer do
     let(:notify_template_id) { "4d09483a-8181-4acb-8ba3-7abd6c8644cd" }
 
     it "calls template_mail with correct personalisation" do
-      described_class.confirmation_injection(consent_form(reason: :contains_gelatine)).deliver_now
+      described_class.confirmation_injection(
+        consent_form(reason: :contains_gelatine)
+      ).deliver_now
 
       expect(@template_options).to include(
         personalisation: {
@@ -101,7 +103,27 @@ RSpec.describe ConsentFormMailer, type: :mailer do
           long_date: consent_form.session.date.strftime("%A %-d %B"),
           short_date: consent_form.session.date.strftime("%-d %B"),
           parent_name: "Harry Potter",
-          reason_for_refusal: "of the gelatine in the nasal spray",
+          reason_for_refusal: "of the gelatine in the nasal spray"
+        },
+        to: "harry@hogwarts.edu"
+      )
+    end
+  end
+
+  describe "#confirmation_refused" do
+    let(:notify_template_id) { "5a676dac-3385-49e4-98c2-fc6b45b5a851" }
+
+    it "calls template_mail with correct personalisation" do
+      described_class.confirmation_refused(consent_form).deliver_now
+
+      expect(@template_options).to include(
+        personalisation: {
+          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
+          location_name: consent_form.session.location.name,
+          long_date: consent_form.session.date.strftime("%A %-d %B"),
+          short_date: consent_form.session.date.strftime("%-d %B"),
+          parent_name: "Harry Potter",
+          short_patient_name: "Severus",
           team_email:,
           team_phone:
         },

--- a/tests/parental_consent_change_answers.spec.ts
+++ b/tests/parental_consent_change_answers.spec.ts
@@ -40,6 +40,18 @@ test("Parental consent change answers", async ({ page }) => {
 
   await when_i_click_the_confirm_button();
   await then_i_see_the_injection_confirmation_page();
+
+  // Consent refused
+  await when_i_go_to_a_prefilled_consent_form();
+  await then_i_see_the_consent_confirm_page();
+
+  await when_i_change_my_consent();
+  await and_say_the_reason_is_that_the_vaccine_contains_gelatine();
+  await and_do_not_agree_to_be_contacted_by_a_nurse();
+  await then_i_see_the_consent_confirm_page();
+
+  await when_i_click_the_confirm_button();
+  await then_i_see_the_refused_confirmation_page();
 });
 
 async function given_the_app_is_setup() {
@@ -146,4 +158,18 @@ async function then_i_see_the_injection_confirmation_page() {
   await expect(
     p.locator("p", { hasText: "having an injection instead" }),
   ).toBeVisible();
+}
+
+async function and_do_not_agree_to_be_contacted_by_a_nurse() {
+  await p.getByRole("radio", { name: "No" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_refused_confirmation_page() {
+  await expect(p.locator("h1")).toContainText(
+    "Your child will not get a nasal flu vaccination",
+  );
+  await expect(
+    p.locator("p", { hasText: "having an injection instead" }),
+  ).not.toBeVisible();
 }

--- a/tests/parental_consent_change_answers.spec.ts
+++ b/tests/parental_consent_change_answers.spec.ts
@@ -5,6 +5,7 @@ let p: Page;
 test("Parental consent change answers", async ({ page }) => {
   p = page;
 
+  // Health questions contain Yes answers
   await given_the_app_is_setup();
   await when_i_go_to_a_prefilled_consent_form();
   await then_i_see_the_consent_confirm_page();
@@ -27,6 +28,18 @@ test("Parental consent change answers", async ({ page }) => {
 
   await when_i_click_the_confirm_button();
   await then_i_see_the_needs_triage_confirmation_page();
+
+  // Offer an injection instead
+  await when_i_go_to_a_prefilled_consent_form();
+  await then_i_see_the_consent_confirm_page();
+
+  await when_i_change_my_consent();
+  await and_say_the_reason_is_that_the_vaccine_contains_gelatine();
+  await and_agree_to_be_contacted_by_a_nurse();
+  await then_i_see_the_consent_confirm_page();
+
+  await when_i_click_the_confirm_button();
+  await then_i_see_the_injection_confirmation_page();
 });
 
 async function given_the_app_is_setup() {
@@ -106,4 +119,31 @@ async function then_i_see_the_needs_triage_confirmation_page() {
   await expect(p.locator("h1")).toContainText(
     "You’ve given consent for your child to get a flu vaccination",
   );
+}
+
+async function when_i_change_my_consent() {
+  await p.getByRole("link", { name: "Change consent", exact: true }).click();
+  await p.getByRole("radio", { name: "No" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function and_say_the_reason_is_that_the_vaccine_contains_gelatine() {
+  await p
+    .getByRole("radio", { name: "Vaccine contains gelatine from pigs" })
+    .click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function and_agree_to_be_contacted_by_a_nurse() {
+  await p.getByRole("radio", { name: "Yes" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_injection_confirmation_page() {
+  await expect(p.locator("h1")).toContainText(
+    "Your child will not get a nasal flu vaccination",
+  );
+  await expect(
+    p.locator("p", { hasText: "having an injection instead" }),
+  ).toBeVisible();
 }


### PR DESCRIPTION
This adds two more mail templates and two more view templates for the remaining consent form final states. This covers the last two scenarios where users refuse consent and agree or disagree to be contacted with the offer of an injection instead.

### Screenshots of all scenarios

| | Confirmation page | Email |
|-|-|-|
| Accepted - All health questions "No" | <img width="1222" alt="Screenshot 2023-11-14 at 17 50 33" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/85300f4a-840c-40ea-9d54-5420f14cf83b"> | <img width="1624" alt="Screenshot 2023-11-14 at 17 51 04" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/3bdae3fc-25ea-4659-a49f-0e9918d13cfd"> |
| Accepted - At least one health question is "Yes" | <img width="1222" alt="Screenshot 2023-11-14 at 17 51 37" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/aec64c43-82a7-490f-b7dd-b3bf079b9cff"> | <img width="1624" alt="Screenshot 2023-11-14 at 17 51 49" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/b8fe153d-2db4-4ef2-9fc0-ee462a1d5c29"> |
| Refused - Agreed to be contacted for an injection | <img width="1222" alt="Screenshot 2023-11-14 at 17 52 14" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/753165e9-1506-4731-8633-4c7b62b8c2bf"> | <img width="1624" alt="Screenshot 2023-11-14 at 17 52 26" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/5d7e0954-c089-4d20-ac11-095586c2f298"> |
| Refused - Disagreed to be contacted | <img width="1222" alt="Screenshot 2023-11-14 at 17 56 51" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/d0719aad-9481-4669-87b8-ecf2ff3c8f76"> | <img width="1624" alt="Screenshot 2023-11-14 at 17 57 02" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/d2ac7604-6b25-433b-a42e-4d23b051830e"> |
