### PR TITLE
Fix campaign type capitalisation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,17 @@ en:
     gp: "gp"
     address: "address"
     health_question: "health-question"
+  consent_form_mailer:
+    reasons_for_refusal:
+      contains_gelatine: "of the gelatine in the nasal spray"
+      already_received: "they have already received the vaccine"
+      given_elsewhere: "they will be given the vaccine elsewhere"
+      medical_reasons: "of medical reasons"
+      personal_choice: "of personal choice"
+      other: "of other reasons"
+  vaccines:
+    hpv: HPV
+    flu: Flu
   activemodel:
     errors:
       models:
@@ -28,14 +39,6 @@ en:
               inclusion: Choose an answer
             notes:
               blank: Enter details
-  consent_form_mailer:
-    reasons_for_refusal:
-      contains_gelatine: "of the gelatine in the nasal spray"
-      already_received: "they have already received the vaccine"
-      given_elsewhere: "they will be given the vaccine elsewhere"
-      medical_reasons: "of medical reasons"
-      personal_choice: "of personal choice"
-      other: "of other reasons"
   activerecord:
     attributes:
       consent:

--- a/db/sample_data/example-flu-campaign.json
+++ b/db/sample_data/example-flu-campaign.json
@@ -1,9 +1,9 @@
 {
   "id": "42",
-  "title": "FLU campaign at Oakham School",
+  "title": "Flu campaign at Oakham School",
   "location": "Oakham School",
   "date": "2023-07-28T12:30",
-  "type": "FLU",
+  "type": "Flu",
   "team": {
     "name": "Rutland SAIS team",
     "users": [
@@ -20,15 +20,15 @@
       "batches": [
         {
           "name": "MO7714",
-          "expiry": "2024-01-28"
+          "expiry": "2024-02-18"
         },
         {
           "name": "RT0255",
-          "expiry": "2024-03-31"
+          "expiry": "2024-04-21"
         },
         {
           "name": "OZ0009",
-          "expiry": "2024-03-18"
+          "expiry": "2024-04-08"
         }
       ]
     }
@@ -108,7 +108,7 @@
     {
       "firstName": "Brittany",
       "lastName": "Klocko",
-      "dob": "2015-09-20",
+      "dob": "2015-10-11",
       "nhsNumber": 4656828688,
       "consent": {
         "response": "given",
@@ -152,7 +152,7 @@
     {
       "firstName": "Mckinley",
       "lastName": "Marvin",
-      "dob": "2016-01-23",
+      "dob": "2016-02-13",
       "nhsNumber": 4526310840,
       "consent": {
         "response": "given",
@@ -196,7 +196,7 @@
     {
       "firstName": "Wonda",
       "lastName": "Schuster",
-      "dob": "2019-08-17",
+      "dob": "2019-09-07",
       "nhsNumber": 4007695997,
       "consent": null,
       "parentEmail": null,
@@ -210,7 +210,7 @@
     {
       "firstName": "Farah",
       "lastName": "Welch",
-      "dob": "2017-06-23",
+      "dob": "2017-07-14",
       "nhsNumber": 4817528605,
       "consent": null,
       "parentEmail": null,
@@ -224,7 +224,7 @@
     {
       "firstName": "Evette",
       "lastName": "Muller",
-      "dob": "2019-04-18",
+      "dob": "2019-05-09",
       "nhsNumber": 4666534172,
       "consent": {
         "response": "refused",
@@ -249,7 +249,7 @@
     {
       "firstName": "Bruce",
       "lastName": "Reynolds",
-      "dob": "2016-07-09",
+      "dob": "2016-07-30",
       "nhsNumber": 4792147433,
       "consent": {
         "response": "refused",
@@ -274,7 +274,7 @@
     {
       "firstName": "Hyman",
       "lastName": "Jaskolski",
-      "dob": "2014-11-10",
+      "dob": "2014-12-01",
       "nhsNumber": 4491141088,
       "consent": {
         "response": "given",
@@ -358,7 +358,7 @@
     {
       "firstName": "Rich",
       "lastName": "Schaden",
-      "dob": "2018-01-03",
+      "dob": "2018-01-24",
       "nhsNumber": 4362534482,
       "consent": {
         "response": "given",
@@ -442,7 +442,7 @@
     {
       "firstName": "Kirstin",
       "lastName": "Labadie",
-      "dob": "2017-06-08",
+      "dob": "2017-06-29",
       "nhsNumber": 4618195770,
       "consent": {
         "response": "given",
@@ -529,7 +529,7 @@
     {
       "firstName": "Ted",
       "lastName": "Swift",
-      "dob": "2016-10-22",
+      "dob": "2016-11-12",
       "nhsNumber": 4459326590,
       "consent": {
         "response": "given",
@@ -616,7 +616,7 @@
     {
       "firstName": "John",
       "lastName": "Grady",
-      "dob": "2018-03-16",
+      "dob": "2018-04-06",
       "nhsNumber": 4359409214,
       "consent": {
         "response": "given",
@@ -703,7 +703,7 @@
     {
       "firstName": "Alysha",
       "lastName": "Cartwright",
-      "dob": "2016-09-08",
+      "dob": "2016-09-29",
       "nhsNumber": 4385039321,
       "consent": {
         "response": "given",

--- a/lib/example_campaign_generator.rb
+++ b/lib/example_campaign_generator.rb
@@ -78,12 +78,13 @@ class ExampleCampaignGenerator
     patients_data = add_consent_to_patients_data(patients_data)
     patients_data = match_mum_and_dad_info_to_consent(patients_data)
 
+    vaccine_name = I18n.t("vaccines.#{type}")
     {
       id: random.seed.to_s,
-      title: "#{type.upcase} campaign at #{school_data[:name]}",
+      title: "#{vaccine_name} campaign at #{school_data[:name]}",
       location: school_data[:name],
       date: "2023-07-28T12:30",
-      type: type.upcase,
+      type: vaccine_name,
       team: team_data,
       vaccines: vaccines_data,
       school: school_data,

--- a/spec/lib/example_campaign_generator_spec.rb
+++ b/spec/lib/example_campaign_generator_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ExampleCampaignGenerator do
     #       presets=default \
     #       type=flu \
     #       username="Nurse Jackie" > db/sample_data/example-flu-campaign.json
-    Timecop.freeze(2023, 10, 25, 12, 0, 0) do
+    Timecop.freeze(2023, 11, 15, 12, 0, 0) do
       generator =
         ExampleCampaignGenerator.new(
           seed: 42,

--- a/tests/session_authorisation.spec.ts
+++ b/tests/session_authorisation.spec.ts
@@ -39,7 +39,7 @@ async function then_i_should_see_only_my_session() {
     1,
   );
   await expect(p.locator(".nhsuk-table__body .nhsuk-table__row")).toHaveText(
-    /FLU campaign at Oakham School/,
+    /Flu campaign at Oakham School/,
   );
 }
 


### PR DESCRIPTION
The `.upcase` method does not work for a vaccine type of `flu`, as it causes it to render as `FLU`.