### PR TITLE
Replace hardcoded references to HPV or flu

### DIFF
--- a/app/views/consent_forms/_confirmation_agreed.html.erb
+++ b/app/views/consent_forms/_confirmation_agreed.html.erb
@@ -1,4 +1,7 @@
-<% title = "#{ @consent_form.full_name } will get their nasal flu vaccination at school on #{ @session.date.to_fs(:nhsuk_date) }" %>
+<% title = t("consent_forms.confirmation_agreed.title.#{ @session.type.downcase }",
+  full_name: @consent_form.full_name,
+  date: @session.date.to_fs(:nhsuk_date)
+) %>
 <% content_for :page_title, title %>
 
 <%= govuk_panel(title_text: title, classes: "app-panel nhsuk-u-margin-bottom-6") %>

--- a/app/views/consent_forms/_confirmation_injection.html.erb
+++ b/app/views/consent_forms/_confirmation_injection.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "Your child will not get a nasal flu vaccination at school",
+<%= h1 t("consent_forms.confirmation_injection.title.#{ @session.type.downcase }"),
   class: 'nhsuk-heading-l' %>
 
 <p>A nurse will be in touch to discuss them having an injection instead.</p>

--- a/app/views/consent_forms/_confirmation_needs_triage.html.erb
+++ b/app/views/consent_forms/_confirmation_needs_triage.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "You’ve given consent for your child to get a flu vaccination",
+<%= h1 t("consent_forms.confirmation_needs_triage.title.#{ @session.type.downcase }"),
   class: 'nhsuk-heading-l' %>
 
 <p>

--- a/app/views/consent_forms/_confirmation_refused.html.erb
+++ b/app/views/consent_forms/_confirmation_refused.html.erb
@@ -1,2 +1,2 @@
-<%= h1 "Your child will not get a nasal flu vaccination at school",
+<%= h1 t("consent_forms.confirmation_refused.title.#{ @session.type.downcase }"),
   class: 'nhsuk-heading-l' %>

--- a/app/views/consent_forms/edit/consent.html.erb
+++ b/app/views/consent_forms/edit/consent.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<% title = "Do you agree to them having a nasal flu vaccination?" %>
+<% title = t("consent_forms.consent.title.#{ @session.type.downcase }") %>
 <% content_for :page_title, title %>
 
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
@@ -13,10 +13,10 @@
 
   <%= f.govuk_radio_buttons_fieldset(:response,
     legend: { size: 'l', text: title, tag: 'h1' },
-    hint: { text: 'The nasal flu spray contains gelatine which comes from pigs.' }
+    hint: { text: t("consent_forms.consent.hint.#{ @session.type.downcase }") }
   ) do %>
     <%= f.govuk_radio_button :response, "given",
-      label: { text: 'Yes, I agree to them having a nasal vaccine ' },
+      label: { text: t("consent_forms.consent.i_agree.#{ @session.type.downcase }") },
       link_errors: true %>
     <%= f.govuk_radio_button :response, "refused",
       label: { text: 'No' } %>

--- a/app/views/consent_forms/start.html.erb
+++ b/app/views/consent_forms/start.html.erb
@@ -1,8 +1,9 @@
-<%= h1 "Give or refuse consent for a flu vaccination" %>
+<%= h1 t("consent_forms.start.title.#{ @session.type.downcase }") %>
 
-<p class="nhsuk-u-margin-bottom-6">
-  The vaccination helps to protect children against flu. It also protects others
-  who are vulnerable to flu, such as babies and older people.
-</p>
+<% t("consent_forms.start.paragraphs.#{ @session.type.downcase }").each do |paragraph| %>
+  <p class="nhsuk-u-margin-bottom-6">
+    <%= paragraph %>
+  </p>
+<% end %>
 
 <%= govuk_button_to "Start now", url_for(action: :create) %>

--- a/app/views/consents/edit_consent.html.erb
+++ b/app/views/consents/edit_consent.html.erb
@@ -7,7 +7,8 @@
   ) %>
 <% end %>
 
-<% content_for :page_title, "Do they agree to them having the HPV vaccination?" %>
+<% title = t("consents.edit_consent.title.#{ @session.type.downcase }") %>
+<% content_for :page_title, title %>
 
 <%= form_for @draft_consent,
   url: session_patient_consents_path(@session, @patient),
@@ -16,7 +17,7 @@
   <%= f.govuk_radio_buttons_fieldset(:consent,
     legend: { size: 'l',
               tag: 'h1',
-              text: 'Do they agree to them having the HPV vaccination?' }) do %>
+              text: title }) do %>
     <%= f.govuk_radio_button :response, "given",
       label: { text: 'Yes, they agree' }, link_errors: true %>
     <%= f.govuk_radio_button :response, "refused",

--- a/app/views/users/shared/_error_messages.html.erb
+++ b/app/views/users/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
     <h2>
-      <%= I18n.t("errors.messages.not_saved",
+      <%= t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>

--- a/app/views/vaccinations/_form.html.erb
+++ b/app/views/vaccinations/_form.html.erb
@@ -11,7 +11,7 @@
       .merge(embedded ? { size: 'm' } : { size: 'l', tag: 'h1' })
   ) do %>
     <%= f.govuk_radio_button :administered, true,
-      label: { text: 'Yes, they got the HPV vaccine' },
+      label: { text: t("vaccinations.form.label.#{ @session.type.downcase }") },
       link_errors: true do %>
       <%= f.govuk_collection_radio_buttons :delivery_site,
         vaccination_initial_delivery_sites,

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -27,7 +27,7 @@
 
       summary_list.with_row do |row|
         row.with_key { 'Vaccine' }
-        row.with_value { 'HPV' }
+        row.with_value { @session.type }
       end
 
       if @draft_vaccination_record.administered?

--- a/app/views/vaccinations/edit_reason.html.erb
+++ b/app/views/vaccinations/edit_reason.html.erb
@@ -5,7 +5,8 @@
              ) %>
 <% end %>
 
-<% content_for :page_title, "Why was the HPV vaccine not given?" %>
+<% title = t("vaccinations.edit_reason.title.#{ @session.type.downcase }") %>
+<% content_for :page_title, title %>
 
 <%= form_with model: @draft_vaccination_record,
               url: session_patient_vaccinations_path(
@@ -15,7 +16,7 @@
               method: :put do |f| %>
     <%= f.govuk_radio_buttons_fieldset(:reason,
       legend: { size: 'l', tag: 'h1',
-                text: 'Why was the HPV vaccine not given?' }) do %>
+                text: title }) do %>
 
       <%= f.govuk_radio_button :reason, "refused",
         label: { text: 'They refused it' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,9 +26,64 @@ en:
       medical_reasons: "of medical reasons"
       personal_choice: "of personal choice"
       other: "of other reasons"
+  consents:
+    edit_consent:
+      title:
+        flu: Do they agree to them having the flu vaccination?
+        hpv: Do they agree to them having the HPV vaccination?
+  vaccinations:
+    form:
+      label:
+        flu: Yes, they got the flu vaccine
+        hpv: Yes, they got the HPV vaccine
+    edit_reason:
+      title:
+        flu: Why was the flu vaccine not given?
+        hpv: Why was the HPV vaccine not given?
+  consent_forms:
+    start:
+      title:
+        flu: Give or refuse consent for a flu vaccination
+        hpv: Give or refuse consent for an HPV vaccination
+      paragraphs:
+        flu:
+          - The vaccination helps to protect children against flu. It also
+            protects others who are vulnerable to flu, such as babies and older
+            people.
+        hpv:
+          - The HPV vaccine helps to prevent HPV related cancers from
+            developing in boys and girls.
+          - The number of doses you need depends on your age and how well your
+            immune system works. Young people usually only need 1 dose.
+    consent:
+      title:
+        flu: Do you agree to them having a nasal flu vaccination?
+        hpv: Do you agree to them having the HPV vaccination?
+      hint:
+        flu: The nasal flu spray contains gelatine which comes from pigs.
+        hpv: ""
+      i_agree:
+        flu: Yes, I agree to them having a nasal vaccine
+        hpv: Yes, I agree
+    confirmation_agreed:
+      title:
+        flu: " %{full_name} will get their nasal flu vaccination at school on %{date}"
+        hpv: " %{full_name} will get their HPV vaccination at school on %{date}"
+    confirmation_needs_triage:
+      title:
+        flu: You’ve given consent for your child to get a flu vaccination
+        hpv: You’ve given consent for your child to get an HPV vaccination
+    confirmation_injection:
+      title:
+        # HPV shouldn't have this state because it's always an injection
+        flu: Your child will not get a nasal flu vaccination at school
+    confirmation_refused:
+      title:
+        flu: Your child will not get a nasal flu vaccination at school
+        hpv: Your child will not get an HPV vaccination at school
   vaccines:
-    hpv: HPV
     flu: Flu
+    hpv: HPV
   activemodel:
     errors:
       models:

--- a/tests/parental_consent_authentication.spec.ts
+++ b/tests/parental_consent_authentication.spec.ts
@@ -35,7 +35,7 @@ const and_i_click_the_start_button = when_i_click_the_start_button;
 
 async function then_i_see_the_consent_start_page() {
   await expect(p.locator("h1")).toContainText(
-    "Give or refuse consent for a flu vaccination",
+    "Give or refuse consent for an HPV vaccination",
   );
 }
 

--- a/tests/parental_consent_refused.spec.ts
+++ b/tests/parental_consent_refused.spec.ts
@@ -64,7 +64,7 @@ async function then_i_see_the_consent_confirm_page() {
 
 async function then_i_see_the_consent_page() {
   await expect(p.locator("h1")).toContainText(
-    "Do you agree to them having a nasal flu vaccination?",
+    "Do you agree to them having the HPV vaccination?",
   );
 }
 


### PR DESCRIPTION
Use the @session.type instead combined with translation strings.