### PR TITLE
Display basic tabs in consents index page

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -1,7 +1,16 @@
 class ConsentsController < ApplicationController
   before_action :set_session
+  before_action :set_patient_sessions, only: %i[index]
 
   def index
+    methods = %i[consent_given? consent_refused? consent_conflicts? no_consent?]
+
+    @tabs =
+      @patient_sessions.group_by do |patient_session|
+        methods.find { |m| patient_session.send(m) }
+      end
+
+    methods.each { |m| @tabs[m] ||= [] }
   end
 
   private
@@ -11,5 +20,13 @@ class ConsentsController < ApplicationController
       policy_scope(Session).find(
         params.fetch(:session_id) { params.fetch(:id) }
       )
+  end
+
+  def set_patient_sessions
+    @patient_sessions =
+      @session
+        .patient_sessions
+        .includes(patient: :consents)
+        .order("patients.first_name", "patients.last_name")
   end
 end

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -104,6 +104,12 @@ module PatientSessionStateMachineConcern
       consents.any?(&:response_refused?)
     end
 
+    def consent_conflicts?
+      return false if no_consent?
+
+      consents.any?(&:response_given?) && consents.any?(&:response_refused?)
+    end
+
     def no_consent?
       consents.empty?
     end

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -7,3 +7,25 @@
 <% end %>
 
 <%= h1 "Check consent responses", class: "govuk-heading-l" %>
+
+<%= govuk_tabs title: "Vaccinations", classes: 'nhsuk-tabs' do |c|
+  c.with_tab(label: "Consent given (#{ @tabs[:consent_given?].size })",
+             classes: 'nhsuk-tabs__panel') do
+    @tabs[:consent_given?].size.to_s
+  end
+
+  c.with_tab(label: "Consent refused (#{ @tabs[:consent_refused?].size })",
+             classes: 'nhsuk-tabs__panel') do
+    @tabs[:consent_refused?].size.to_s
+  end
+
+  c.with_tab(label: "Consent conflicts (#{ @tabs[:consent_conflicts?].size })",
+             classes: 'nhsuk-tabs__panel') do
+    @tabs[:consent_conflicts?].size.to_s
+  end
+
+  c.with_tab(label: "No response (#{ @tabs[:no_consent?].size })",
+             classes: 'nhsuk-tabs__panel') do
+    @tabs[:no_consent?].size.to_s
+  end
+end %>


### PR DESCRIPTION
This queries the list of patient_sessions and splits them into the respective categories that match the tabs in the design.

The tabs contain just the number of items in each category for now. The tables are coming in a follow-up PR, as componentised versions of the partials used for tables in the other sections.

This moves some of the `consent_given?` and associated methods out of the state machine concern and into the `patient_session` model.

### Screenshot

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/928a9bb4-aadd-463e-9996-0f1592e0a67e)
