### PR TITLE
Update state machine to take into account multiple consents

### DIFF
--- a/app/components/app_status_banner_component.rb
+++ b/app/components/app_status_banner_component.rb
@@ -9,7 +9,7 @@ class AppStatusBannerComponent < ViewComponent::Base
     I18n.t(
       "patient_session_statuses.#{state}.banner_title",
       full_name:,
-      who_responded: who_responded&.downcase
+      who_responded:
     )
   end
 
@@ -23,7 +23,7 @@ class AppStatusBannerComponent < ViewComponent::Base
       gave_consent =
         I18n.t(
           "patient_session_statuses.#{state}.banner_explanation.gave_consent",
-          who_responded: who_responded.downcase
+          who_responded:
         )
 
       "#{reason_for_refusal}\n<br />\n#{gave_consent}".html_safe
@@ -32,7 +32,7 @@ class AppStatusBannerComponent < ViewComponent::Base
         "patient_session_statuses.#{state}.banner_explanation",
         default: "",
         full_name:,
-        who_responded: who_responded&.downcase
+        who_responded:
       )
     end
   end
@@ -44,7 +44,8 @@ class AppStatusBannerComponent < ViewComponent::Base
   private
 
   def consent
-    @consent ||= @patient_session.consent
+    # HACK: Component needs to be updated to work with multiple consents.
+    @consent ||= @patient_session.consents.first
   end
 
   def vaccination_record
@@ -52,7 +53,7 @@ class AppStatusBannerComponent < ViewComponent::Base
   end
 
   def who_responded
-    @patient_session.consent&.who_responded
+    consent&.who_responded&.downcase
   end
 
   def full_name

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -105,7 +105,8 @@ class TriageController < ApplicationController
   end
 
   def set_consent
-    @consent = @patient.consent_for_campaign(@session.campaign)
+    # HACK: Triage needs to be updated to work with multiple consents.
+    @consent = @patient_session.consents.first
   end
 
   def set_vaccination_record

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -285,7 +285,8 @@ class VaccinationsController < ApplicationController
   end
 
   def set_consent
-    @consent = @patient.consent_for_campaign(@session.campaign)
+    # HACK: Vaccinations needs to be updated to work with multiple consents.
+    @consent = @patient_session.consents.first
   end
 
   def set_triage

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -93,23 +93,27 @@ module PatientSessionStateMachineConcern
     end
 
     def consent_given?
-      consent&.response_given?
+      return false if no_consent?
+
+      consents.all?(&:response_given?)
     end
 
     def consent_refused?
-      consent&.response_refused?
+      return false if no_consent?
+
+      consents.any?(&:response_refused?)
     end
 
     def no_consent?
-      consent.nil?
+      consents.empty?
     end
 
     def triage_needed?
-      consent&.triage_needed?
+      consents.any?(&:triage_needed?)
     end
 
     def triage_not_needed?
-      !consent&.triage_needed?
+      !triage_needed?
     end
 
     def triage_ready_to_vaccinate?

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -65,10 +65,6 @@ class Patient < ApplicationRecord
       )
   end
 
-  def consent_for_campaign(campaign)
-    consents.to_a.find { |t| t.campaign == campaign && t.recorded_at.present? }
-  end
-
   def as_json(options = {})
     super.merge("full_name" => full_name, "age" => age)
   end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -37,8 +37,8 @@ class PatientSession < ApplicationRecord
             on: :edit_gillick
   validates :gillick_competence_notes, presence: true, on: :edit_gillick
 
-  def consent
-    patient.consent_for_campaign(session.campaign)
+  def consents
+    patient.consents.where(campaign:).where.not(recorded_at: nil)
   end
 
   def vaccination_record

--- a/app/views/triage/_patient_row.html.erb
+++ b/app/views/triage/_patient_row.html.erb
@@ -7,7 +7,9 @@
   <td class="nhsuk-table__cell">
     <% if middle_column == :triage_reasons %>
       <ul class="nhsuk-list nhsuk-u-margin-bottom-2">
-        <% patient_session.consent.reasons_triage_needed.map do |reason| %>
+        <%# HACK: Triage needs to be updated to work with multiple consents. %>
+        <% patient_session.consents.first
+            .reasons_triage_needed.map do |reason| %>
           <li><%= reason %></li>
         <% end %>
       </ul>

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -97,7 +97,8 @@ RSpec.describe AppStatusBannerComponent, type: :component do
     it { should have_css(".app-consent-banner--green") }
     it { should have_text("Vaccinated") }
     it "explains who gave consent" do
-      who_responded = patient_session.consent.who_responded
+      # HACK: Component needs to be updated to work with multiple consents.
+      who_responded = patient_session.consents.first.who_responded
       expect(component.explanation).to include(
         "Their #{who_responded} gave consent"
       )

--- a/spec/models/concerns/patient_session_state_machine_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_machine_concern_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PatientSessionStateMachineConcern do
 
       include PatientSessionStateMachineConcern
 
-      def consent
+      def consents
       end
 
       def triage
@@ -25,12 +25,13 @@ RSpec.describe PatientSessionStateMachineConcern do
 
   before do
     fsm.aasm_write_state_without_persistence(state) if state
-    allow(fsm).to receive(:consent).and_return(consent)
+    allow(fsm).to receive(:consents).and_return(consents)
     allow(fsm).to receive(:triage).and_return([triage])
     allow(fsm).to receive(:vaccination_record).and_return(vaccination_record)
   end
 
   let(:consent) { double("Consent") }
+  let(:consents) { [consent] }
   let(:triage) { double("Triage") }
   let(:vaccination_record) { double("VaccinationRecord") }
 
@@ -83,7 +84,7 @@ RSpec.describe PatientSessionStateMachineConcern do
 
     describe "#do_vaccination" do
       it "transitions to unable_to_vaccinate_not_assessed when consent is nil" do
-        allow(fsm).to receive(:consent).and_return(nil)
+        allow(fsm).to receive(:consents).and_return([])
 
         fsm.do_vaccination
         expect(fsm).to be_unable_to_vaccinate_not_assessed


### PR DESCRIPTION
This is partial support for the state machine for multiple consents in the state machine. I haven't thoroughly reviewed all the scenarios to see if it behaves correctly. The tests pass for scenarios where there is only one consent, but we don't have test coverage for multiple consents.

We also have to update the triage/vaccination flows. For now, this just stubs out the respective places where @consent is defined to use the `.first` consent, which is similar to the previous code.