### PR TITLE
Remove deprecation warning

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -14,7 +14,7 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # config.secret_key = ''
+  config.secret_key = Rails.application.secret_key_base
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.


### PR DESCRIPTION
It's coming from Devise and can be removed by specifying the secret_key_base explicitly: https://github.com/heartcombo/devise/issues/5644