### PR TITLE
Make show pages one

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -1,0 +1,5 @@
+<%= h1 patient.full_name, id: dom_id(patient), class: "nhsuk-heading-l" %>
+
+<%= render AppStatusBannerComponent.new(patient_session: patient_session) %>
+
+<%= render AppPatientCardComponent.new(patient: patient, session: session) %>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AppPatientPageComponent < ViewComponent::Base
+  include ApplicationHelper
+
+  attr_reader :patient_session
+
+  def initialize(patient_session:)
+    super
+
+    @patient_session = patient_session
+  end
+
+  delegate :patient, to: :patient_session
+
+  delegate :session, to: :patient_session
+end

--- a/app/views/triage/show.html.erb
+++ b/app/views/triage/show.html.erb
@@ -5,13 +5,7 @@
              ) %>
 <% end %>
 
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
-<%= h1 @patient.full_name, id: dom_id(@patient), class: "nhsuk-heading-l" %>
-
-<%= render AppStatusBannerComponent.new(patient_session: @patient_session) %>
-
-<%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
+<%= render AppPatientPageComponent.new(patient_session: @patient_session) %>
 
 <% if @consent.present? %>
   <%= render AppConsentCardComponent.new(

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -5,11 +5,7 @@
              ) %>
 <% end %>
 
-<%= h1 @patient.full_name, id: dom_id(@patient), class: "nhsuk-heading-l" %>
-
-<%= render AppStatusBannerComponent.new(patient_session: @patient_session) %>
-
-<%= render AppPatientCardComponent.new(patient: @patient, session: @session) %>
+<%= render AppPatientPageComponent.new(patient_session: @patient_session) %>
 
 <% if @consent.present? %>
   <% if @consent.via_self_consent? %>

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe AppPatientPageComponent, type: :component do
+  let(:patient_session) { FactoryBot.create(:patient_session) }
+  let(:component) { described_class.new(patient_session:) }
+
+  describe "rendering" do
+    before { render_inline(component) }
+
+    subject { page }
+
+    it { should have_css(".nhsuk-card", text: "Child details") }
+  end
+end

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -18,8 +18,25 @@ test("Triage", async ({ page }) => {
   // Triage - ready to vaccinate
   await when_i_click_on_a_patient();
   await and_i_enter_a_note_and_select_ready_to_vaccinate();
-  await and_i_click_on_the_ready_to_vaccinate_tab();
+  await and_i_click_on_the_triage_complete_tab();
   await then_the_patient_should_be_in_ready_to_vaccinate();
+
+  await when_i_click_on_a_patient();
+  await then_i_should_see_the_triage_details();
+
+  // Triage - not ready to vaccinate
+  await given_i_click_on_back();
+  await when_i_click_on_the_needs_triage_tab();
+  await and_i_click_on_another_patient();
+  await and_i_enter_a_note_and_select_do_not_vaccinate();
+  await then_i_should_be_back_on_the_needs_triage_tab();
+  await and_i_should_not_see_the_other_patient();
+
+  await when_i_click_on_the_triage_complete_tab();
+  await then_i_should_see_the_other_patient();
+
+  await when_i_click_on_the_other_patient();
+  await then_i_should_see_their_do_not_vaccinate_status();
 });
 
 async function given_the_app_is_setup() {
@@ -39,7 +56,7 @@ async function when_i_click_on_a_patient() {
 }
 
 async function and_i_enter_a_note_and_save_triage() {
-  await p.getByLabel("Triage notes").type("Unable to reach mother");
+  await p.getByLabel("Triage notes").fill("Unable to reach mother");
   await p.getByRole("button", { name: "Save triage" }).click();
 }
 
@@ -52,14 +69,16 @@ async function then_the_patient_should_still_be_in_triage() {
 }
 
 async function and_i_enter_a_note_and_select_ready_to_vaccinate() {
-  await p.getByLabel("Triage notes").type("Reached mother, able to proceed");
+  await p.getByLabel("Triage notes").fill("Reached mother, able to proceed");
   await p.getByRole("radio", { name: "Ready to vaccinate" }).click();
   await p.getByRole("button", { name: "Save triage" }).click();
 }
 
-async function and_i_click_on_the_ready_to_vaccinate_tab() {
+async function when_i_click_on_the_triage_complete_tab() {
   await p.getByRole("tab", { name: "Triage complete" }).click();
 }
+const and_i_click_on_the_triage_complete_tab =
+  when_i_click_on_the_triage_complete_tab;
 
 async function then_the_patient_should_be_in_ready_to_vaccinate() {
   await expect(
@@ -67,4 +86,54 @@ async function then_the_patient_should_be_in_ready_to_vaccinate() {
       name: "Caridad Sipes Health questions need triage Vaccinate",
     }),
   ).toBeVisible();
+}
+
+async function then_i_should_see_the_triage_details() {
+  await expect(
+    p.getByRole("radio", { name: "Ready to vaccinate" }),
+  ).toBeChecked();
+}
+
+async function given_i_click_on_back() {
+  await p.click("text=Back");
+}
+
+async function when_i_click_on_the_needs_triage_tab() {
+  await p.getByRole("tab", { name: "Needs triage" }).click();
+}
+
+async function when_i_click_on_the_other_patient() {
+  await p.getByRole("link", { name: "Blaine DuBuque" }).click();
+}
+const and_i_click_on_another_patient = when_i_click_on_the_other_patient;
+
+async function and_i_enter_a_note_and_select_do_not_vaccinate() {
+  await p
+    .getByLabel("Triage notes")
+    .fill("Father adament he does not want to vaccine");
+  await p.getByRole("radio", { name: "Do not vaccinate" }).click();
+  await p.getByRole("button", { name: "Save triage" }).click();
+}
+
+async function then_i_should_be_back_on_the_needs_triage_tab() {
+  await expect(p.getByRole("tab", { name: "Needs triage" })).toBeVisible();
+}
+
+async function and_i_should_not_see_the_other_patient() {
+  await expect(
+    p.getByRole("link", { name: "Blaine DuBuque" }),
+  ).not.toBeVisible();
+}
+
+async function then_i_should_see_the_other_patient() {
+  await expect(p.getByRole("link", { name: "Blaine DuBuque" })).toBeVisible();
+}
+
+async function then_i_should_see_their_do_not_vaccinate_status() {
+  await expect(p.getByRole("textbox", { name: "Triage notes" })).toHaveValue(
+    "Father adament he does not want to vaccine",
+  );
+  await expect(
+    p.getByRole("radio", { name: "Do not vaccinate" }),
+  ).toBeChecked();
 }


### PR DESCRIPTION
Beginning of incremental approach to moving to the new child/patient page design.

This PR simply adds a `AppPatientPageComponent` and moves the common components between the triage and the vaccinations show pages into it. No visual changes and the only changes to journey tests are to add checks for the Back button in the triage journey.