### PR TITLE
Add table to consents index

### DIFF
--- a/app/components/app_empty_list_component.rb
+++ b/app/components/app_empty_list_component.rb
@@ -1,0 +1,16 @@
+class AppEmptyListComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <div class="app-empty-list">
+      <div class="nhsuk-card__content">
+        <h2 class="nhsuk-heading-l">No results</h2>
+        <p><%= @message %></p>
+      </div>
+    </div>
+  ERB
+
+  def initialize(message:)
+    super
+
+    @message = message
+  end
+end

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -1,0 +1,48 @@
+class AppPatientTableComponent < ViewComponent::Base
+  def call
+    govuk_table do |table|
+      table.with_head do |head|
+        head.with_row do |row|
+          @columns.each { |column| row.with_cell(text: column_name(column)) }
+        end
+      end
+
+      table.with_body do |body|
+        @patient_sessions.each do |patient_session|
+          body.with_row do |row|
+            @columns.each do |column|
+              row.with_cell(text: column_value(patient_session, column))
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def initialize(patient_sessions:, columns: %i[name dob])
+    super
+
+    @patient_sessions = patient_sessions
+    @columns = columns
+  end
+
+  private
+
+  def column_name(column)
+    case column
+    when :name
+      "Name"
+    when :dob
+      "Date of birth"
+    end
+  end
+
+  def column_value(patient_session, column)
+    case column
+    when :name
+      patient_session.patient.full_name
+    when :dob
+      patient_session.patient.dob.to_fs(:nhsuk_date)
+    end
+  end
+end

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -8,24 +8,22 @@
 
 <%= h1 "Check consent responses", class: "govuk-heading-l" %>
 
-<%= govuk_tabs title: "Vaccinations", classes: 'nhsuk-tabs' do |c|
-  c.with_tab(label: "Consent given (#{ @tabs[:consent_given?].size })",
-             classes: 'nhsuk-tabs__panel') do
-    @tabs[:consent_given?].size.to_s
+<% def consent_tab(slot, label, data)
+  slot.with_tab(label: "#{label} (#{data.size})",
+                classes: 'nhsuk-tabs__panel') do
+    if data.size > 0
+      render AppPatientTableComponent.new(patient_sessions: data)
+    else
+      render AppEmptyListComponent.new(
+        message: "We couldn’t find any children that matched your filters."
+      )
+    end
   end
+end %>
 
-  c.with_tab(label: "Consent refused (#{ @tabs[:consent_refused?].size })",
-             classes: 'nhsuk-tabs__panel') do
-    @tabs[:consent_refused?].size.to_s
-  end
-
-  c.with_tab(label: "Consent conflicts (#{ @tabs[:consent_conflicts?].size })",
-             classes: 'nhsuk-tabs__panel') do
-    @tabs[:consent_conflicts?].size.to_s
-  end
-
-  c.with_tab(label: "No response (#{ @tabs[:no_consent?].size })",
-             classes: 'nhsuk-tabs__panel') do
-    @tabs[:no_consent?].size.to_s
-  end
+<%= govuk_tabs title: "Consents", classes: 'nhsuk-tabs' do |slot|
+  consent_tab(slot, "Consent given", @tabs[:consent_given?])
+  consent_tab(slot, "Consent refused", @tabs[:consent_refused?])
+  consent_tab(slot, "Consent conflicts", @tabs[:consent_conflicts?])
+  consent_tab(slot, "No response", @tabs[:no_consent?])
 end %>

--- a/app/views/layouts/_empty_list.html.erb
+++ b/app/views/layouts/_empty_list.html.erb
@@ -1,6 +1,0 @@
-<div class="app-empty-list">
-  <div class="nhsuk-card__content">
-    <h2 class="nhsuk-heading-l">No results</h2>
-    <p><%= message %></p>
-  </div>
-</div>

--- a/app/views/triage/_patients_with_dob.html.erb
+++ b/app/views/triage/_patients_with_dob.html.erb
@@ -16,7 +16,7 @@
         </tbody>
       </table>
     <% else %>
-      <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
+      <%= render AppEmptyListComponent.new(message: "We couldn’t find any children that matched your filters.") %>
     <% end %>
   </div>
 </div>

--- a/app/views/triage/_patients_with_triage_reasons.html.erb
+++ b/app/views/triage/_patients_with_triage_reasons.html.erb
@@ -16,7 +16,7 @@
         </tbody>
       </table>
     <% else %>
-      <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
+      <%= render AppEmptyListComponent.new(message: "We couldn’t find any children that matched your filters.") %>
     <% end %>
   </div>
 </div>

--- a/app/views/vaccinations/_patients_with_actions.html.erb
+++ b/app/views/vaccinations/_patients_with_actions.html.erb
@@ -41,7 +41,7 @@
         </tbody>
       </table>
     <% else %>
-      <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
+      <%= render AppEmptyListComponent.new(message: "We couldn’t find any children that matched your filters.") %>
     <% end %>
   </div>
 </div>

--- a/app/views/vaccinations/_patients_with_outcomes.html.erb
+++ b/app/views/vaccinations/_patients_with_outcomes.html.erb
@@ -41,7 +41,7 @@
         </tbody>
       </table>
     <% else %>
-        <%= render "layouts/empty_list", message: "We couldn’t find any children that matched your filters." %>
+      <%= render AppEmptyListComponent.new(message: "We couldn’t find any children that matched your filters.") %>
     <% end %>
   </div>
 </div>

--- a/spec/components/app_empty_list_component_spec.rb
+++ b/spec/components/app_empty_list_component_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe AppEmptyListComponent, type: :component do
+  before { render_inline(component) }
+
+  subject { page }
+
+  let(:message) { "No items found." }
+  let(:component) { described_class.new(message:) }
+
+  it { should have_css(".app-empty-list", text: "No results") }
+  it { should have_css(".nhsuk-card__content", text: message) }
+end

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AppPatientTableComponent, type: :component do
+  before { render_inline(component) }
+
+  subject { page }
+
+  let(:patient_sessions) { create_list(:patient_session, 2) }
+  let(:component) { described_class.new(patient_sessions:) }
+
+  it { should have_css(".nhsuk-table") }
+  it { should have_css(".nhsuk-table__head") }
+  it { should have_css(".nhsuk-table__head th", text: "Name") }
+  it { should have_css(".nhsuk-table__head th", text: "Date of birth") }
+  it { should have_css(".nhsuk-table__head .nhsuk-table__row", count: 1) }
+
+  it { should have_css(".nhsuk-table__body") }
+  it { should have_css(".nhsuk-table__body .nhsuk-table__row", count: 2) }
+end


### PR DESCRIPTION
This adds a reusable table component that can be expanded and reused across the consents/triage/vaccinations index pages. 

### After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/e30049dc-8ef4-4d60-92a8-9166b24b74d7)
