### PR TITLE
Update footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,8 +23,8 @@
       <div class="nhsuk-header__container app-header__container">
         <div class="nhsuk-header__logo nhsuk-header__logo--only">
           <a class="nhsuk-header__link nhsuk-header__link--service"
-             href="<%= @header_path %>"
-             aria-label="Service homepage">
+            href="<%= @header_path %>"
+            aria-label="Service homepage">
             <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
               <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
               <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
@@ -36,7 +36,7 @@
         </div>
       </div>
 
-      <nav class="nhsuk-navigation" id="header-navigation" role="navigation" aria-label="Primary navigation">
+      <nav class="nhsuk-navigation" role="navigation" aria-label="Primary navigation">
         <ul class="nhsuk-header__navigation-list app-header__navigation-list">
           <% if current_user.present? %>
             <li class="nhsuk-header__navigation-item">
@@ -61,8 +61,6 @@
           </li>
         </ul>
       </nav>
-
-
     </header>
 
     <%= yield :before_main %>
@@ -71,11 +69,10 @@
       <main class="nhsuk-main-wrapper" id="main-content" role="main">
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
-
     </div>
 
     <footer role="contentinfo">
-      <div class="nhsuk-footer" id="nhsuk-footer">
+      <div class="nhsuk-footer-container">
         <div class="nhsuk-width-container">
           <p class="nhsuk-footer__copyright">&copy; Crown copyright</p>
         </div>


### PR DESCRIPTION
Update footer with most recent markup changes from NHSUK Frontend:

| Before | After |
| - | - |
| <img width="460" alt="Screenshot 2023-11-30 at 12 05 25" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/d2ad96db-91bb-4c8b-b4c8-00ab89612a5b"> | <img width="400" alt="Screenshot 2023-11-30 at 12 05 38" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/e73cf13f-a6a8-4529-9c51-74d1891d5ac6"> |

Also, remove errant whitespace and unused `header-navigation` and `nhsuk-footer` `id`s in application layout.