### PR TITLE
Update session table display to include town and postcode, make responsive

### DIFF
--- a/app/views/sessions/_session_row.html.erb
+++ b/app/views/sessions/_session_row.html.erb
@@ -1,12 +1,17 @@
 <tr class="nhsuk-table__row">
   <td class="nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Date</span>
     <%= session.date.to_fs(:nhsuk_date_short_month) %>
   </td>
   <td class="nhsuk-table__cell">
+    <span class="nhsuk-table-responsive__heading">Time</span>
     <%= session.date.strftime("%l%P") %>
   </td>
   <td class="nhsuk-table__cell" id="<%= dom_id session %>">
-    <%= link_to session.name, session_path(session), "data-testid": "session-link" %>
+    <span class="nhsuk-table-responsive__heading">School</span>
+    <p class="nhsuk-u-margin-bottom-0 nhsuk-u-secondary-text-color">
+      <%= link_to session.location.name, session_path(session), "data-testid": "session-link" %><br>
+      <%= session.location.town %>, <%= session.location.postcode %>
+    </p>
   </td>
-  <td class="nhsuk-table__cell"></td>
 </tr>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -11,13 +11,12 @@
 <% @sessions_by_type.each do |campaign_type, sessions| %>
   <h2><%= campaign_type %></h2>
 
-  <table class="nhsuk-table">
+  <table class="nhsuk-table-responsive nhsuk-u-margin-bottom-4">
     <thead class="nhsuk-table__head">
       <tr class="nhsuk-table__row">
-        <th class="nhsuk-table__header">Date</th>
-        <th class="nhsuk-table__header">Time</th>
-        <th class="nhsuk-table__header" style="width: 50%">School</th>
-        <th class="nhsuk-table__header" style="width: 25%"></th>
+        <th class="nhsuk-table__header" scope="col">Date</th>
+        <th class="nhsuk-table__header" scope="col">Time</th>
+        <th class="nhsuk-table__header" scope="col">School</th>
       </tr>
     </thead>
     <tbody class="nhsuk-table__body">

--- a/tests/session_authorisation.spec.ts
+++ b/tests/session_authorisation.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { signInTestUser } from "./shared";
+import { signInTestUser, fixtures } from "./shared";
 
 let p: Page;
 
@@ -39,7 +39,7 @@ async function then_i_should_see_only_my_session() {
     1,
   );
   await expect(p.locator(".nhsuk-table__body .nhsuk-table__row")).toHaveText(
-    /Flu campaign at/,
+    fixtures.schoolName,
   );
 }
 

--- a/tests/shared/index.ts
+++ b/tests/shared/index.ts
@@ -15,5 +15,7 @@ export const fixtures = {
   patientThatNeedsVaccination: "Brittany Klocko",
   secondPatientThatNeedsVaccination: "Luigi Ondricka",
 
+  schoolName: /Heath House Hospital School/,
+
   vaccineBatch: "ZS7570",
 };


### PR DESCRIPTION
This PR adds `session.location.town` and `session.location.postcode` to each session row. Also, it changes the link to show the `session.location.name`, not `session.name`. Is location information guaranteed to be always available, or does it require checking for the presence of these values, first?

It also updates the table to use the responsive variant provided by the NHS Design System. While not perfect (right aligned values, hmmm), it adapts better to smaller screens than the non-responsive table.

## Mobile

| Before | After |
| - | - |
| <img width="378" alt="Screenshot 2023-11-30 at 13 32 06" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/fd57670e-8697-47da-84b7-3e49d4aa5a34"> | <img width="378" alt="Screenshot 2023-11-30 at 13 37 49" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/3c65cb4c-3e49-4594-a0f2-4a970f1275d5"> |

## Desktop

| Before | After |
| - | - |
| <img width="990" alt="Screenshot 2023-11-30 at 13 32 23" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/6347b6fc-ac77-4bfc-a5cf-fc10f4dedcc9"> | <img width="1000" alt="Screenshot 2023-11-30 at 13 37 39" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/a3207ea2-2f36-4668-9aa4-ab2ffa656c60"> |
