### PR TITLE
Consents show page

### DIFF
--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -19,11 +19,12 @@ class AppPatientTableComponent < ViewComponent::Base
     end
   end
 
-  def initialize(patient_sessions:, columns: %i[name dob])
+  def initialize(patient_sessions:, columns: %i[name dob], route: nil)
     super
 
     @patient_sessions = patient_sessions
     @columns = columns
+    @route = route
   end
 
   private
@@ -35,7 +36,7 @@ class AppPatientTableComponent < ViewComponent::Base
   def column_value(patient_session, column)
     case column
     when :name
-      patient_session.patient.full_name
+      patient_link(patient_session)
     when :dob
       patient_session.patient.dob.to_fs(:nhsuk_date)
     when :reason
@@ -44,6 +45,18 @@ class AppPatientTableComponent < ViewComponent::Base
         .map { |c| c.human_enum_name(:reason_for_refusal) }
         .join("<br />")
         .html_safe
+    end
+  end
+
+  def patient_link(patient_session)
+    if @route == :consent
+      govuk_link_to patient_session.patient.full_name,
+                    session_patient_consents_path(
+                      patient_session.session,
+                      patient_session.patient
+                    )
+    else
+      raise ArgumentError, "Unknown route: #{@route}"
     end
   end
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -1,6 +1,11 @@
 class ConsentsController < ApplicationController
   before_action :set_session
   before_action :set_patient_sessions, only: %i[index]
+  before_action :set_patient, only: %i[show]
+  before_action :set_patient_session, only: %i[show]
+  before_action :set_consent, only: %i[show]
+
+  layout "two_thirds", except: :index
 
   def index
     methods = %i[consent_given? consent_refused? consent_conflicts? no_consent?]
@@ -13,6 +18,9 @@ class ConsentsController < ApplicationController
     methods.each { |m| @tabs[m] ||= [] }
   end
 
+  def show
+  end
+
   private
 
   def set_session
@@ -20,6 +28,19 @@ class ConsentsController < ApplicationController
       policy_scope(Session).find(
         params.fetch(:session_id) { params.fetch(:id) }
       )
+  end
+
+  def set_patient
+    @patient = Patient.find(params.fetch(:patient_id) { params.fetch(:id) })
+  end
+
+  def set_patient_session
+    @patient_session = @patient.patient_sessions.find_by(session: @session)
+  end
+
+  def set_consent
+    # HACK
+    @consent = @patient_session.consents.first
   end
 
   def set_patient_sessions

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -12,7 +12,11 @@
   slot.with_tab(label: "#{label} (#{data.size})",
                 classes: 'nhsuk-tabs__panel') do
     if data.size > 0
-      render AppPatientTableComponent.new(patient_sessions: data, columns:)
+      render AppPatientTableComponent.new(
+        patient_sessions: data,
+        columns:,
+        route: :consent,
+      )
     else
       render AppEmptyListComponent.new(
         message: "We couldn’t find any children that matched your filters."

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -1,0 +1,12 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+               href: consents_session_path(@session),
+               name: "consents page"
+             ) %>
+<% end %>
+
+<%= render AppPatientPageComponent.new(
+      patient_session: @patient_session,
+      consent: @consent,
+      route: "triage",
+    ) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,8 @@ Rails.application.routes.draw do
     end
 
     resources :patients do
+      resource :consents, only: %i[show]
+
       resource :triage, only: %i[create show update]
 
       resource :vaccinations, only: %i[new create show update] do

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe AppPatientTableComponent, type: :component do
 
   subject { page }
 
+  let(:route) { :consent }
   let(:patient_sessions) { create_list(:patient_session, 2) }
-  let(:component) { described_class.new(patient_sessions:) }
+  let(:component) { described_class.new(patient_sessions:, route:) }
 
   it { should have_css(".nhsuk-table") }
   it { should have_css(".nhsuk-table__head") }
@@ -18,4 +19,11 @@ RSpec.describe AppPatientTableComponent, type: :component do
 
   it { should have_css(".nhsuk-table__body") }
   it { should have_css(".nhsuk-table__body .nhsuk-table__row", count: 2) }
+  it { should have_link(patient_sessions.first.patient.full_name) }
+
+  it "raises an ArgumentError when route is unknown" do
+    expect {
+      render_inline(described_class.new(patient_sessions:, route: :unknown))
+    }.to raise_error(ArgumentError)
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -52,7 +52,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join("/spec/fixtures")
+  config.fixture_paths = [Rails.root.join("/spec/fixtures")]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/tests/consent.spec.ts
+++ b/tests/consent.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
-import { signInTestUser } from "./shared/sign_in";
+import { signInTestUser, fixtures } from "./shared";
 
 let p: Page;
 
@@ -8,7 +8,10 @@ test("Check consent responses", async ({ page }) => {
   await given_the_app_is_setup();
   await and_i_am_signed_in();
   await when_i_go_to_the_consent_page();
-  await then_i_see_the_consent_page();
+  await then_i_see_the_consents_page();
+
+  await when_i_click_on_a_patient();
+  await then_i_see_the_patient_page();
 });
 
 async function given_the_app_is_setup() {
@@ -23,6 +26,14 @@ async function when_i_go_to_the_consent_page() {
   await p.goto("/sessions/1/consents");
 }
 
-async function then_i_see_the_consent_page() {
+async function then_i_see_the_consents_page() {
   await expect(p.locator("h1")).toHaveText("Check consent responses");
+}
+
+async function when_i_click_on_a_patient() {
+  await p.getByRole("link", { name: fixtures.patientThatNeedsTriage }).click();
+}
+
+async function then_i_see_the_patient_page() {
+  await expect(p.locator("h1")).toHaveText(fixtures.patientThatNeedsTriage);
 }


### PR DESCRIPTION
Updates the names in the patient table component to link to the consents show page. This is passed in as a `route` argument which we can customise when we reuse this component across the other sections.

### Screenshot

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/5b5d3f67-9147-48a5-9be2-8ff255deced7)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/4aab0394-8806-477c-8a6d-84c1c9e4ab85)
