### PR TITLE
Display the consent route

### DIFF
--- a/app/components/app_consent_response_component.rb
+++ b/app/components/app_consent_response_component.rb
@@ -4,7 +4,7 @@ class AppConsentResponseComponent < ViewComponent::Base
       @consents.map do |consent|
         [
           tag.p(class: "nhsuk-u-margin-bottom-0") do
-            "#{consent.human_enum_name(:response).capitalize} (online)"
+            "#{response(consent:)} (#{route(consent:)})"
           end,
           tag.p(class: date_and_time_p_classes) do
             date_and_time consent.created_at
@@ -41,5 +41,13 @@ class AppConsentResponseComponent < ViewComponent::Base
     at_time = date.strftime("%-l:%M%P")
 
     %(#{date_text} at <span class="nhsuk-u-margin-left-1">#{at_time}</span>).html_safe
+  end
+
+  def response(consent:)
+    consent.human_enum_name(:response).capitalize
+  end
+
+  def route(consent:)
+    consent.human_enum_name(:route).downcase
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,8 @@ en:
           given: "consent given"
           refused: "consent refused"
           not_provided: "not provided"
+        routes:
+          website: online
       patient:
         parent_relationships:
           father: dad

--- a/spec/components/app_consent_details_component_spec.rb
+++ b/spec/components/app_consent_details_component_spec.rb
@@ -23,22 +23,6 @@ RSpec.describe AppConsentDetailsComponent, type: :component do
     should have_css("div", text: /Response ?Consent refused/)
   end
 
-  context "consent response was given over the phone" do
-    let(:consent) do
-      create(
-        :consent,
-        :refused,
-        :from_dad,
-        parent_name: "Harry",
-        route: "phone"
-      )
-    end
-
-    xit "displays the route" do
-      should have_css("div", text: /Response ?Consent refused \(phone\)/)
-    end
-  end
-
   it "displays the refusal reason" do
     should have_css("div", text: /Refusal reason ?Personal choice/)
   end

--- a/spec/components/app_consent_response_component_spec.rb
+++ b/spec/components/app_consent_response_component_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe AppConsentResponseComponent, type: :component do
     it { should_not have_css("ul") }
   end
 
+  context "with consent taken over the phone" do
+    let(:consents) { [create(:consent, :given, route: "phone")] }
+
+    it { should have_css("p", text: "Consent given (phone)") }
+  end
+
   context "with multiple consents" do
     let(:consent1) { create(:consent, :given) }
     let(:consent2) { create(:consent, :given) }


### PR DESCRIPTION
> [!Caution]
> This PR is based on #638 which should be merged first.

This adds "online", "phone", etc to the response field in the consent details. Whereas this was hardcoded to "online" before.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/f52b810c-2ab4-4554-9ec3-1bfde86f3b0d)
