### PR TITLE
Fix consent fields in avo

### DIFF
--- a/app/avo/resources/consent_form_resource.rb
+++ b/app/avo/resources/consent_form_resource.rb
@@ -34,6 +34,11 @@ class ConsentFormResource < Avo::BaseResource
   field :address_line_2, as: :string
   field :address_postcode, as: :string
   field :address_town, as: :string
-  field :health_answers, as: :text
-  field :recorded_at, as: :datetime
+  field :health_answers, as: :code, language: "javascript", only_on: :edit
+  field :health_answers, as: :code, language: "javascript" do |record|
+    if record.health_questions.present?
+      JSON.pretty_generate(record.health_questions.as_json)
+    end
+  end
+  field :recorded_at, as: :date_time
 end

--- a/app/avo/resources/consent_resource.rb
+++ b/app/avo/resources/consent_resource.rb
@@ -29,9 +29,14 @@ class ConsentResource < Avo::BaseResource
   field :gp_response, as: :select, enum: ::Consent.gp_responses
   field :gp_name, as: :textarea
   field :route, as: :select, enum: ::Consent.routes
-  field :health_questions, as: :text
+  field :health_questions, as: :code, language: "javascript", only_on: :edit
+  field :health_questions, as: :code, language: "javascript" do |record|
+    if record.health_questions.present?
+      JSON.pretty_generate(record.health_questions.as_json)
+    end
+  end
   field :patient, as: :belongs_to
   field :campaign, as: :belongs_to
-  field :recorded_at, as: :datetime
+  field :recorded_at, as: :date_time
   # add fields here
 end


### PR DESCRIPTION
Adds better formatting of the JSON health question and answer fields in the `consent` and `consent_form` resources. Without this when editing the a consent record Avo somehow modified the healh questinos JSON, it stripped the topmost wrapping `[]`.

Also fixes complaints about `datetime` not being a field type in these resources.

| Viewing health questions before | Viewing health questions after |
|-|-|
| ![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/a355a8f8-e6a1-4402-b33c-265176366f75) | ![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/4478eb7a-64f4-4cbe-aeff-ec4ef5ed7872) |


| Editing health questions before | Editing health questions after |
|-|-|
| ![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/55144fc6-0a31-44e9-aa81-c2b68cc4e4b9) | ![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/70d71abf-cefb-466c-b170-d0ce9a1adc3e) |
