### PR TITLE
Show stats on session page

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -47,7 +47,8 @@ class ConsentsController < ApplicationController
     @patient_sessions =
       @session
         .patient_sessions
-        .includes(patient: :consents)
-        .order("patients.first_name", "patients.last_name")
+        .strict_loading
+        .includes(:campaign, :consents, :patient)
+        .sort_by { |ps| ps.patient.full_name }
   end
 end

--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -3,7 +3,6 @@ class ConsentsController < ApplicationController
   before_action :set_patient_sessions, only: %i[index]
   before_action :set_patient, only: %i[show]
   before_action :set_patient_session, only: %i[show]
-  before_action :set_consent, only: %i[show]
 
   layout "two_thirds", except: :index
 
@@ -36,11 +35,6 @@ class ConsentsController < ApplicationController
 
   def set_patient_session
     @patient_session = @patient.patient_sessions.find_by(session: @session)
-  end
-
-  def set_consent
-    # HACK
-    @consent = @patient_session.consents.first
   end
 
   def set_patient_sessions

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,6 +6,31 @@ class SessionsController < ApplicationController
   end
 
   def show
+    @patient_sessions = @session.patient_sessions
+      .includes(:campaign, patient: :consents)
+
+    @counts = {
+      with_consent_given: 0,
+      with_consent_refused: 0,
+      without_a_response: 0,
+      needing_triage: 0,
+      ready_to_vaccinate: 0
+    }
+
+    @patient_sessions.each do |s|
+      @counts[:with_consent_given] += 1 if s.consent_given?
+      @counts[:with_consent_refused] += 1 if s.consent_refused?
+      @counts[:without_a_response] += 1 if s.no_consent?
+
+      if s.consent_given_triage_needed? || s.triaged_kept_in_triage?
+        @counts[:needing_triage] += 1
+        @counts[:ready_to_vaccinate] += 1
+      end
+
+      @counts[:ready_to_vaccinate] += 1 if s.triaged_ready_to_vaccinate? ||
+                                            s.added_to_session? ||
+                                            s.consent_given_triage_not_needed?
+    end
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,8 +6,8 @@ class SessionsController < ApplicationController
   end
 
   def show
-    @patient_sessions = @session.patient_sessions
-      .includes(:campaign, patient: :consents)
+    @patient_sessions =
+      @session.patient_sessions.strict_loading.includes(:campaign, :consents)
 
     @counts = {
       with_consent_given: 0,
@@ -28,8 +28,7 @@ class SessionsController < ApplicationController
       end
 
       @counts[:ready_to_vaccinate] += 1 if s.triaged_ready_to_vaccinate? ||
-                                            s.added_to_session? ||
-                                            s.consent_given_triage_not_needed?
+        s.added_to_session? || s.consent_given_triage_not_needed?
     end
   end
 

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -19,7 +19,6 @@ class TriageController < ApplicationController
     tabs_to_states = {
       needs_triage: %w[consent_given_triage_needed triaged_kept_in_triage],
       triage_complete: %w[triaged_ready_to_vaccinate triaged_do_not_vaccinate],
-      get_consent: %w[added_to_session],
       no_triage_needed: %w[
         consent_refused
         consent_given_triage_not_needed

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -13,7 +13,8 @@ class TriageController < ApplicationController
     patient_sessions =
       @session
         .patient_sessions
-        .includes(:vaccination_records, patient: %i[consents triage])
+        .strict_loading
+        .includes(:campaign, :patient)
         .order("patients.first_name", "patients.last_name")
 
     tabs_to_states = {

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -47,6 +47,9 @@ class Consent < ApplicationRecord
   belongs_to :patient
   belongs_to :campaign
 
+  scope :submitted_for_campaign,
+        ->(campaign) { where(campaign:).where.not(recorded_at: nil) }
+
   enum :parent_relationship, %w[mother father guardian other], prefix: true
   enum :response, %w[given refused not_provided], prefix: true
   enum :reason_for_refusal,

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -29,6 +29,10 @@ class PatientSession < ApplicationRecord
   has_one :campaign, through: :session
   has_many :triage
   has_many :vaccination_records
+  has_many :consents,
+           ->(patient) { Consent.submitted_for_campaign(patient.campaign) },
+           through: :patient,
+           class_name: "Consent"
 
   validates :gillick_competent,
             inclusion: {
@@ -36,10 +40,6 @@ class PatientSession < ApplicationRecord
             },
             on: :edit_gillick
   validates :gillick_competence_notes, presence: true, on: :edit_gillick
-
-  def consents
-    patient.consents.where(campaign:).where.not(recorded_at: nil)
-  end
 
   def vaccination_record
     vaccination_records.last

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -12,7 +12,7 @@
   <%= page_title %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @session.date.to_fs(:long_ordinal_uk) %> ·
-    <%= pluralize(@session.patient_sessions.size, 'child') %> in chort
+    <%= pluralize(@patient_sessions.size, 'child') %> in cohort
   </span>
 <% end %>
 
@@ -25,9 +25,9 @@
             consents_session_path(@session) %>
         </h2>
         <p>
-          <%= pluralize(0, 'child') %> with consent given<br>
-          <%= pluralize(0, 'child') %> with consent refused<br>
-          <%= pluralize(0, 'child') %> without a response
+          <%= pluralize(@counts[:with_consent_given], 'child') %> with consent given<br>
+          <%= pluralize(@counts[:with_consent_refused], 'child') %> with consent refused<br>
+          <%= pluralize(@counts[:without_a_response], 'child') %> without a response
         </p>
 
         <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
@@ -35,7 +35,7 @@
             triage_session_path(@session) %>
         </h2>
         <p>
-          <%= pluralize(0, 'child') %> needing triage
+          <%= pluralize(@counts[:needing_triage], 'child') %> needing triage
         </p>
 
         <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
@@ -43,7 +43,7 @@
             vaccinations_session_path(@session) %>
         </h2>
         <p>
-          <%= pluralize(0, 'child') %> ready to vaccinate
+          <%= pluralize(@counts[:ready_to_vaccinate], 'child') %> ready to vaccinate
         </p>
       </div>
     </div>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -11,7 +11,8 @@
 <%= h1 page_title:, class: "nhsuk-heading-l" do %>
   <%= page_title %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-    <%= @session.date.to_fs(:long_ordinal_uk) %>
+    <%= @session.date.to_fs(:long_ordinal_uk) %> ·
+    <%= pluralize(@session.patient_sessions.size, 'child') %> in chort
   </span>
 <% end %>
 
@@ -19,18 +20,31 @@
   <div class="nhsuk-grid-column-two-thirds">
     <div class="nhsuk-card">
       <div class="nhsuk-card__content">
-        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-3">
+        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
           <%= link_to "Check consent responses",
             consents_session_path(@session) %>
         </h2>
-        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-3">
+        <p>
+          <%= pluralize(0, 'child') %> with consent given<br>
+          <%= pluralize(0, 'child') %> with consent refused<br>
+          <%= pluralize(0, 'child') %> without a response
+        </p>
+
+        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
           <%= link_to "Triage health questions",
             triage_session_path(@session) %>
         </h2>
-        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-3">
+        <p>
+          <%= pluralize(0, 'child') %> needing triage
+        </p>
+
+        <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
           <%= link_to "Record vaccinations",
             vaccinations_session_path(@session) %>
         </h2>
+        <p>
+          <%= pluralize(0, 'child') %> ready to vaccinate
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
I had a quick go at adding relevant stats to the session page:

- Number of patient in cohort
- Patients with consent given
- Patients with consent refused
- Patients without a response
- Patients needing triage
- Patients ready to vaccinate

To get some of these numbers, it seems as if various states are combined in the consents, triage and vaccination and controllers; it doesn’t seem right to repeat that same or similar logic in the sessions controller too.

<img width="660" alt="Screenshot 2023-12-04 at 15 40 53" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/f32f3f00-6c57-4f6e-a429-3e041d05d53f">

All of which is to say is, here’s a page where we’d want to show some information we already show in other places, maybe some broader refactoring is required to make it easier to build out the above?
