### PR TITLE
Add link to ‘School sessions’ to signed in header navigation

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -110,17 +110,13 @@ $color_app-pale-blue: #ccdff1;
   }
 
   &__navigation-list {
-    justify-content: flex-end;
-
-    .button_to,
-    .app-header__button-link {
-      height: 100%;
+    .nhsuk-header__navigation-item:first-of-type {
+      margin-right: auto;
     }
   }
 
   &__button-link {
     @extend .nhsuk-header__navigation-link;
-    @include nhsuk-font(16);
     border: none;
     border-bottom: nhsuk-spacing(1) solid transparent;
     border-top: nhsuk-spacing(1) solid transparent;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,9 +40,12 @@
         <ul class="nhsuk-header__navigation-list app-header__navigation-list">
           <% if current_user.present? %>
             <li class="nhsuk-header__navigation-item">
-              <div class="nhsuk-header__navigation-link app-u-text-decoration-none">
+              <%= link_to "School sessions", sessions_path, class: "nhsuk-header__navigation-link" %>
+            </li>
+            <li class="nhsuk-header__navigation-item">
+              <span class="nhsuk-header__navigation-link app-u-text-decoration-none">
                 <%= current_user.email %>
-              </div>
+              </span>
             </li>
             <li class="nhsuk-header__navigation-item">
               <%= button_to destroy_user_session_path, class: "app-header__button-link", method: :delete do %>


### PR DESCRIPTION
<img width="460" alt="Screenshot 2023-12-04 at 16 08 26" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/e17848ba-b9b4-42b3-9594-f26cf4a194e4">

Also fixes the size of the ‘Sign out’ button, which was appearing to small at the mobile breakpoint; removing `@include nhsuk-font(16);` seemingly does the trick.