### PR TITLE
Move vaccination card to patient page component.

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -15,3 +15,11 @@
 <%= render AppCardComponent.new(heading: "Triage notes") do %>
   <%= render AppTriageNotesComponent.new(patient_session:) %>
 <% end %>
+
+
+<%=
+render AppVaccinateFormComponent.new(
+    patient_session:,
+    vaccination_record: @vaccination_record,
+)
+%>

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -5,11 +5,12 @@ class AppPatientPageComponent < ViewComponent::Base
 
   attr_reader :patient_session, :consent
 
-  def initialize(patient_session:, consent:, route:)
+  def initialize(patient_session:, consent:, route:, vaccination_record: nil)
     super
 
     @patient_session = patient_session
     @consent = consent
+    @vaccination_record = vaccination_record || VaccinationRecord.new
     @route = route
   end
 

--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -1,0 +1,52 @@
+<%=
+form_with(
+    model: @vaccination_record,
+    url: @url,
+    method: :post,
+    class: "nhsuk-card",
+    builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f|
+%>
+  <div class="nhsuk-card__content">
+    <h2 class="nhsuk-card__heading nhsuk-heading-m">
+      Did they get the <%= campaign_name %> vaccine?
+    </h2>
+    <% content_for(:before_content) { f.govuk_error_summary } %>
+
+    <%= f.govuk_radio_buttons_fieldset(:administered, legend: nil) do %>
+      <%=
+      f.govuk_radio_button(
+        :administered, true,
+        label: { text: t("vaccinations.form.label.#{ session.type.downcase }") },
+        link_errors: true
+      ) do
+      %>
+        <%=
+        f.govuk_collection_radio_buttons(
+          :delivery_site,
+          vaccination_initial_delivery_sites,
+          :to_s,
+          :humanize,
+          inline: true,
+          legend: {
+            text: 'Where did they get it?',
+            hidden: true
+          },
+          bold_labels: false
+        )
+        %>
+      <% end %>
+      <%=
+      f.govuk_radio_button(
+        :administered,
+        false,
+        label: { text: 'No, they did not get it' }
+      )
+      %>
+    <% end %>
+
+    <%= f.hidden_field :delivery_method, value: :intramuscular %>
+
+    <%= f.submit "Continue", class: "nhsuk-button" %>
+  </div>
+<% end %>

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -7,6 +7,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
     @vaccination_record = vaccination_record
   end
 
+  # rubocop:disable Naming/MemoizedInstanceVariableName
   def before_render
     @url ||=
       session_patient_vaccinations_path(
@@ -14,6 +15,7 @@ class AppVaccinateFormComponent < ViewComponent::Base
         patient_id: patient.id
       )
   end
+  # rubocop:enable Naming/MemoizedInstanceVariableName
 
   private
 

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -1,0 +1,35 @@
+class AppVaccinateFormComponent < ViewComponent::Base
+  def initialize(patient_session:, vaccination_record:, url: nil)
+    super
+
+    @patient_session = patient_session
+    @url = url
+    @vaccination_record = vaccination_record
+  end
+
+  def before_render
+    @url ||=
+      session_patient_vaccinations_path(
+        session_id: session.id,
+        patient_id: patient.id
+      )
+  end
+
+  private
+
+  def patient
+    @patient_session.patient
+  end
+
+  def session
+    @patient_session.session
+  end
+
+  def campaign_name
+    @patient_session.campaign.name
+  end
+
+  def vaccination_initial_delivery_sites
+    %w[left_arm right_arm other]
+  end
+end

--- a/app/views/vaccinations/show.html.erb
+++ b/app/views/vaccinations/show.html.erb
@@ -8,6 +8,7 @@
 <%= render AppPatientPageComponent.new(
       patient_session: @patient_session,
       consent: @consent,
+      vaccination_record: @draft_vaccination_record,
       route: "vaccinations",
     ) %>
 
@@ -83,12 +84,6 @@
           </div>
         <% end %>
       </dl>
-    </div>
-  </div>
-<% elsif @vaccination_record.nil? %>
-  <div class="nhsuk-card">
-    <div class="nhsuk-card__content">
-      <%= render "form", embedded: true %>
     </div>
   </div>
 <% end %>

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -16,5 +16,6 @@ RSpec.describe AppPatientPageComponent, type: :component do
     it { should have_css(".nhsuk-card", text: "Child details") }
     it { should have_css(".nhsuk-card", text: "Consent") }
     it { should have_css(".nhsuk-card", text: "Triage notes") }
+    it { should have_css(".nhsuk-card", text: "Did they get the HPV vaccine?") }
   end
 end

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe AppVaccinateFormComponent, type: :component do
+  let(:heading) { "A Heading" }
+  let(:body) { "A Body" }
+  let(:patient_session) { create :patient_session }
+  let(:vaccination_record) { VaccinationRecord.new }
+  let(:url) { "/vaccinate" }
+  let(:component) do
+    described_class.new(patient_session:, url:, vaccination_record:)
+  end
+  let(:rendered) { render_inline(component) }
+
+  subject { page }
+
+  before { rendered }
+
+  it { should have_css(".nhsuk-card") }
+
+  it "has the correct heading" do
+    should have_css(
+             "h2.nhsuk-card__heading",
+             text: "Did they get the HPV vaccine?"
+           )
+  end
+
+  it { should have_field("Yes, they got the HPV vaccine") }
+  it { should have_field("No, they did not get it") }
+end


### PR DESCRIPTION
This change doesn't change the journey much, aside from making the vaccination card visible on all the pages. This isn't ideal but I want to get this change in before we go down the rabbit-hole of adding session-awareness and other changes to stuff like the journey (hiding the delivery site on the patient page).