### PR TITLE
Conditionally render vaccination forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ You can run a rake task to load data from the example campaign file
 
 ```bash
 # Load the default example campaign, currently HPV:
-$ rails load_campaign_example
+$ rails load_campaign_example in_progress=1
 
 # Load the Flu campaign as an additional campaign:
-$ rails load_campaign_example[db/sample_data/example-flu-campaign.json] new_campaign=1
+$ rails load_campaign_example[db/sample_data/example-flu-campaign.json] new_campaign=1 in_progress=1
 ```
 
 The importer will `find_or_create` the records by default, using specific attributes to match records:

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -17,6 +17,10 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
 
+  def render?
+    @patient_session.ready_to_vaccinate? && session.in_progress?
+  end
+
   private
 
   def patient

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -16,11 +16,13 @@ class DevController < ApplicationController
       end
 
       LoadExampleCampaign.load(
-        example_file: "db/sample_data/example-hpv-campaign.json"
+        example_file: "db/sample_data/example-hpv-campaign.json",
+        in_progress: true
       )
       LoadExampleCampaign.load(
         example_file: "db/sample_data/example-flu-campaign.json",
-        new_campaign: true
+        new_campaign: true,
+        in_progress: true
       )
     end
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -49,4 +49,8 @@ class PatientSession < ApplicationRecord
     !unable_to_vaccinate? && !unable_to_vaccinate_not_assessed? &&
       !unable_to_vaccinate_not_gillick_competent?
   end
+
+  def ready_to_vaccinate?
+    consent_given_triage_not_needed? || triaged_ready_to_vaccinate?
+  end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -34,4 +34,8 @@ class Session < ApplicationRecord
     Rails.logger.warn "Deprecation warning: Session#title is deprecated. Use Session#name instead."
     name
   end
+
+  def in_progress?
+    date.to_date == Time.zone.today
+  end
 end

--- a/lib/example_campaign_data.rb
+++ b/lib/example_campaign_data.rb
@@ -7,6 +7,10 @@ class ExampleCampaignData
     @raw_data ||= JSON.parse(File.read(@data_file))
   end
 
+  def in_progress!
+    raw_data["date"] = Time.zone.today.to_s
+  end
+
   def vaccine_attributes
     raw_data["vaccines"].map do |vaccine|
       {

--- a/lib/load_example_campaign.rb
+++ b/lib/load_example_campaign.rb
@@ -1,8 +1,9 @@
 require "example_campaign_data"
 
 module LoadExampleCampaign
-  def self.load(example_file:, new_campaign: false)
+  def self.load(example_file:, new_campaign: false, in_progress: false)
     example = ExampleCampaignData.new(data_file: Rails.root.join(example_file))
+    example.in_progress! if in_progress
 
     ActiveRecord::Base.transaction do
       campaign =
@@ -27,6 +28,10 @@ module LoadExampleCampaign
       create_vaccine_health_questions(example, campaign:)
       create_children(example, campaign:, session:)
     end
+  end
+
+  def self.make_in_progress!(example)
+    example["date"] = Time.zone.today
   end
 
   def self.transition_states(patient_session)

--- a/lib/tasks/load_campaign_example.rake
+++ b/lib/tasks/load_campaign_example.rake
@@ -10,9 +10,16 @@ task :load_campaign_example,
             "1",
             "yes"
           ]
+  in_progress =
+    args.fetch(:in_progress) { ENV.fetch("in_progress", false) }.in? [
+            true,
+            "true",
+            "1",
+            "yes"
+          ]
 
   example_file =
     args.fetch(:example_file, "db/sample_data/example-hpv-campaign.json")
 
-  LoadExampleCampaign.load(example_file:, new_campaign:)
+  LoadExampleCampaign.load(example_file:, new_campaign:, in_progress:)
 end

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -1,8 +1,13 @@
 require "rails_helper"
 
 RSpec.describe AppPatientPageComponent, type: :component do
-  let(:triage) { [FactoryBot.create(:triage, notes: "Patient notes")] }
-  let(:patient_session) { FactoryBot.create(:patient_session, triage:) }
+  let(:patient_session) do
+    FactoryBot.create(
+      :patient_session,
+      :triaged_ready_to_vaccinate,
+      :session_in_progress
+    )
+  end
   let(:consent) { FactoryBot.create(:consent, patient_session:) }
   let(:component) do
     described_class.new(patient_session:, consent:, route: "triage")

--- a/spec/components/app_vaccinate_form_component_spec.rb
+++ b/spec/components/app_vaccinate_form_component_spec.rb
@@ -3,17 +3,18 @@ require "rails_helper"
 RSpec.describe AppVaccinateFormComponent, type: :component do
   let(:heading) { "A Heading" }
   let(:body) { "A Body" }
-  let(:patient_session) { create :patient_session }
+  let(:session) { create :session, :in_progress }
+  let(:patient_session) do
+    create :patient_session, :consent_given_triage_not_needed, session:
+  end
   let(:vaccination_record) { VaccinationRecord.new }
   let(:url) { "/vaccinate" }
   let(:component) do
     described_class.new(patient_session:, url:, vaccination_record:)
   end
-  let(:rendered) { render_inline(component) }
+  let!(:rendered) { render_inline(component) }
 
   subject { page }
-
-  before { rendered }
 
   it { should have_css(".nhsuk-card") }
 
@@ -26,4 +27,46 @@ RSpec.describe AppVaccinateFormComponent, type: :component do
 
   it { should have_field("Yes, they got the HPV vaccine") }
   it { should have_field("No, they did not get it") }
+
+  describe "render?" do
+    subject { component.render? }
+
+    context "patient is not ready for vaccination" do
+      before do
+        allow(patient_session).to receive(:ready_to_vaccinate?).and_return(
+          false
+        )
+      end
+
+      context "session is in progress" do
+        let(:session) { create :session, :in_progress }
+
+        it { should be_falsey }
+      end
+
+      context "session is in the future" do
+        let(:session) { create :session, :in_future }
+
+        it { should be_falsey }
+      end
+    end
+
+    context "patient is ready for vaccination" do
+      before do
+        allow(patient_session).to receive(:ready_to_vaccinate?).and_return(true)
+      end
+
+      context "session is progress" do
+        let(:session) { create :session, :in_progress }
+
+        it { should be_truthy }
+      end
+
+      context "session is in the future" do
+        let(:session) { create :session, :in_future }
+
+        it { should be_falsey }
+      end
+    end
+  end
 end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -44,7 +44,9 @@ FactoryBot.define do
     trait :triaged_ready_to_vaccinate do
       state { "triaged_ready_to_vaccinate" }
       patient { create :patient, :consent_given_triage_needed, session: }
-      triage { [create(:triage, status: :ready_to_vaccinate)] }
+      triage do
+        [create(:triage, status: :ready_to_vaccinate, notes: "Ok to vaccinate")]
+      end
     end
 
     trait :triaged_do_not_vaccinate do
@@ -84,6 +86,10 @@ FactoryBot.define do
       after :create do |patient_session|
         create :vaccination_record, administered: true, patient_session:
       end
+    end
+
+    trait :session_in_progress do
+      session { create :session, :in_progress }
     end
   end
 end

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -24,6 +24,18 @@ FactoryBot.define do
     date { Time.zone.today }
     name { "#{campaign.name} session at #{location.name}" }
 
+    trait :in_progress do
+      date { Time.zone.now }
+    end
+
+    trait :in_future do
+      date { Time.zone.now + 1.week }
+    end
+
+    trait :in_past do
+      date { Time.zone.now - 1.week }
+    end
+
     after :create do |session, context|
       create_list :patient, context.patients_in_session, sessions: [session]
     end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe PatientSession do
+  let(:patient_session_trait) { nil }
+  let(:patient_session) { create :patient_session, patient_session_trait }
+
+  describe "#ready_to_vaccinate?" do
+    subject { patient_session.ready_to_vaccinate? }
+
+    context "no consent response received yet" do
+      let(:patient_session_trait) { :added_to_session }
+
+      it { should be_falsey }
+    end
+
+    context "consent has been refused" do
+      let(:patient_session_trait) { :consent_refused }
+
+      it { should be_falsey }
+    end
+
+    context "consent has been given and triage is not needed" do
+      let(:patient_session_trait) { :consent_given_triage_not_needed }
+
+      it { should be_truthy }
+    end
+
+    context "consent has been given and triage is ready to vaccinate" do
+      let(:patient_session_trait) { :triaged_ready_to_vaccinate }
+
+      it { should be_truthy }
+    end
+
+    context "consent has been given and triage is do not vaccinate" do
+      let(:patient_session_trait) { :triaged_do_not_vaccinate }
+
+      it { should be_falsey }
+    end
+
+    context "patient was unable to be vaccinated" do
+      let(:patient_session_trait) { :unable_to_vaccinate }
+
+      it { should be_falsey }
+    end
+
+    context "patient has been vaccinated" do
+      let(:patient_session_trait) { :vaccinated }
+
+      it { should be_falsey }
+    end
+  end
+end

--- a/spec/models/session_spec.rb
+++ b/spec/models/session_spec.rb
@@ -1,0 +1,41 @@
+# == Schema Information
+#
+# Table name: sessions
+#
+#  id          :bigint           not null, primary key
+#  date        :datetime
+#  name        :text             not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  campaign_id :bigint           not null
+#  location_id :bigint
+#
+# Indexes
+#
+#  index_sessions_on_campaign_id  (campaign_id)
+#
+require "rails_helper"
+
+RSpec.describe Session do
+  describe "#in_progress?" do
+    subject { session.in_progress? }
+
+    context "when the session is scheduled for today" do
+      let(:session) { FactoryBot.create :session, :in_progress }
+
+      it { should be_truthy }
+    end
+
+    context "when the session is scheduled in the past" do
+      let(:session) { FactoryBot.create :session, :in_past }
+
+      it { should be_falsey }
+    end
+
+    context "when the session is scheduled in the future" do
+      let(:session) { FactoryBot.create :session, :in_future }
+
+      it { should be_falsey }
+    end
+  end
+end


### PR DESCRIPTION
The patient must be ready to vaccinate and the session must be in progress for the vaccination form to be shown.

This doesn't change the appearance of the vaccination form.