### PR TITLE
Dedupe reasons for refusal in patients table

### DIFF
--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -43,6 +43,7 @@ class AppPatientTableComponent < ViewComponent::Base
       patient_session
         .consents
         .map { |c| c.human_enum_name(:reason_for_refusal) }
+        .uniq
         .join("<br />")
         .html_safe
     end


### PR DESCRIPTION
We should only display one reason if there are multiple identical ones.