### PR TITLE
Make AppConsentComponent work with multiple consents 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.19)
-    benchmark (0.2.1)
+    benchmark (0.3.0)
     bigdecimal (3.1.4)
     bindex (0.8.1)
     bootsnap (1.17.0)
@@ -301,13 +301,13 @@ GEM
     irb (1.9.1)
       rdoc
       reline (>= 0.3.8)
-    jaro_winkler (1.5.4)
+    jaro_winkler (1.5.6)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jsbundling-rails (1.2.1)
       railties (>= 6.0.0)
-    json (2.6.3)
+    json (2.7.1)
     jsonb_accessor (1.4)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
@@ -374,7 +374,7 @@ GEM
     orm_adapter (0.5.0)
     pagy (6.2.0)
     parallel (1.23.0)
-    parser (3.2.2.3)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
@@ -446,7 +446,7 @@ GEM
     rbs (2.8.4)
     rdoc (6.6.0)
       psych (>= 4.0.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     reline (0.4.0)
       io-console (~> 0.5)
     request_store (1.5.1)
@@ -529,7 +529,7 @@ GEM
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
     silencer (2.0.0)
-    solargraph (0.49.0)
+    solargraph (0.50.0)
       backport (~> 1.2)
       benchmark
       bundler (~> 2.0)
@@ -563,7 +563,7 @@ GEM
       syntax_tree (>= 2.0.1)
     temple (0.10.0)
     thor (1.3.0)
-    tilt (2.1.0)
+    tilt (2.3.0)
     timecop (0.9.8)
     timeout (0.4.1)
     turbo-rails (1.5.0)
@@ -578,7 +578,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (2.4.2)
+    unicode-display_width (2.5.0)
     view_component (3.6.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -602,7 +602,7 @@ GEM
       railties (>= 3.0.7)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.32)
+    yard (0.9.34)
     zeitwerk (2.6.12)
 
 PLATFORMS

--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -5,23 +5,21 @@
     <%= render AppDetailsComponent.new(summary:, open: open_consents?) do %>
       <%= render AppConsentDetailsComponent.new(consents:) %>
 
-      <% if @consent.response_refused? %>
+      <% if consents.any?(&:response_refused?) %>
         <p><%= contact_parent_or_guardian_link %></p>
       <% end %>
     <% end %>
   <% end %>
 
-  <%=
-  if display_health_questions?
+  <%= if display_health_questions?
     render AppDetailsComponent.new(
       summary: "Responses to health questions",
       open: open_health_questions?,
       expander: true
     ) do
-      render AppHealthQuestionsComponent.new(consent: @consent)
+      render AppHealthQuestionsComponent.new(consents: @patient_session.consents)
     end
-  end
-  %>
+  end %>
 <% else %>
   <p class="app-status">
     No response yet

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -1,12 +1,10 @@
 class AppConsentComponent < ViewComponent::Base
-  attr_reader :patient_session, :consent
+  attr_reader :patient_session
 
   def initialize(patient_session:, route:)
     super
 
     @patient_session = patient_session
-    # HACK: This should use multiple consents
-    @consent = patient_session.consents.first
     @route = route
   end
 
@@ -14,7 +12,7 @@ class AppConsentComponent < ViewComponent::Base
   delegate :session, to: :patient_session
 
   def display_health_questions?
-    @consent&.response_given?
+    @patient_session.consents.any?(&:response_given?)
   end
 
   def open_health_questions?
@@ -22,7 +20,7 @@ class AppConsentComponent < ViewComponent::Base
   end
 
   def display_gillick_consent_button?
-    @consent.nil? && @patient_session.able_to_vaccinate?
+    @patient_session.consents.empty? && @patient_session.able_to_vaccinate?
   end
 
   def open_consents?

--- a/app/components/app_health_questions_component.rb
+++ b/app/components/app_health_questions_component.rb
@@ -1,8 +1,9 @@
 class AppHealthQuestionsComponent < ViewComponent::Base
-  def initialize(consent:)
+  def initialize(consents:)
     super
 
-    @consent = consent
+    # HACK: This needs to work with multiple consents
+    @consent = consents.first
   end
 
   def health_questions

--- a/app/components/app_patient_medical_history_card_component.html.erb
+++ b/app/components/app_patient_medical_history_card_component.html.erb
@@ -13,7 +13,7 @@
         </summary>
 
         <div class="nhsuk-details__text">
-          <%= render AppHealthQuestionsComponent.new(consent: @consent) %>
+          <%= render AppHealthQuestionsComponent.new(consents: [@consent]) %>
         </div>
       </details>
     <% end %>

--- a/app/components/app_patient_medical_history_card_component.rb
+++ b/app/components/app_patient_medical_history_card_component.rb
@@ -3,6 +3,7 @@ class AppPatientMedicalHistoryCardComponent < ViewComponent::Base
     super
 
     @patient = patient
+    # HACK: This needs to work with multiple consents
     @consent = consent
     @triage = triage
   end

--- a/app/views/nurse_consents/edit_confirm.html.erb
+++ b/app/views/nurse_consents/edit_confirm.html.erb
@@ -77,7 +77,7 @@
       </h2>
 
       <%= render AppHealthQuestionsComponent.new(
-        consent: @draft_consent) %>
+        consents: [@draft_consent]) %>
     </div>
   </div>
 <% end %>

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -32,11 +32,11 @@ RSpec.describe AppHealthQuestionsComponent, type: :component do
 
   let(:patient) { FactoryBot.create(:patient) }
   let(:session) { FactoryBot.create(:session) }
-  let(:consent) do
-    create :consent, patient:, campaign: session.campaign, health_questions:
+  let(:consents) do
+    [create(:consent, patient:, campaign: session.campaign, health_questions:)]
   end
 
-  let(:component) { described_class.new(consent:) }
+  let(:component) { described_class.new(consents:) }
 
   # Copy pasted from the consents factory
   health_questions.each_with_index do |health_question, i|


### PR DESCRIPTION
This updates the various calls to run on the array of consents instead of a singular consent.

Moves the `# HACK` comment deeper to the component stack, which will be addressed in a future commit/PR.

First commit is unrelated and came up from my editor.