### PR TITLE
Add AppTriageFormComponent

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -18,7 +18,7 @@ class AppConsentComponent < ViewComponent::Base
   end
 
   def open_health_questions?
-    @patient_session.consent_given_triage_needed?
+    @patient_session.next_step == :triage
   end
 
   def display_gillick_consent_button?

--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -14,6 +14,12 @@
   <%= render AppTriageNotesComponent.new(patient_session:) %>
 <% end %>
 
+<%=
+render AppTriageFormComponent.new(
+    patient_session:,
+    triage: @triage
+)
+%>
 
 <%=
 render AppVaccinateFormComponent.new(

--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -5,12 +5,13 @@ class AppPatientPageComponent < ViewComponent::Base
 
   attr_reader :patient_session
 
-  def initialize(patient_session:, route:, vaccination_record: nil)
+  def initialize(patient_session:, route:, triage: nil, vaccination_record: nil)
     super
 
     @patient_session = patient_session
-    @vaccination_record = vaccination_record || VaccinationRecord.new
     @route = route
+    @triage = triage || Triage.new
+    @vaccination_record = vaccination_record || VaccinationRecord.new
   end
 
   delegate :patient, to: :patient_session

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -1,0 +1,35 @@
+<%=
+form_with(
+    model: @triage,
+    url: @url,
+    class: "nhsuk-card",
+    builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f|
+%>
+  <div class="nhsuk-card__content">
+    <h2 class="nhsuk-card__heading nhsuk-heading-m">
+      Triage
+    </h2>
+    <% content_for(:before_content) { f.govuk_error_summary } %>
+
+    <%=
+    f.govuk_text_area(
+        :notes,
+        label: { text: 'Triage notes (optional)' },
+        rows: 5
+    )
+    %>
+
+    <%=
+    f.govuk_collection_radio_buttons(
+        :status,
+        triage_status_options,
+        :first,
+        :second,
+        legend: nil,
+    )
+    %>
+
+    <%= f.submit "Save triage", class: "nhsuk-button" %>
+  </div>
+<% end %>

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -13,6 +13,10 @@ class AppTriageFormComponent < ViewComponent::Base
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
 
+  def render?
+    @patient_session.next_step == :triage
+  end
+
   private
 
   def patient

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -1,0 +1,34 @@
+class AppTriageFormComponent < ViewComponent::Base
+  def initialize(patient_session:, triage:, url: nil)
+    super
+
+    @patient_session = patient_session
+    @triage = triage
+    @url = url
+  end
+
+  # rubocop:disable Naming/MemoizedInstanceVariableName
+  def before_render
+    @url ||=
+      session_patient_triage_path(
+                    session, patient, @triage
+                 )
+  end
+  # rubocop:enable Naming/MemoizedInstanceVariableName
+
+  private
+
+  def patient
+    @patient_session.patient
+  end
+
+  def session
+    @patient_session.session
+  end
+
+  def triage_status_options
+    Triage.statuses.keys.map do |status|
+      [status, Triage.human_enum_name(:status, status)]
+    end
+  end
+end

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -9,10 +9,7 @@ class AppTriageFormComponent < ViewComponent::Base
 
   # rubocop:disable Naming/MemoizedInstanceVariableName
   def before_render
-    @url ||=
-      session_patient_triage_path(
-                    session, patient, @triage
-                 )
+    @url ||= session_patient_triage_path(session, patient, @triage)
   end
   # rubocop:enable Naming/MemoizedInstanceVariableName
 

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -145,5 +145,9 @@ module PatientSessionStateMachineConcern
     def not_gillick_competent?
       !gillick_competent?
     end
+
+    def next_step
+      :triage if consent_given_triage_needed? || triaged_kept_in_triage?
+    end
   end
 end

--- a/app/views/triage/show.html.erb
+++ b/app/views/triage/show.html.erb
@@ -8,8 +8,5 @@
 <%= render AppPatientPageComponent.new(
       patient_session: @patient_session,
       route: "triage",
+      triage: @triage,
     ) %>
-
-<% if @consent&.response_given? %>
-  <%= render "patient_triage_card", session: @session, patient: @patient, triage: @triage %>
-<% end %>

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -1,23 +1,46 @@
 require "rails_helper"
 
 RSpec.describe AppPatientPageComponent, type: :component do
-  let(:patient_session) do
-    FactoryBot.create(
-      :patient_session,
-      :triaged_ready_to_vaccinate,
-      :session_in_progress
-    )
+  let(:component) do
+    described_class.new(patient_session:, route: "triage", triage:)
   end
-  let(:component) { described_class.new(patient_session:, route: "triage") }
+  let(:triage) { nil }
+  let!(:rendered) { render_inline(component) }
 
-  describe "rendering" do
-    before { render_inline(component) }
+  subject { page }
 
-    subject { page }
+  context "patient in triage" do
+    let(:patient_session) do
+      FactoryBot.create(
+        :patient_session,
+        :consent_given_triage_needed,
+        :session_in_progress
+      )
+    end
+    let(:triage) { FactoryBot.create(:triage, patient_session:) }
 
     it { should have_css(".nhsuk-card", text: "Child details") }
     it { should have_css(".nhsuk-card", text: "Consent") }
     it { should have_css(".nhsuk-card", text: "Triage notes") }
+    it { should have_css(".nhsuk-card", text: "Triage") }
+    it do
+      should_not have_css(".nhsuk-card", text: "Did they get the HPV vaccine?")
+    end
+  end
+
+  context "patient ready to vaccinate" do
+    let(:patient_session) do
+      FactoryBot.create(
+        :patient_session,
+        :triaged_ready_to_vaccinate,
+        :session_in_progress
+      )
+    end
+
+    it { should have_css(".nhsuk-card", text: "Child details") }
+    it { should have_css(".nhsuk-card", text: "Consent") }
+    it { should have_css(".nhsuk-card", text: "Triage notes") }
+    it { should_not have_css(".nhsuk-card", text: /^Triage$/) }
     it { should have_css(".nhsuk-card", text: "Did they get the HPV vaccine?") }
   end
 end

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -22,8 +22,7 @@ test("Triage", async ({ page }) => {
   await then_the_patient_should_be_in_ready_to_vaccinate();
 
   await when_i_click_on_a_patient();
-  await then_i_should_see_the_triage_details();
-  await and_i_should_see_triage_notes();
+  await then_i_should_see_triage_notes();
 
   // Triage - not ready to vaccinate
   await given_i_click_on_back();
@@ -37,8 +36,7 @@ test("Triage", async ({ page }) => {
   await then_i_should_see_the_other_patient();
 
   await when_i_click_on_the_other_patient();
-  await then_i_should_see_their_do_not_vaccinate_status();
-  await and_i_should_see_the_do_not_vaccinate_triage_notes();
+  await then_i_should_see_the_do_not_vaccinate_triage_notes();
 });
 
 async function given_the_app_is_setup() {
@@ -91,13 +89,7 @@ async function then_the_patient_should_be_in_ready_to_vaccinate() {
   ).toBeVisible();
 }
 
-async function then_i_should_see_the_triage_details() {
-  await expect(
-    p.getByRole("radio", { name: "Ready to vaccinate" }),
-  ).toBeChecked();
-}
-
-async function and_i_should_see_triage_notes() {
+async function then_i_should_see_triage_notes() {
   const today = new Date();
   // Partial test. We're going to avoid wrestling with DateTimeFormat to get
   // this 100% right, it's not useful for this test.
@@ -157,16 +149,7 @@ async function then_i_should_see_the_other_patient() {
   ).toBeVisible();
 }
 
-async function then_i_should_see_their_do_not_vaccinate_status() {
-  await expect(p.getByRole("textbox", { name: "Triage notes" })).toHaveValue(
-    "Father adament he does not want to vaccinate",
-  );
-  await expect(
-    p.getByRole("radio", { name: "Do not vaccinate" }),
-  ).toBeChecked();
-}
-
-async function and_i_should_see_the_do_not_vaccinate_triage_notes() {
+async function then_i_should_see_the_do_not_vaccinate_triage_notes() {
   const today = new Date();
   // Partial test. We're going to avoid wrestling with DateTimeFormat to get
   // this 100% right, it's not useful for this test.

--- a/tests/vaccination_refused_validations.spec.ts
+++ b/tests/vaccination_refused_validations.spec.ts
@@ -28,7 +28,7 @@ async function given_i_am_on_the_reason_vaccination_not_given_page_for_a_child()
     .getByRole("link", { name: fixtures.patientThatNeedsVaccination })
     .click();
 
-  await p.getByRole("radio", { name: "No" }).click();
+  await p.getByRole("radio", { name: /^No/ }).click();
   await p.getByRole("button", { name: "Continue" }).click();
 }
 


### PR DESCRIPTION
Move the triage form card rendering to the patient page.

This doesn't change the design, but it does add conditional rendering of the triage form. This adds a `next_step` to the state machine to bring this one bit of logic closer to the state machine.