### PR TITLE
Design snags (Part 2: Show patient name in page captions)

### DIFF
--- a/app/views/nurse_consents/assessing_gillick.html.erb
+++ b/app/views/nurse_consents/assessing_gillick.html.erb
@@ -5,7 +5,14 @@
   ) %>
 <% end %>
 
-<%= h1 "Assessing Gillick competence", class: "nhsuk-heading-l" %>
+<% page_title = "Assessing Gillick competence" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
 
 <p>Can the young person tell you:</p>
 

--- a/app/views/nurse_consents/edit_confirm.html.erb
+++ b/app/views/nurse_consents/edit_confirm.html.erb
@@ -9,7 +9,14 @@
   ) %>
 <% end %>
 
-<%= h1 "Check and confirm answers", class: "nhsuk-heading-l" %>
+<% page_title = "Check and confirm answers" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
 
 <% if @draft_consent.via_self_consent? %>
   <%= render AppGillickCardComponent.new(

--- a/app/views/nurse_consents/edit_consent.html.erb
+++ b/app/views/nurse_consents/edit_consent.html.erb
@@ -15,6 +15,8 @@
   method: :put do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_radio_buttons_fieldset(:consent,
+    caption: { size: 'l',
+               text: @patient.full_name },
     legend: { size: 'l',
               tag: 'h1',
               text: title }) do %>

--- a/app/views/nurse_consents/edit_gillick.html.erb
+++ b/app/views/nurse_consents/edit_gillick.html.erb
@@ -12,6 +12,8 @@
   method: :put do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_radio_buttons_fieldset(:gillick_competent,
+    caption: { size: 'l',
+               text: @patient.full_name },
     legend: { size: 'l',
               tag: 'h1',
               text: 'Are they Gillick competent?' }) do %>

--- a/app/views/nurse_consents/edit_questions.html.erb
+++ b/app/views/nurse_consents/edit_questions.html.erb
@@ -5,7 +5,14 @@
   ) %>
 <% end %>
 
-<%= h1 "Health questions", class: "nhsuk-heading-l" %>
+<% page_title = "Health questions" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
 
 <%= form_for @draft_consent,
   url: session_patient_nurse_consents_path(@session, @patient),

--- a/app/views/nurse_consents/edit_reason.html.erb
+++ b/app/views/nurse_consents/edit_reason.html.erb
@@ -12,6 +12,8 @@
   method: :put do |f| %>
   <%= f.govuk_error_summary %>
   <%= f.govuk_radio_buttons_fieldset(:reason_for_refusal,
+    caption: { size: 'l',
+               text: @patient.full_name },
     legend: { size: 'l',
               tag: 'h1',
               text: 'Why do they not agree?' }) do %>

--- a/app/views/nurse_consents/edit_who.html.erb
+++ b/app/views/nurse_consents/edit_who.html.erb
@@ -5,7 +5,14 @@
   ) %>
 <% end %>
 
-<%= h1 "Who are you trying to get consent from?", class: "nhsuk-heading-l" %>
+<% page_title = "Who are you trying to get consent from?" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
 
 <%= form_for @draft_consent,
   url: session_patient_nurse_consents_path(@session, @patient),

--- a/app/views/vaccinations/_form.html.erb
+++ b/app/views/vaccinations/_form.html.erb
@@ -7,6 +7,7 @@
   <% content_for(:before_content) { f.govuk_error_summary } %>
 
   <%= f.govuk_radio_buttons_fieldset(:administered,
+    caption: { text: @patient.full_name, size: 'l' },
     legend: { text: 'Did they get the vaccine?' }
       .merge(embedded ? { size: 'm' } : { size: 'l', tag: 'h1' })
   ) do %>

--- a/app/views/vaccinations/batches/edit.html.erb
+++ b/app/views/vaccinations/batches/edit.html.erb
@@ -14,6 +14,7 @@
    ),
  method: :put do |f| %>
   <%= f.govuk_radio_buttons_fieldset(:batch_id,
+    caption: { text: @patient.full_name, size: 'l' },
     legend: { size: 'l', tag: 'h1', text: 'Which batch did you use?' }) do %>
     <% @batches.each do |batch| %>
       <%= f.govuk_radio_button :batch_id,

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -12,7 +12,14 @@
   ) %>
 <% end %>
 
-<%= h1 "Check and confirm", class: "nhsuk-heading-l" %>
+<% page_title = "Check and confirm" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
 
 <div class="nhsuk-card">
   <div class="nhsuk-card__content">

--- a/app/views/vaccinations/delivery_site/edit.html.erb
+++ b/app/views/vaccinations/delivery_site/edit.html.erb
@@ -5,7 +5,14 @@
   ) %>
 <% end %>
 
-<%= h1 "Tell us how the vaccination was given", class: "nhsuk-heading-l" %>
+<% page_title = "Tell us how the vaccination was given" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
 
 <%= form_with model: @draft_vaccination_record,
    url: session_patient_vaccinations_delivery_site_path(

--- a/app/views/vaccinations/edit_reason.html.erb
+++ b/app/views/vaccinations/edit_reason.html.erb
@@ -15,6 +15,7 @@
               ),
               method: :put do |f| %>
     <%= f.govuk_radio_buttons_fieldset(:reason,
+      caption: { text: @patient.full_name, size: 'l' },
       legend: { size: 'l', tag: 'h1',
                 text: title }) do %>
 

--- a/app/views/vaccinations/history.html.erb
+++ b/app/views/vaccinations/history.html.erb
@@ -1,6 +1,13 @@
 <%= link_to "Back", session_patient_vaccinations_path(@session, @patient) %>
 
-<%= h1 "Vaccination record", class: "govuk-heading-l" %>
+<% page_title = "Vaccination record" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
 
 <% @history.each do |entry| %>
   <h3 class="nhsuk-heading-m">


### PR DESCRIPTION
Show patient name as page/form caption in consent and vaccination flows