### PR TITLE
Create multiple triage notes

### DIFF
--- a/app/components/app_patient_page_component.rb
+++ b/app/components/app_patient_page_component.rb
@@ -10,7 +10,7 @@ class AppPatientPageComponent < ViewComponent::Base
 
     @patient_session = patient_session
     @route = route
-    @triage = triage || Triage.new
+    @triage = triage
     @vaccination_record = vaccination_record || VaccinationRecord.new
   end
 

--- a/app/components/app_triage_form_component.html.erb
+++ b/app/components/app_triage_form_component.html.erb
@@ -1,11 +1,10 @@
-<%=
-form_with(
-    model: @triage,
-    url: @url,
-    class: "nhsuk-card",
-    builder: GOVUKDesignSystemFormBuilder::FormBuilder
-) do |f|
-%>
+<%= form_with(
+  model: @triage,
+  url: @url,
+  class: "nhsuk-card",
+  method: :post,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f| %>
   <div class="nhsuk-card__content">
     <h2 class="nhsuk-card__heading nhsuk-heading-m">
       Is it safe to vaccinate <%= patient.full_name %>?

--- a/app/components/app_triage_form_component.rb
+++ b/app/components/app_triage_form_component.rb
@@ -3,7 +3,13 @@ class AppTriageFormComponent < ViewComponent::Base
     super
 
     @patient_session = patient_session
-    @triage = triage
+    @triage =
+      triage ||
+        Triage.new.tap do |t|
+          if patient_session.triage.any?
+            t.status = patient_session.triage.order(:created_at).last.status
+          end
+        end
     @url = url
   end
 

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -2,7 +2,6 @@ class TriageController < ApplicationController
   before_action :set_session, only: %i[index show create update]
   before_action :set_patient, only: %i[show create update]
   before_action :set_patient_session, only: %i[create update show]
-  before_action :set_triage, only: %i[show]
   before_action :set_consent, only: %i[show create update]
   before_action :set_vaccination_record, only: %i[show]
 
@@ -98,10 +97,6 @@ class TriageController < ApplicationController
 
   def set_patient
     @patient = @session.patients.find_by(id: params[:patient_id])
-  end
-
-  def set_triage
-    @triage = Triage.find_or_initialize_by(patient_session: @patient_session)
   end
 
   def set_consent

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -10,7 +10,7 @@ class VaccinationsController < ApplicationController
 
   before_action :set_vaccination_record, only: %i[show confirm record]
   before_action :set_consent, only: %i[create show confirm update]
-  before_action :set_triage, only: %i[show confirm]
+  before_action :set_triage, only: %i[confirm]
   before_action :set_draft_consent, only: %i[show]
   before_action :set_todays_batch_id, only: :create
 

--- a/spec/components/app_triage_form_component_spec.rb
+++ b/spec/components/app_triage_form_component_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe AppTriageFormComponent, type: :component do
+  describe "#initialize" do
+    let(:patient_session) { create :patient_session }
+    let(:triage) { nil }
+    let(:url) { nil }
+    let(:component) { described_class.new(patient_session:, triage:, url:) }
+
+    subject { component }
+
+    it { should be_a described_class }
+
+    describe "triage instance variable" do
+      subject { component.instance_variable_get(:@triage) }
+
+      context "patient_session has no existing triage" do
+        it "creates a new Triage object" do
+          should be_a Triage
+        end
+      end
+
+      context "patient_session has existing triage" do
+        let(:old_triage) { create :triage, :kept_in_triage }
+        let(:patient_session) { create :patient_session, triage: [old_triage] }
+
+        it { should_not eq triage }
+        it { should be_needs_follow_up } # AKA kept_in_triage
+      end
+    end
+  end
+end

--- a/spec/factories/triage.rb
+++ b/spec/factories/triage.rb
@@ -26,5 +26,9 @@ FactoryBot.define do
     notes { nil }
     patient_session { create :patient_session }
     user { create :user }
+
+    trait :kept_in_triage do
+      status { "needs_follow_up" }
+    end
   end
 end

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -99,6 +99,16 @@ async function then_i_should_see_triage_notes() {
     year: "numeric",
   });
 
+  // Note 1
+  await expect(
+    p.locator("div.nhsuk-card", {
+      has: p.locator('h2:has-text("Triage notes")'),
+    }),
+  ).toHaveText(
+    new RegExp(`Unable to reach mother\\s*Nurse Joy, ${formattedDate}`),
+  );
+
+  // Note 2
   await expect(
     p.locator("div.nhsuk-card", {
       has: p.locator('h2:has-text("Triage notes")'),


### PR DESCRIPTION
Creates multiple triage notes by default now, populating the triage form with the status of the latest triage entry if available.

e.g. for a patient that has been kept in triage, the triage form on their page will now look like this by default:

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/a715fff6-9aff-4ae2-8a90-fdb09b267de4)

And saving the triage there will create new triage note that will be displayed in the "Triage notes" section.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/12b45a82-dd8e-4ed0-b022-a724ef49bf1a)
