### PR TITLE
Rename Needs triage tab to Triage needed

### DIFF
--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -15,7 +15,7 @@
 
 <%=
 govuk_tabs title: "Patient triage", classes: 'nhsuk-tabs' do |c|
-  c.with_tab(label: "Needs triage (#{ @partitioned_patient_sessions[:needs_triage].size })", classes: 'nhsuk-tabs__panel') do
+  c.with_tab(label: "Triage needed (#{ @partitioned_patient_sessions[:needs_triage].size })", classes: 'nhsuk-tabs__panel') do
     render "patients_with_triage_reasons", patient_sessions: @partitioned_patient_sessions[:needs_triage]
   end
   c.with_tab(label: "Triage completed (#{ @partitioned_patient_sessions[:triage_complete].size })", classes: 'nhsuk-tabs__panel') do

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -26,10 +26,10 @@ test("Triage", async ({ page }) => {
 
   // Triage - not ready to vaccinate
   await given_i_click_on_back();
-  await when_i_click_on_the_needs_triage_tab();
+  await when_i_click_on_the_triage_needed_tab();
   await and_i_click_on_another_patient();
   await and_i_enter_a_note_and_select_do_not_vaccinate();
-  await then_i_should_be_back_on_the_needs_triage_tab();
+  await then_i_should_be_back_on_the_triage_needed_tab();
   await and_i_should_not_see_the_other_patient();
 
   await when_i_click_on_the_triage_complete_tab();
@@ -124,8 +124,8 @@ async function given_i_click_on_back() {
   await p.click("text=Back");
 }
 
-async function when_i_click_on_the_needs_triage_tab() {
-  await p.getByRole("tab", { name: "Needs triage" }).click();
+async function when_i_click_on_the_triage_needed_tab() {
+  await p.getByRole("tab", { name: /Triage needed/ }).click();
 }
 
 async function when_i_click_on_the_other_patient() {
@@ -143,8 +143,8 @@ async function and_i_enter_a_note_and_select_do_not_vaccinate() {
   await p.getByRole("button", { name: "Save triage" }).click();
 }
 
-async function then_i_should_be_back_on_the_needs_triage_tab() {
-  await expect(p.getByRole("tab", { name: "Needs triage" })).toBeVisible();
+async function then_i_should_be_back_on_the_triage_needed_tab() {
+  await expect(p.getByRole("tab", { name: /Triage needed/ })).toBeVisible();
 }
 
 async function and_i_should_not_see_the_other_patient() {

--- a/tests/triage_authorisation.spec.ts
+++ b/tests/triage_authorisation.spec.ts
@@ -36,7 +36,7 @@ async function and_i_go_to_the_triage_page() {
 
 async function then_i_should_only_see_my_patients() {
   await expect(
-    p.locator("#needs-triage-4 .nhsuk-table__body .nhsuk-table__row"),
+    p.locator("#triage-needed-4 .nhsuk-table__body .nhsuk-table__row"),
   ).toHaveCount(4);
 }
 

--- a/tests/triage_validations.spec.ts
+++ b/tests/triage_validations.spec.ts
@@ -24,7 +24,7 @@ async function and_i_am_signed_in() {
 
 async function given_i_am_on_the_triage_page_for_a_child() {
   await p.goto("/sessions/1/triage");
-  await p.getByRole("tab", { name: "Needs triage" }).click();
+  await p.getByRole("tab", { name: /Triage needed/ }).click();
   await p.getByRole("link", { name: fixtures.patientThatNeedsTriage }).click();
 }
 


### PR DESCRIPTION
Follow the design from the prototype.

This is spun out from https://github.com/nhsuk/manage-childrens-vaccinations/pull/669.