### PR TITLE
Allow editing a consent

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -26,17 +26,14 @@
   </p>
 
   <p>
-    <%=
-    govuk_button_link_to(
+    <%= govuk_button_link_to(
       "Get consent",
       new_session_patient_nurse_consents_path(session, patient, @route),
       class: "nhsuk-u-margin-bottom-2"
-    )
-    %>
+    ) %>
 
     <% if display_gillick_consent_button? %>
-      <%=
-      govuk_button_link_to(
+      <%= govuk_button_link_to(
         "Assess Gillick competence",
         assessing_gillick_session_patient_nurse_consents_path(
           session,
@@ -44,8 +41,7 @@
           route: @route
         ),
         class: "nhsuk-button--secondary nhsuk-u-margin-bottom-2"
-      )
-      %>
+      ) %>
     <% end %>
   </p>
 <% end %>

--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -39,7 +39,12 @@ class AppConsentComponent < ViewComponent::Base
       consent.parent_relationship.in?(%w[mother father]) ? "parent" : "guardian"
     link_to(
       "Contact #{consent.parent_name} (the #{role} who refused)",
-      new_session_patient_nurse_consents_path(session, patient, @route),
+      edit_session_patient_nurse_consents_path(
+        session,
+        patient,
+        @route,
+        consent_id: consent.id
+      ),
       class: "nhsuk-u-font-weight-bold"
     )
   end

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -20,11 +20,19 @@ module PatientSessionStateMachineConcern
       state :vaccinated
 
       event :do_consent do
-        transitions from: :added_to_session,
+        transitions from: %i[
+                      added_to_session
+                      consent_refused
+                      consent_conflicts
+                    ],
                     to: :consent_given_triage_needed,
                     if: %i[consent_given? triage_needed?]
 
-        transitions from: :added_to_session,
+        transitions from: %i[
+                      added_to_session
+                      consent_refused
+                      consent_conflicts
+                    ],
                     to: :consent_given_triage_not_needed,
                     if: %i[consent_given? triage_not_needed?]
 

--- a/tests/nurse_consent_conflicting_consent.spec.ts
+++ b/tests/nurse_consent_conflicting_consent.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, Page } from "@playwright/test";
+import { signInTestUser, fixtures } from "./shared";
+
+let p: Page;
+
+test("Consent - conflicting", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+  await and_i_am_signed_in();
+
+  await given_i_am_checking_consent();
+  await when_i_select_a_child_with_conflicting_consent();
+  await then_i_see_the_patient_has_conflicting_consent();
+
+  await when_i_attempt_to_contact_the_parent_who_refused();
+  await then_i_see_the_consent_response_page();
+
+  await when_i_submit_a_consent_with_no_health_concerns();
+  await then_i_see_the_success_banner();
+
+  await when_i_select_the_same_patient();
+  await then_i_see_the_patient_has_consent_given();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function and_i_am_signed_in() {
+  await signInTestUser(p);
+}
+
+async function given_i_am_checking_consent() {
+  await p.goto("/sessions/1/consents");
+}
+
+async function when_i_select_a_child_with_conflicting_consent() {
+  await p.getByRole("tab", { name: "Consent conflicts" }).click();
+  await p
+    .getByRole("link", { name: fixtures.patientWithConflictingConsent })
+    .click();
+}
+
+async function then_i_see_the_patient_has_conflicting_consent() {
+  await expect(
+    p.getByRole("heading", { name: "Conflicting consent" }),
+  ).toBeVisible();
+}
+
+async function when_i_attempt_to_contact_the_parent_who_refused() {
+  await p
+    .getByRole("link", { name: /Contact.*the parent who refused/ })
+    .click();
+}
+
+async function then_i_see_the_consent_response_page() {
+  await expect(p.getByRole("heading", { name: "Do they agree" })).toBeVisible();
+}
+
+async function when_i_submit_a_consent_with_no_health_concerns() {
+  // Consent
+  await p.getByRole("radio", { name: "Yes, they agree" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+
+  // Health questions
+  const radio = (n: number) =>
+    `input[name="consent[question_${n}][response]"][value="no"]`;
+
+  await p.click(radio(0));
+  await p.click(radio(1));
+  await p.click(radio(2));
+  await p.getByRole("radio", { name: "Yes, it's safe to vaccinate" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+
+  // Check answers page
+  await p.getByRole("button", { name: "Confirm" }).click();
+}
+
+async function then_i_see_the_success_banner() {
+  await expect(p.getByRole("heading", { name: "Success" })).toBeVisible();
+}
+
+async function when_i_select_the_same_patient() {
+  await p
+    .getByRole("link", { name: fixtures.patientWithConflictingConsent })
+    .click();
+}
+
+async function then_i_see_the_patient_has_consent_given() {
+  await expect(
+    p.getByRole("heading", { name: "Safe to vaccinate" }),
+  ).toBeVisible();
+}

--- a/tests/shared/index.ts
+++ b/tests/shared/index.ts
@@ -10,6 +10,9 @@ export const fixtures = {
   patientThatNeedsConsent: "Jose Pacocha",
   secondPatientThatNeedsConsent: "Silvia Waters",
 
+  // Get from /sessions/1/consents, "Consent conflicts" tab
+  patientWithConflictingConsent: "Corrinne Hahn",
+
   // Get from /sessions/1/triage, "Triage needed" tab
   patientThatNeedsTriage: "Michale Fisher",
   secondPatientThatNeedsTriage: "Shenika Hammes",


### PR DESCRIPTION
Allow nurses to contact a parent and edit their consent if they accept on the phone.

- [x] Separate PR: Correctly fetch HPV health questions from DB instead of legacy hardcoded ones
- [x] Make it work with patients with multiple consents (correctly find the right consent)
- [x] Add test coverage

Stretch:

- [ ] Persist the previous refusal / history