### PR TITLE
Use health_questions from db when creating consent

### DIFF
--- a/app/controllers/nurse_consents_controller.rb
+++ b/app/controllers/nurse_consents_controller.rb
@@ -16,7 +16,9 @@ class NurseConsentsController < ApplicationController
 
   def create
     health_questions =
-      Consent::HEALTH_QUESTIONS.fetch(:hpv).map { |question| { question: } }
+      @session.health_questions.in_order.map do |health_question|
+        { question: health_question.question }
+      end
 
     if consent_who_params.present?
       @draft_consent.assign_attributes(
@@ -259,8 +261,7 @@ class NurseConsentsController < ApplicationController
     params.fetch(:consent, {}).permit(
       question_0: %i[notes response],
       question_1: %i[notes response],
-      question_2: %i[notes response],
-      question_3: %i[notes response]
+      question_2: %i[notes response]
     )
   end
 

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -96,22 +96,6 @@ class Consent < ApplicationRecord
             if: -> { reason_for_refusal == "other" },
             on: :edit_reason
 
-  HEALTH_QUESTIONS = {
-    flu: [
-      "Does the child have a disease or treatment that severely affects their immune system?",
-      "Is anyone in your household having treatment that severely affects their immune system?",
-      "Has your child been diagnosed with asthma?",
-      "Has your child been admitted to intensive care because of a severe egg allergy?",
-      "Is there anything else we should know?"
-    ],
-    hpv: [
-      "Does the child have any severe allergies that have led to an anaphylactic reaction?",
-      "Does the child have any existing medical conditions?",
-      "Does the child take any regular medication?",
-      "Is there anything else we should know?"
-    ]
-  }.freeze
-
   def triage_needed?
     response_given? &&
       (parent_relationship_other? || health_questions_require_follow_up?)

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -26,6 +26,10 @@ class Session < ApplicationRecord
   validates :name, presence: true
   validates :date, presence: true
 
+  def health_questions
+    campaign.vaccines.first.health_questions
+  end
+
   def type
     campaign.name
   end

--- a/db/sample_data/example-flu-campaign.json
+++ b/db/sample_data/example-flu-campaign.json
@@ -20,15 +20,15 @@
       "batches": [
         {
           "name": "MO7714",
-          "expiry": "2024-03-08"
+          "expiry": "2024-03-14"
         },
         {
           "name": "RT0255",
-          "expiry": "2024-05-10"
+          "expiry": "2024-05-16"
         },
         {
           "name": "OZ0009",
-          "expiry": "2024-04-27"
+          "expiry": "2024-05-03"
         }
       ]
     }
@@ -108,7 +108,7 @@
     {
       "firstName": "Brittany",
       "lastName": "Klocko",
-      "dob": "2015-10-30",
+      "dob": "2015-11-05",
       "nhsNumber": 4656828688,
       "consents": [
         {
@@ -121,23 +121,43 @@
           "parentPhone": "07368 092638",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have a disease or treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
-              "question": "Is anyone in your household having treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
               "question": "Has your child been diagnosed with asthma?",
               "response": "no"
             },
             {
-              "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+              "question": "Have they taken oral steroids in the last 2 weeks?",
               "response": "no"
             },
             {
-              "question": "Is there anything else we should know?",
+              "question": "Have they been admitted to intensive care for their asthma?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child had a flu vaccination in the last 5 months?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have a disease or treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have any allergies to medication?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever had a reaction to previous vaccinations?",
+              "response": "no"
+            },
+            {
+              "question": "Does you child take regular aspirin?",
               "response": "no"
             }
           ],
@@ -153,23 +173,43 @@
           "parentPhone": "07830 242049",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have a disease or treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
-              "question": "Is anyone in your household having treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
               "question": "Has your child been diagnosed with asthma?",
               "response": "no"
             },
             {
-              "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+              "question": "Have they taken oral steroids in the last 2 weeks?",
               "response": "no"
             },
             {
-              "question": "Is there anything else we should know?",
+              "question": "Have they been admitted to intensive care for their asthma?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child had a flu vaccination in the last 5 months?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have a disease or treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have any allergies to medication?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever had a reaction to previous vaccinations?",
+              "response": "no"
+            },
+            {
+              "question": "Does you child take regular aspirin?",
               "response": "no"
             }
           ],
@@ -185,23 +225,43 @@
           "parentPhone": "056 8254 1751",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have a disease or treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
-              "question": "Is anyone in your household having treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
               "question": "Has your child been diagnosed with asthma?",
               "response": "no"
             },
             {
-              "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+              "question": "Have they taken oral steroids in the last 2 weeks?",
               "response": "no"
             },
             {
-              "question": "Is there anything else we should know?",
+              "question": "Have they been admitted to intensive care for their asthma?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child had a flu vaccination in the last 5 months?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have a disease or treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have any allergies to medication?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever had a reaction to previous vaccinations?",
+              "response": "no"
+            },
+            {
+              "question": "Does you child take regular aspirin?",
               "response": "no"
             }
           ],
@@ -219,7 +279,7 @@
     {
       "firstName": "Sebastian",
       "lastName": "Farrell",
-      "dob": "2018-08-28",
+      "dob": "2018-09-03",
       "nhsNumber": 4617774696,
       "consents": [
         {
@@ -232,23 +292,43 @@
           "parentPhone": "0878 600 8838",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have a disease or treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
-              "question": "Is anyone in your household having treatment that severely affects their immune system?",
-              "response": "no"
-            },
-            {
               "question": "Has your child been diagnosed with asthma?",
               "response": "no"
             },
             {
-              "question": "Has your child been admitted to intensive care because of a severe egg allergy?",
+              "question": "Have they taken oral steroids in the last 2 weeks?",
               "response": "no"
             },
             {
-              "question": "Is there anything else we should know?",
+              "question": "Have they been admitted to intensive care for their asthma?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child had a flu vaccination in the last 5 months?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have a disease or treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Is anyone in your household currently having treatment that severely affects their immune system?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever been admitted to intensive care due to an allergic reaction to egg?",
+              "response": "no"
+            },
+            {
+              "question": "Does your child have any allergies to medication?",
+              "response": "no"
+            },
+            {
+              "question": "Has your child ever had a reaction to previous vaccinations?",
+              "response": "no"
+            },
+            {
+              "question": "Does you child take regular aspirin?",
               "response": "no"
             }
           ],
@@ -266,7 +346,7 @@
     {
       "firstName": "Verlie",
       "lastName": "Gorczany",
-      "dob": "2019-04-11",
+      "dob": "2019-04-17",
       "nhsNumber": 4154210416,
       "consents": [
 
@@ -282,7 +362,7 @@
     {
       "firstName": "Clora",
       "lastName": "Mueller",
-      "dob": "2015-06-19",
+      "dob": "2015-06-25",
       "nhsNumber": 4788269341,
       "consents": [
 
@@ -298,7 +378,7 @@
     {
       "firstName": "Morgan",
       "lastName": "Treutel",
-      "dob": "2019-06-24",
+      "dob": "2019-06-30",
       "nhsNumber": 4211140043,
       "consents": [
         {
@@ -326,7 +406,7 @@
     {
       "firstName": "Mckinley",
       "lastName": "Steuber",
-      "dob": "2019-02-08",
+      "dob": "2019-02-14",
       "nhsNumber": 4845045486,
       "consents": [
         {
@@ -354,7 +434,7 @@
     {
       "firstName": "Cary",
       "lastName": "Paucek",
-      "dob": "2020-02-11",
+      "dob": "2020-02-17",
       "nhsNumber": 4189923842,
       "consents": [
         {
@@ -441,7 +521,7 @@
     {
       "firstName": "Jeromy",
       "lastName": "Macejkovic",
-      "dob": "2019-04-17",
+      "dob": "2019-04-23",
       "nhsNumber": 4433815748,
       "consents": [
         {
@@ -528,7 +608,7 @@
     {
       "firstName": "Gabriel",
       "lastName": "Kemmer",
-      "dob": "2016-06-06",
+      "dob": "2016-06-12",
       "nhsNumber": 4017480152,
       "consents": [
         {
@@ -619,7 +699,7 @@
     {
       "firstName": "Cinda",
       "lastName": "McGlynn",
-      "dob": "2016-10-09",
+      "dob": "2016-10-15",
       "nhsNumber": 4231514186,
       "consents": [
         {
@@ -710,7 +790,7 @@
     {
       "firstName": "John",
       "lastName": "Grady",
-      "dob": "2018-04-25",
+      "dob": "2018-05-01",
       "nhsNumber": 4359409214,
       "consents": [
         {
@@ -801,7 +881,7 @@
     {
       "firstName": "Alysha",
       "lastName": "Cartwright",
-      "dob": "2016-10-18",
+      "dob": "2016-10-24",
       "nhsNumber": 4385039321,
       "consents": [
         {

--- a/db/sample_data/example-hpv-campaign.json
+++ b/db/sample_data/example-hpv-campaign.json
@@ -20,15 +20,15 @@
       "batches": [
         {
           "name": "QM4000",
-          "expiry": "2024-03-03"
+          "expiry": "2024-03-09"
         },
         {
           "name": "UP2000",
-          "expiry": "2024-05-10"
+          "expiry": "2024-05-16"
         },
         {
           "name": "EG1460",
-          "expiry": "2024-03-25"
+          "expiry": "2024-03-31"
         }
       ]
     }
@@ -69,7 +69,7 @@
     {
       "firstName": "Brittany",
       "lastName": "Klocko",
-      "dob": "2011-10-30",
+      "dob": "2011-11-05",
       "nhsNumber": 4656828688,
       "consents": [
         {
@@ -82,19 +82,15 @@
           "parentPhone": "07368 092638",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
+              "question": "Does your child have any severe allergies?",
               "response": "no"
             },
             {
-              "question": "Does the child have any existing medical conditions?",
+              "question": "Does your child have any medical conditions for which they receive treatment?",
               "response": "no"
             },
             {
-              "question": "Does the child take any regular medication?",
-              "response": "no"
-            },
-            {
-              "question": "Is there anything else we should know?",
+              "question": "Has your child ever had a severe reaction to any medicines, including vaccines?",
               "response": "no"
             }
           ],
@@ -110,19 +106,15 @@
           "parentPhone": "07830 242049",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
+              "question": "Does your child have any severe allergies?",
               "response": "no"
             },
             {
-              "question": "Does the child have any existing medical conditions?",
+              "question": "Does your child have any medical conditions for which they receive treatment?",
               "response": "no"
             },
             {
-              "question": "Does the child take any regular medication?",
-              "response": "no"
-            },
-            {
-              "question": "Is there anything else we should know?",
+              "question": "Has your child ever had a severe reaction to any medicines, including vaccines?",
               "response": "no"
             }
           ],
@@ -138,19 +130,15 @@
           "parentPhone": "056 8254 1751",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
+              "question": "Does your child have any severe allergies?",
               "response": "no"
             },
             {
-              "question": "Does the child have any existing medical conditions?",
+              "question": "Does your child have any medical conditions for which they receive treatment?",
               "response": "no"
             },
             {
-              "question": "Does the child take any regular medication?",
-              "response": "no"
-            },
-            {
-              "question": "Is there anything else we should know?",
+              "question": "Has your child ever had a severe reaction to any medicines, including vaccines?",
               "response": "no"
             }
           ],
@@ -168,7 +156,7 @@
     {
       "firstName": "Sebastian",
       "lastName": "Farrell",
-      "dob": "2011-01-16",
+      "dob": "2011-01-22",
       "nhsNumber": 4617774696,
       "consents": [
         {
@@ -181,19 +169,15 @@
           "parentPhone": "0878 600 8838",
           "healthQuestionResponses": [
             {
-              "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
+              "question": "Does your child have any severe allergies?",
               "response": "no"
             },
             {
-              "question": "Does the child have any existing medical conditions?",
+              "question": "Does your child have any medical conditions for which they receive treatment?",
               "response": "no"
             },
             {
-              "question": "Does the child take any regular medication?",
-              "response": "no"
-            },
-            {
-              "question": "Is there anything else we should know?",
+              "question": "Has your child ever had a severe reaction to any medicines, including vaccines?",
               "response": "no"
             }
           ],
@@ -211,7 +195,7 @@
     {
       "firstName": "Verlie",
       "lastName": "Gorczany",
-      "dob": "2011-07-11",
+      "dob": "2011-07-17",
       "nhsNumber": 4154210416,
       "consents": [
 
@@ -227,7 +211,7 @@
     {
       "firstName": "Davis",
       "lastName": "Pfeffer",
-      "dob": "2011-03-11",
+      "dob": "2011-03-17",
       "nhsNumber": 4499058678,
       "consents": [
 
@@ -243,7 +227,7 @@
     {
       "firstName": "Morgan",
       "lastName": "Treutel",
-      "dob": "2011-04-10",
+      "dob": "2011-04-16",
       "nhsNumber": 4211140043,
       "consents": [
         {
@@ -271,7 +255,7 @@
     {
       "firstName": "Mckinley",
       "lastName": "Steuber",
-      "dob": "2011-04-17",
+      "dob": "2011-04-23",
       "nhsNumber": 4845045486,
       "consents": [
         {
@@ -312,7 +296,7 @@
     {
       "firstName": "Loris",
       "lastName": "Effertz",
-      "dob": "2011-08-24",
+      "dob": "2011-08-30",
       "nhsNumber": 4010796014,
       "consents": [
         {
@@ -359,7 +343,7 @@
     {
       "firstName": "Rodrigo",
       "lastName": "Davis",
-      "dob": "2011-06-06",
+      "dob": "2011-06-12",
       "nhsNumber": 4573381031,
       "consents": [
         {
@@ -406,7 +390,7 @@
     {
       "firstName": "Romaine",
       "lastName": "Schumm",
-      "dob": "2011-08-13",
+      "dob": "2011-08-19",
       "nhsNumber": 4356101561,
       "consents": [
         {
@@ -457,7 +441,7 @@
     {
       "firstName": "Bettina",
       "lastName": "Weissnat",
-      "dob": "2011-07-24",
+      "dob": "2011-07-30",
       "nhsNumber": 4599468649,
       "consents": [
         {
@@ -508,7 +492,7 @@
     {
       "firstName": "Gustavo",
       "lastName": "Hackett",
-      "dob": "2011-10-26",
+      "dob": "2011-11-01",
       "nhsNumber": 4807686488,
       "consents": [
         {
@@ -559,7 +543,7 @@
     {
       "firstName": "Fonda",
       "lastName": "Krajcik",
-      "dob": "2011-09-01",
+      "dob": "2011-09-07",
       "nhsNumber": 4109868696,
       "consents": [
         {

--- a/lib/example_campaign_generator.rb
+++ b/lib/example_campaign_generator.rb
@@ -154,7 +154,6 @@ class ExampleCampaignGenerator
 
   def build_consent(*options, **attrs)
     patient = attrs.fetch(:patient)
-    options << @type
     unless (%i[from_mum from_dad from_granddad] & options).any?
       options << if patient.parent_relationship == "mother"
         :from_mum
@@ -163,12 +162,17 @@ class ExampleCampaignGenerator
       end
     end
 
-    FactoryBot.build(:consent, *options, random:, campaign: nil, **attrs)
+    FactoryBot.build(
+      :consent,
+      *options,
+      random:,
+      campaign: nil,
+      health_questions_list: health_questions_data.map { |hq| hq[:question] },
+      **attrs
+    )
   end
 
   def build_dual_consents(*options, **attrs)
-    options << @type
-
     [
       build_consent(:from_mum, *options, **attrs),
       build_consent(:from_dad, *options, **attrs)
@@ -176,8 +180,6 @@ class ExampleCampaignGenerator
   end
 
   def build_triple_consents(*options, **attrs)
-    options << @type
-
     [
       build_consent(:from_mum, *options, **attrs),
       build_consent(:from_dad, *options, **attrs),

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
   factory :consent do
     transient do
       random { Random.new }
-      health_questions_list { Consent::HEALTH_QUESTIONS.fetch(:flu) }
+      health_questions_list { ["Is there anything else we should know?"] }
       # Allow caller to provide patient_session as a shortcut to produce
       # patient and campaign
       patient_session { nil }
@@ -136,18 +136,6 @@ FactoryBot.define do
     trait :from_granddad do
       parent_relationship { "other" }
       parent_relationship_other { "Granddad" }
-    end
-
-    trait :flu do
-      transient do
-        health_questions_list { Consent::HEALTH_QUESTIONS.fetch(:flu) }
-      end
-    end
-
-    trait :hpv do
-      transient do
-        health_questions_list { Consent::HEALTH_QUESTIONS.fetch(:hpv) }
-      end
     end
 
     trait :health_question_notes do

--- a/spec/lib/example_campaign_generator_spec.rb
+++ b/spec/lib/example_campaign_generator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ExampleCampaignGenerator do
     #       presets=default \
     #       type=hpv \
     #       username="Nurse Joy" > db/sample_data/example-hpv-campaign.json
-    Timecop.freeze(2023, 12, 4, 12, 0, 0) do
+    Timecop.freeze(2023, 12, 10, 12, 0, 0) do
       generator =
         ExampleCampaignGenerator.new(
           seed: 42,
@@ -61,7 +61,7 @@ RSpec.describe ExampleCampaignGenerator do
     #       presets=default \
     #       type=flu \
     #       username="Nurse Jackie" > db/sample_data/example-flu-campaign.json
-    Timecop.freeze(2023, 12, 4, 12, 0, 0) do
+    Timecop.freeze(2023, 12, 10, 12, 0, 0) do
       generator =
         ExampleCampaignGenerator.new(
           seed: 42,

--- a/tests/full_journey.spec.ts
+++ b/tests/full_journey.spec.ts
@@ -67,7 +67,6 @@ async function and_i_record_the_triage_details() {
   await p.click(radio(0));
   await p.click(radio(1));
   await p.click(radio(2));
-  await p.click(radio(3));
   await p.fill('[name="consent[triage][notes]"]', "Some notes");
   await p.getByRole("radio", { name: "Yes, it's safe to vaccinate" }).click();
   await p.getByRole("button", { name: "Continue" }).click();

--- a/tests/nurse_consent_during_vaccination.spec.ts
+++ b/tests/nurse_consent_during_vaccination.spec.ts
@@ -72,7 +72,6 @@ async function when_i_go_through_the_consent_and_triage_forms() {
   await p.click(radio(0));
   await p.click(radio(1));
   await p.click(radio(2));
-  await p.click(radio(3));
 
   // Triage
   await p.click("text=Yes, it's safe to vaccinate");

--- a/tests/nurse_consent_gillick.spec.ts
+++ b/tests/nurse_consent_gillick.spec.ts
@@ -121,7 +121,6 @@ async function when_i_answer_the_health_questions() {
   await p.click(radio(0));
   await p.click(radio(1));
   await p.click(radio(2));
-  await p.click(radio(3));
 }
 
 async function then_i_see_the_check_answers_page() {

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -86,7 +86,6 @@ async function when_i_submit_a_consent_with_a_response() {
   await p.click(radio(0));
   await p.click(radio(1));
   await p.click(radio(2));
-  await p.click(radio(3));
 
   // Triage
   await p.fill('[name="consent[triage][notes]"]', "Some notes");


### PR DESCRIPTION
This only works with campaigns that have one vaccine.

TODO:

- [x] Replace `Consent::HEALTH_QUESTIONS.fetch(:flu)` calls in Consent factory
- [x] Remove HEALTH_QUESTIONS array from Consent model