### PR TITLE
Update vaccination site values and labels

### DIFF
--- a/app/components/app_vaccinate_form_component.html.erb
+++ b/app/components/app_vaccinate_form_component.html.erb
@@ -21,20 +21,17 @@ form_with(
         link_errors: true
       ) do
       %>
-        <%=
-        f.govuk_collection_radio_buttons(
+        <%= f.govuk_collection_radio_buttons(
           :delivery_site,
           vaccination_initial_delivery_sites,
-          :to_s,
-          :humanize,
-          inline: true,
+          :value,
+          :label,
           legend: {
             text: 'Where did they get it?',
             hidden: true
           },
           bold_labels: false
-        )
-        %>
+        ) %>
       <% end %>
       <%=
       f.govuk_radio_button(

--- a/app/components/app_vaccinate_form_component.rb
+++ b/app/components/app_vaccinate_form_component.rb
@@ -36,6 +36,17 @@ class AppVaccinateFormComponent < ViewComponent::Base
   end
 
   def vaccination_initial_delivery_sites
-    %w[left_arm right_arm other]
+    sites = "activerecord.attributes.vaccination_record.delivery_sites"
+    [
+      OpenStruct.new(
+        value: "left_arm_upper_position",
+        label: t("#{sites}.left_arm_upper_position")
+      ),
+      OpenStruct.new(
+        value: "right_arm_upper_position",
+        label: t("#{sites}.right_arm_upper_position")
+      ),
+      OpenStruct.new(value: "other", label: "Other")
+    ]
   end
 end


### PR DESCRIPTION
Use `(upper position)` for the left and right arm sites.

![Screenshot 2023-12-09 at 15 43 31](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/7c290a12-f6a6-48c9-a372-016ef4b0761b)
