### PR TITLE
Fix notification banner

### DIFF
--- a/app/components/app_flash_message_component.html.erb
+++ b/app/components/app_flash_message_component.html.erb
@@ -6,6 +6,6 @@
 ) do |notification_banner| %>
   <% notification_banner.with_heading(text: heading) if heading.present? %>
   <% if body.present? %>
-    <p class="nhsuk-body"><%= body.html_safe %></p>
+    <p><%= body.html_safe %></p>
   <% end %>
 <% end %>

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -22,10 +22,10 @@ application.register("govuk-details", GovukDetailsController);
 import GovukHeaderController from "./govuk_header_controller";
 application.register("govuk-header", GovukHeaderController);
 
-import GovukNotificationBannerController from "./govuk_notification_banner_controller";
+import NhsukNotificationBannerController from "./nhsuk_notification_banner_controller";
 application.register(
-  "govuk-notification-banner",
-  GovukNotificationBannerController,
+  "nhsuk-notification-banner",
+  NhsukNotificationBannerController,
 );
 
 import GovukSkipLinkController from "./govuk_skip_link_controller";

--- a/app/javascript/controllers/nhsuk_notification_banner_controller.ts
+++ b/app/javascript/controllers/nhsuk_notification_banner_controller.ts
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { NotificationBanner } from "govuk-frontend";
 
-// Connects to data-module="govuk-notification-banner"
+// Connects to data-module="nhsuk-notification-banner"
 export default class extends Controller {
   connect() {
     new NotificationBanner(this.element).init();

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -1,6 +1,6 @@
 <% page_title = "Record vaccinations" %>
 
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
+<%= render(AppFlashMessageComponent.new(flash:)) %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [

--- a/spec/components/app_flash_message_component_spec.rb
+++ b/spec/components/app_flash_message_component_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe AppFlashMessageComponent, type: :component do
       )
     end
 
-    it { should have_css("p", text: "You win!", class: "nhsuk-body") }
+    it { should have_css("p", text: "You win!") }
   end
 
   context "when a hash is provided" do


### PR DESCRIPTION
Change the classnames and module to `nhsuk-notification-banner` across the board. This uses the `govuk-notification-banner` JS, which is a total hack, but it seems to work.

![Screenshot 2023-12-09 at 17 01 08](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/575951fc-2a34-40ea-aad6-cf43022dac7a)
