### PR TITLE
Return to consent responses page in consent and vaccination flows

### DIFF
--- a/app/controllers/nurse_consents_controller.rb
+++ b/app/controllers/nurse_consents_controller.rb
@@ -162,7 +162,14 @@ class NurseConsentsController < ApplicationController
                     }
                   }
     else
-      redirect_to triage_session_path(@session),
+      redirect_path =
+        case params[:route]
+        when "triage"
+          triage_session_path(@session)
+        else
+          consents_session_path(@session)
+        end
+      redirect_to redirect_path,
                   flash: {
                     success: {
                       heading: "Consent saved for #{@patient.full_name}",

--- a/app/controllers/nurse_consents_controller.rb
+++ b/app/controllers/nurse_consents_controller.rb
@@ -166,9 +166,12 @@ class NurseConsentsController < ApplicationController
         case params[:route]
         when "triage"
           triage_session_path(@session)
+        when "vaccinations"
+          vaccinations_session_path(@session)
         else
           consents_session_path(@session)
         end
+
       redirect_to redirect_path,
                   flash: {
                     success: {

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -1,3 +1,5 @@
+<%= render(AppFlashMessageComponent.new(flash: flash)) %>
+
 <% page_title = "Check consent responses" %>
 
 <% content_for :before_main do %>

--- a/app/views/consents/show.html.erb
+++ b/app/views/consents/show.html.erb
@@ -7,5 +7,5 @@
 
 <%= render AppPatientPageComponent.new(
       patient_session: @patient_session,
-      route: "triage",
+      route: "consents",
     ) %>

--- a/tests/full_journey.spec.ts
+++ b/tests/full_journey.spec.ts
@@ -15,7 +15,7 @@ test("Full journey - consent obtained before session", async ({ page }) => {
   await given_i_call_the_parent_and_receive_consent();
   await when_i_record_the_consent_given();
   await and_i_record_the_triage_details();
-  await then_i_see_that_the_child_is_ready_to_vaccinate();
+  await then_i_see_that_the_child_has_gotten_consent();
 
   await given_i_am_performing_the_vaccination();
   await when_i_record_the_successful_vaccination();
@@ -75,11 +75,10 @@ async function and_i_record_the_triage_details() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
-async function then_i_see_that_the_child_is_ready_to_vaccinate() {
+async function then_i_see_that_the_child_has_gotten_consent() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
     `Consent saved for ${fixtures.patientThatNeedsConsent}`,
   );
-  await p.getByRole("tab", { name: "Triage completed" }).click();
   const row = p.locator(`tr`, { hasText: fixtures.patientThatNeedsConsent });
   await expect(row).toBeVisible();
 }

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -14,7 +14,7 @@ test("Consent - No response", async ({ page }) => {
 
   // Consent - No response
   await when_i_submit_a_consent_with_no_response();
-  await then_i_see_the_triage_list();
+  await then_i_see_the_consent_responses_page();
 
   await when_i_select_a_child_with_no_consent_response();
   await and_i_click_get_consent();
@@ -22,9 +22,10 @@ test("Consent - No response", async ({ page }) => {
 
   // Consent - With response
   await when_i_submit_a_consent_with_a_response();
-  await then_i_see_the_triage_list();
+  await then_i_see_the_consent_responses_page();
+  await and_i_see_the_consent_has_been_saved();
 
-  await when_i_click_the_triage_completed_tab();
+  await when_i_go_to_the_triage_completed_tab();
   await then_the_patient_is_triaged();
 });
 
@@ -47,10 +48,6 @@ async function when_i_click_get_consent() {
 }
 const and_i_click_get_consent = when_i_click_get_consent;
 
-async function when_i_click_the_triage_completed_tab() {
-  await p.getByRole("tab", { name: "Triage completed" }).click();
-}
-
 async function when_i_submit_a_consent_with_no_response() {
   // Who
   await p.fill('[name="consent[parent_name]"]', fixtures.parentName);
@@ -64,6 +61,16 @@ async function when_i_submit_a_consent_with_no_response() {
 
   // Check answers
   await p.getByRole("button", { name: "Confirm" }).click();
+}
+
+async function then_i_see_the_consent_responses_page() {
+  await expect(p.locator("h1")).toContainText("Check consent responses");
+}
+
+async function and_i_see_the_consent_has_been_saved() {
+  await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
+    `Consent saved for ${fixtures.patientThatNeedsConsent}`,
+  );
 }
 
 async function when_i_submit_a_consent_with_a_response() {
@@ -90,10 +97,6 @@ async function when_i_submit_a_consent_with_a_response() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
-async function then_i_see_the_triage_list() {
-  await expect(p.locator("h1")).toContainText("Triage");
-}
-
 async function then_the_consent_form_is_empty() {
   await expect(p.locator('[name="consent[parent_name]"]')).toBeEmpty();
   await expect(p.locator('[name="consent[parent_phone]"]')).toBeEmpty();
@@ -108,6 +111,11 @@ async function then_the_consent_form_is_prepopulated() {
     "07700900000",
   );
   await expect(p.locator("text=Mum")).toBeChecked();
+}
+
+async function when_i_go_to_the_triage_completed_tab() {
+  await p.goto("/sessions/1/triage");
+  await p.getByRole("tab", { name: "Triage completed" }).click();
 }
 
 async function then_the_patient_is_triaged() {

--- a/tests/nurse_consent_refused.spec.ts
+++ b/tests/nurse_consent_refused.spec.ts
@@ -3,7 +3,7 @@ import { signInTestUser, fixtures } from "./shared";
 
 let p: Page;
 
-test("Consent", async ({ page }) => {
+test("Consent - refused", async ({ page }) => {
   p = page;
   await given_the_app_is_setup();
   await and_i_am_signed_in();
@@ -17,6 +17,7 @@ test("Consent", async ({ page }) => {
   await when_i_record_the_consent_refused();
   await and_i_record_the_reason_for_refusal();
   // TODO: This is a bug in the app, their status should be do not vaccinate.
+  await then_i_see_the_consent_responses_page();
   await then_i_see_that_the_child_needs_their_refusal_checked();
 });
 
@@ -71,10 +72,15 @@ async function and_i_record_the_reason_for_refusal() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
+async function then_i_see_the_consent_responses_page() {
+  await expect(p.locator("h1")).toContainText("Check consent responses");
+}
+
 async function then_i_see_that_the_child_needs_their_refusal_checked() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
     `Consent saved for ${fixtures.patientThatNeedsConsent}`,
   );
+  await p.goto("/sessions/1/triage");
   await p.getByRole("tab", { name: "No triage needed" }).click();
   const row = p.locator(`tr`, { hasText: fixtures.patientThatNeedsConsent });
   await expect(row).toBeVisible();

--- a/tests/nurse_consent_refused_during_vaccination.spec.ts
+++ b/tests/nurse_consent_refused_during_vaccination.spec.ts
@@ -17,9 +17,8 @@ test("Consent refused during vaccination", async ({ page }) => {
   await when_i_record_the_consent_refused();
   await and_i_record_the_reason_for_refusal();
   // TODO: This is a bug in the app, their status should be do not vaccinate.
-  // TODO: Other bug: the test returns to the triage page, but should be the
-  //       vaccinations page
-  await then_i_see_that_the_child_needs_their_refusal_checked();
+  await then_i_see_the_record_vaccinations_page();
+  await and_i_see_that_the_child_needs_their_refusal_checked();
 });
 
 async function given_the_app_is_setup() {
@@ -74,11 +73,14 @@ async function and_i_record_the_reason_for_refusal() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
-async function then_i_see_that_the_child_needs_their_refusal_checked() {
+async function then_i_see_the_record_vaccinations_page() {
+  await expect(p.locator("h1")).toContainText("Record vaccinations");
+}
+
+async function and_i_see_that_the_child_needs_their_refusal_checked() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
     `Consent saved for ${fixtures.patientThatNeedsConsent}`,
   );
-  await p.getByRole("tab", { name: "No triage needed" }).click();
   const row = p.locator(`tr`, { hasText: fixtures.patientThatNeedsConsent });
   await expect(row).toBeVisible();
 }


### PR DESCRIPTION
When nurses get consent for a patient from the consents page, return them to the consents page when done. Likewise, when getting consent during vaccination, return them to the vaccination pages (only necessary for consent refused as the consent given flow already did this).