### PR TITLE
Refactor empty list component to use card component

### DIFF
--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -1,4 +1,4 @@
-.nhsuk-card {
+.app-card {
   &--green {
     .nhsuk-card__heading--feature {
       background-color: $color_nhsuk-green;

--- a/app/assets/stylesheets/_card.scss
+++ b/app/assets/stylesheets/_card.scss
@@ -23,4 +23,9 @@
       background-color: $color_nhsuk-red;
     }
   }
+
+  &--empty-list {
+    margin-bottom: 0;
+    min-height: 300px;
+  }
 }

--- a/app/assets/stylesheets/_empty-list.scss
+++ b/app/assets/stylesheets/_empty-list.scss
@@ -1,5 +1,0 @@
-.app-empty-list {
-  margin-top: nhsuk-spacing(6);
-  border: 2px solid $nhsuk-border-color;
-  min-height: 300px;
-}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,7 +26,6 @@ $color_app-pale-blue: #ccdff1;
 
 @import "banner";
 @import "card";
-@import "empty-list";
 @import "header";
 @import "notification-banner";
 @import "offline";

--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -30,7 +30,7 @@ class AppCardComponent < ViewComponent::Base
     [
       "nhsuk-card",
       ("nhsuk-card--feature" if @feature),
-      ("nhsuk-card--#{@colour}" if @colour.present?)
+      ("app-card--#{@colour}" if @colour.present?)
     ].compact.join(" ")
   end
 

--- a/app/components/app_card_component.rb
+++ b/app/components/app_card_component.rb
@@ -11,11 +11,19 @@ class AppCardComponent < ViewComponent::Base
     </div>
   ERB
 
-  def initialize(heading:, feature: false, colour: nil)
+  def initialize(
+    heading:,
+    heading_size: "m",
+    feature: false,
+    colour: nil,
+    card_classes: nil
+  )
     super
 
     @heading = heading
+    @heading_size = heading_size
     @feature = feature
+    @card_classes = card_classes
 
     @colour = colour
   end
@@ -30,7 +38,8 @@ class AppCardComponent < ViewComponent::Base
     [
       "nhsuk-card",
       ("nhsuk-card--feature" if @feature),
-      ("app-card--#{@colour}" if @colour.present?)
+      ("app-card--#{@colour}" if @colour.present?),
+      @card_classes
     ].compact.join(" ")
   end
 
@@ -45,7 +54,7 @@ class AppCardComponent < ViewComponent::Base
     [
       "nhsuk-card__heading",
       ("nhsuk-card__heading--feature" if @feature),
-      "nhsuk-heading-m"
+      ("nhsuk-heading-#{@heading_size}" if @heading_size)
     ].compact.join(" ")
   end
 end

--- a/app/components/app_empty_list_component.html.erb
+++ b/app/components/app_empty_list_component.html.erb
@@ -1,0 +1,3 @@
+<%= render AppCardComponent.new(heading: "No results", heading_size: "l", card_classes: "app-card--empty-list") do %>
+  <p>We couldn’t find any children that matched your filters.</p>
+<% end %>

--- a/app/components/app_empty_list_component.rb
+++ b/app/components/app_empty_list_component.rb
@@ -1,16 +1,2 @@
 class AppEmptyListComponent < ViewComponent::Base
-  erb_template <<-ERB
-    <div class="app-empty-list">
-      <div class="nhsuk-card__content">
-        <h2 class="nhsuk-heading-l">No results</h2>
-        <p><%= @message %></p>
-      </div>
-    </div>
-  ERB
-
-  def initialize(message:)
-    super
-
-    @message = message
-  end
 end

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -23,9 +23,7 @@
         route: :consent,
       )
     else
-      render AppEmptyListComponent.new(
-        message: "We couldn’t find any children that matched your filters."
-      )
+      render AppEmptyListComponent.new
     end
   end
 end %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -23,9 +23,7 @@
         route: :triage,
       )
     else
-      render AppEmptyListComponent.new(
-        message: "We couldn’t find any children that matched your filters."
-      )
+      render AppEmptyListComponent.new
     end
   end
 end %>

--- a/app/views/vaccinations/_patients_with_actions.html.erb
+++ b/app/views/vaccinations/_patients_with_actions.html.erb
@@ -41,7 +41,7 @@
         </tbody>
       </table>
     <% else %>
-      <%= render AppEmptyListComponent.new(message: "We couldn’t find any children that matched your filters.") %>
+      <%= render AppEmptyListComponent.new %>
     <% end %>
   </div>
 </div>

--- a/app/views/vaccinations/_patients_with_outcomes.html.erb
+++ b/app/views/vaccinations/_patients_with_outcomes.html.erb
@@ -41,7 +41,7 @@
         </tbody>
       </table>
     <% else %>
-      <%= render AppEmptyListComponent.new(message: "We couldn’t find any children that matched your filters.") %>
+      <%= render AppEmptyListComponent.new %>
     <% end %>
   </div>
 </div>

--- a/spec/components/app_card_component_spec.rb
+++ b/spec/components/app_card_component_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe AppCardComponent, type: :component do
     it { should_not have_css(".nhsuk-card__content") }
   end
 
+  context "classes on container" do
+    let(:component) do
+      described_class.new(heading:, card_classes: "app-card--empty")
+    end
+
+    it { should have_css(".nhsuk-card.app-card--empty") }
+  end
+
+  context "larger heading" do
+    let(:component) { described_class.new(heading:, heading_size: "xl") }
+
+    it { should have_css("h2.nhsuk-heading-xl", text: "A Heading") }
+  end
+
   context "feature card" do
     let(:component) { described_class.new(heading:, feature: true) }
 

--- a/spec/components/app_card_component_spec.rb
+++ b/spec/components/app_card_component_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AppCardComponent, type: :component do
     describe "card_classes" do
       subject { component.send(:card_classes) }
 
-      it { should include "nhsuk-card--purple" }
+      it { should include "app-card--purple" }
     end
   end
 end

--- a/spec/components/app_empty_list_component_spec.rb
+++ b/spec/components/app_empty_list_component_spec.rb
@@ -5,9 +5,13 @@ RSpec.describe AppEmptyListComponent, type: :component do
 
   subject { page }
 
-  let(:message) { "No items found." }
-  let(:component) { described_class.new(message:) }
+  let(:component) { described_class.new }
 
-  it { should have_css(".app-empty-list", text: "No results") }
-  it { should have_css(".nhsuk-card__content", text: message) }
+  it { should have_css(".app-card--empty-list", text: "No results") }
+  it do
+    should have_css(
+             ".nhsuk-card__content",
+             text: "We couldn’t find any children that matched your filters."
+           )
+  end
 end

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
   context "state is added_to_session" do
     let(:patient_session) { create :patient_session, :added_to_session }
 
-    it { should have_css(".nhsuk-card--blue") }
+    it { should have_css(".app-card--blue") }
   end
 
   context "state is consent_given_triage_not_needed" do
@@ -25,7 +25,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
       create :patient_session, :consent_given_triage_not_needed
     end
 
-    it { should have_css(".nhsuk-card--purple") }
+    it { should have_css(".app-card--purple") }
     it { should have_css(".nhsuk-card__heading", text: "Consent given") }
     it { should have_text("#{patient_name} is ready to vaccinate") }
   end
@@ -35,7 +35,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
       create :patient_session, :consent_given_triage_needed
     end
 
-    it { should have_css(".nhsuk-card--blue") }
+    it { should have_css(".app-card--blue") }
     it { should have_css(".nhsuk-card__heading", text: "Needs triage") }
     it { should have_text("Responses to health questions need triage") }
   end
@@ -43,7 +43,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
   context "state is consent_refused" do
     let(:patient_session) { create :patient_session, :consent_refused }
 
-    it { should have_css(".nhsuk-card--orange") }
+    it { should have_css(".app-card--orange") }
     it { should have_css(".nhsuk-card__heading", text: "Consent refused") }
     it { should have_text("Mum refused to give consent") }
   end
@@ -51,7 +51,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
   context "state is triaged_kept_in_triage" do
     let(:patient_session) { create :patient_session, :triaged_kept_in_triage }
 
-    it { should have_css(".nhsuk-card--blue") }
+    it { should have_css(".app-card--blue") }
     it { should have_css(".nhsuk-card__heading", text: "Needs triage") }
     it { should have_text("Responses to health questions need triage") }
   end
@@ -61,7 +61,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
       create :patient_session, :triaged_ready_to_vaccinate
     end
 
-    it { should have_css(".nhsuk-card--purple") }
+    it { should have_css(".app-card--purple") }
     it { should have_css(".nhsuk-card__heading", text: "Safe to vaccinate") }
     it "explains who took the decision that the patient should be vaccinated" do
       expect(component.explanation).to eq(
@@ -73,7 +73,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
   context "state is unable_to_vaccinate" do
     let(:patient_session) { create :patient_session, :unable_to_vaccinate }
 
-    it { should have_css(".nhsuk-card--red") }
+    it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it "explains who took the decision that the patient should be vaccinated" do
       expect(component.explanation).to include(
@@ -91,7 +91,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
     let(:date) { vaccination_record.recorded_at.to_fs(:nhsuk_date) }
     let(:time) { vaccination_record.recorded_at.to_fs(:time) }
 
-    it { should have_css(".nhsuk-card--green") }
+    it { should have_css(".app-card--green") }
     it { should have_css(".nhsuk-card__heading", text: "Vaccinated") }
     it { should have_text("VaccineHPV (#{vaccine.brand}, #{batch.name})") }
     it { should have_text("SiteLeft arm") }
@@ -120,7 +120,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
     let(:triage) { patient_session.triage.first }
     let(:date) { triage.created_at.to_fs(:nhsuk_date) }
 
-    it { should have_css(".nhsuk-card--red") }
+    it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it { should have_text("ReasonDo not vaccinate in campaign") }
     it { should have_text("DateToday (#{date})") }


### PR DESCRIPTION
Refactor `AppEmptyListComponent` to use `AppCardComponent`. Currently, this component contains hard-coded values, so maybe it should be a partial instead? However, I can imaging it needing to become a component in the future, so maybe this is fine?

Also…

* Use `app-` prefix for card colours (this is what I should have done in the prototype)
* Allow the card component to have a different heading size, and additional classes added to the container. This enables the above refactor of the empty list component.

| Before | After |
| - | - |
|  <img width="980" alt="Screenshot 2023-12-11 at 12 33 17" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/5654168f-ca12-4afd-9522-b0dc98dc3268"> | <img width="974" alt="Screenshot 2023-12-11 at 12 33 36" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/cc3644b1-8ca1-475e-ad6a-ce6569e79f3f"> |
