### PR TITLE
Prefill consent

### DIFF
--- a/app/controllers/nurse_consents_controller.rb
+++ b/app/controllers/nurse_consents_controller.rb
@@ -11,6 +11,15 @@ class NurseConsentsController < ApplicationController
   layout "two_thirds"
 
   def new
+    # Temporary: Prefill the consent details.
+    # This should be replaced with the design that allows users to choose
+    # from available parent details when submiting a new consent.
+    if @patient.consents.submitted_for_campaign(@session.campaign).empty?
+      @draft_consent.parent_name ||= @patient.parent_name
+      @draft_consent.parent_phone ||= @patient.parent_phone
+      @draft_consent.parent_relationship ||= @patient.parent_relationship
+    end
+
     render :edit_who
   end
 

--- a/tests/nurse_consent_during_vaccination.spec.ts
+++ b/tests/nurse_consent_during_vaccination.spec.ts
@@ -13,7 +13,6 @@ test("Records consent and then allows vaccination", async ({ page }) => {
   await then_i_see_the_vaccination_page();
 
   await when_i_click_yes_i_am_contacting_a_parent();
-  await and_i_click_continue();
   await then_i_see_the_new_consent_form();
 
   await when_i_go_through_the_consent_and_triage_forms();

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -10,7 +10,7 @@ test("Consent - No response", async ({ page }) => {
 
   await when_i_select_a_child_with_no_consent_response();
   await and_i_click_get_consent();
-  await then_the_consent_form_is_empty();
+  await then_the_consent_form_is_prefilled();
 
   // Consent - No response
   await when_i_submit_a_consent_with_no_response();
@@ -96,10 +96,9 @@ async function when_i_submit_a_consent_with_a_response() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
-async function then_the_consent_form_is_empty() {
-  await expect(p.locator('[name="consent[parent_name]"]')).toBeEmpty();
-  await expect(p.locator('[name="consent[parent_phone]"]')).toBeEmpty();
-  await expect(p.locator("text=Mum")).not.toBeChecked();
+async function then_the_consent_form_is_prefilled() {
+  await expect(p.locator('[name="consent[parent_name]"]')).not.toBeEmpty();
+  await expect(p.locator('[name="consent[parent_phone]"]')).not.toBeEmpty();
 }
 
 async function then_the_consent_form_is_prepopulated() {

--- a/tests/nurse_consent_refused.spec.ts
+++ b/tests/nurse_consent_refused.spec.ts
@@ -11,7 +11,7 @@ test("Consent - refused", async ({ page }) => {
   await given_i_am_checking_consent();
   await when_i_select_a_child_with_no_consent_response();
   await and_i_click_get_consent();
-  await then_the_consent_form_is_empty();
+  await then_the_consent_form_is_prefilled();
 
   await given_i_call_the_parent_and_they_refuse_consent();
   await when_i_record_the_consent_refused();
@@ -43,10 +43,9 @@ async function when_i_click_get_consent() {
 }
 const and_i_click_get_consent = when_i_click_get_consent;
 
-async function then_the_consent_form_is_empty() {
-  await expect(p.locator('[name="consent[parent_name]"]')).toBeEmpty();
-  await expect(p.locator('[name="consent[parent_phone]"]')).toBeEmpty();
-  await expect(p.locator("text=Mum")).not.toBeChecked();
+async function then_the_consent_form_is_prefilled() {
+  await expect(p.locator('[name="consent[parent_name]"]')).not.toBeEmpty();
+  await expect(p.locator('[name="consent[parent_phone]"]')).not.toBeEmpty();
 }
 
 async function given_i_call_the_parent_and_they_refuse_consent() {}

--- a/tests/nurse_consent_refused_during_vaccination.spec.ts
+++ b/tests/nurse_consent_refused_during_vaccination.spec.ts
@@ -11,7 +11,7 @@ test("Consent refused during vaccination", async ({ page }) => {
   await given_i_am_performing_vaccinations();
   await when_i_select_a_child_with_no_consent_response();
   await and_i_select_that_i_am_getting_consent();
-  await then_the_consent_form_is_empty();
+  await then_the_consent_form_is_prefilled();
 
   await given_i_call_the_parent_and_they_refuse_consent();
   await when_i_record_the_consent_refused();
@@ -44,10 +44,9 @@ async function when_i_select_that_i_am_getting_consent() {
 const and_i_select_that_i_am_getting_consent =
   when_i_select_that_i_am_getting_consent;
 
-async function then_the_consent_form_is_empty() {
-  await expect(p.locator('[name="consent[parent_name]"]')).toBeEmpty();
-  await expect(p.locator('[name="consent[parent_phone]"]')).toBeEmpty();
-  await expect(p.locator("text=Mum")).not.toBeChecked();
+async function then_the_consent_form_is_prefilled() {
+  await expect(p.locator('[name="consent[parent_name]"]')).not.toBeEmpty();
+  await expect(p.locator('[name="consent[parent_phone]"]')).not.toBeEmpty();
 }
 
 async function given_i_call_the_parent_and_they_refuse_consent() {}

--- a/tests/nurse_consent_validations.spec.ts
+++ b/tests/nurse_consent_validations.spec.ts
@@ -10,7 +10,9 @@ test("Consent validations", async ({ page }) => {
 
   // Who are you getting consent from validations
   await given_i_am_on_the_who_am_i_contacting_for_consent_page();
-  await when_i_continue_without_entering_anything();
+  await then_the_page_is_prefilled_with_the_parent_details();
+
+  await when_i_delete_the_prefilled_field_data_and_submit();
   await then_i_see_the_who_i_am_contacting_validation_errors();
 
   await given_i_select_other_relationship();
@@ -44,6 +46,16 @@ async function given_i_am_on_the_who_am_i_contacting_for_consent_page() {
   await p.getByRole("button", { name: "Get consent" }).click();
 }
 
+async function then_the_page_is_prefilled_with_the_parent_details() {
+  await expect(p.getByRole("textbox", { name: "Full name" })).not.toBeEmpty();
+}
+
+async function when_i_delete_the_prefilled_field_data_and_submit() {
+  await p.fill('[name="consent[parent_name]"]', "");
+  await p.fill('[name="consent[parent_phone]"]', "");
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
 async function when_i_continue_without_entering_anything() {
   await p.getByRole("button", { name: "Continue" }).click();
 }
@@ -59,7 +71,6 @@ async function then_i_see_the_who_i_am_contacting_validation_errors() {
   await expect(alert).toBeVisible();
   await expect(alert).toContainText("Enter a name");
   await expect(alert).toContainText("Enter a phone number");
-  await expect(alert).toContainText("Choose a relationship");
 }
 
 async function given_i_select_other_relationship() {


### PR DESCRIPTION
This is temporary. The prototype has a better design but it's more effort to implement at this stage.

This prefills the fields when a user attempts to submit consent for a patient whose parent didn't respond to requests for cconsnt.