### PR TITLE
Update banner content for nurse consent journey

### DIFF
--- a/app/controllers/nurse_consents_controller.rb
+++ b/app/controllers/nurse_consents_controller.rb
@@ -177,7 +177,7 @@ class NurseConsentsController < ApplicationController
       redirect_to redirect_path,
                   flash: {
                     success: {
-                      heading: "Consent saved for #{@patient.full_name}",
+                      heading: "Record saved for #{@patient.full_name}",
                       body:
                         ActionController::Base.helpers.link_to(
                           "View child record",

--- a/tests/full_journey.spec.ts
+++ b/tests/full_journey.spec.ts
@@ -76,7 +76,7 @@ async function and_i_record_the_triage_details() {
 
 async function then_i_see_that_the_child_has_gotten_consent() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
-    `Consent saved for ${fixtures.patientThatNeedsConsent}`,
+    `Record saved for ${fixtures.patientThatNeedsConsent}`,
   );
   const row = p.locator(`tr`, { hasText: fixtures.patientThatNeedsConsent });
   await expect(row).toBeVisible();

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -69,7 +69,7 @@ async function then_i_see_the_consent_responses_page() {
 
 async function and_i_see_the_consent_has_been_saved() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
-    `Consent saved for ${fixtures.patientThatNeedsConsent}`,
+    `Record saved for ${fixtures.patientThatNeedsConsent}`,
   );
 }
 

--- a/tests/nurse_consent_refused.spec.ts
+++ b/tests/nurse_consent_refused.spec.ts
@@ -78,7 +78,7 @@ async function then_i_see_the_consent_responses_page() {
 
 async function then_i_see_that_the_child_needs_their_refusal_checked() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
-    `Consent saved for ${fixtures.patientThatNeedsConsent}`,
+    `Record saved for ${fixtures.patientThatNeedsConsent}`,
   );
   await p.goto("/sessions/1/triage");
   await p.getByRole("tab", { name: "No triage needed" }).click();

--- a/tests/nurse_consent_refused_during_vaccination.spec.ts
+++ b/tests/nurse_consent_refused_during_vaccination.spec.ts
@@ -79,7 +79,7 @@ async function then_i_see_the_record_vaccinations_page() {
 
 async function and_i_see_that_the_child_needs_their_refusal_checked() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
-    `Consent saved for ${fixtures.patientThatNeedsConsent}`,
+    `Record saved for ${fixtures.patientThatNeedsConsent}`,
   );
   const row = p.locator(`tr`, { hasText: fixtures.patientThatNeedsConsent });
   await expect(row).toBeVisible();


### PR DESCRIPTION
"Record saved" is more accurate than "Consent saved."