### PR TITLE
Display conflicting consent banner

### DIFF
--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -24,6 +24,7 @@ class VaccinationsController < ApplicationController
         triaged_ready_to_vaccinate
         added_to_session
         consent_refused
+        consent_conflicts
         consent_given_triage_not_needed
       ],
       vaccinated: %w[vaccinated],

--- a/app/helpers/patient_session_helper.rb
+++ b/app/helpers/patient_session_helper.rb
@@ -19,6 +19,10 @@ module PatientSessionHelper
       text: "Check refusal",
       banner_title: "Their %{who_responded} has refused to give consent"
     },
+    consent_conflicts: {
+      colour: "orange",
+      text: "Check conflicting consent"
+    },
     triaged_do_not_vaccinate: {
       colour: "red",
       text: "Do not vaccinate",

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -9,6 +9,7 @@ module PatientSessionStateMachineConcern
       state :consent_given_triage_not_needed
       state :consent_given_triage_needed
       state :consent_refused
+      state :consent_conflicts
       state :triaged_ready_to_vaccinate
       state :triaged_do_not_vaccinate
       state :triaged_kept_in_triage
@@ -30,6 +31,14 @@ module PatientSessionStateMachineConcern
         transitions from: :added_to_session,
                     to: :consent_refused,
                     if: :consent_refused?
+
+        transitions from: %i[
+                      added_to_session
+                      consent_given_triage_needed
+                      consent_refused
+                    ],
+                    to: :consent_conflicts,
+                    if: :consent_conflicts?
       end
 
       event :do_gillick_assessment do

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -20,6 +20,11 @@ en:
       text: Check refusal
       banner_title: Consent refused
       banner_explanation: "%{who_refused} refused to give consent"
+    consent_conflicts:
+      colour: orange
+      text: Check conflicting consent
+      banner_title: Conflicting consent
+      banner_explanation: "You can only vaccinate if all respondents give consent."
     delay_vaccination:
       colour: red
       text: Delay vaccination


### PR DESCRIPTION
This requires updating the state machine to take this state into account.

This brings us a little bit closer to properly supporting multiple consents.

### Vaccinations index (status tag)

![Screenshot 2023-12-11 at 13 33 32](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/0374f5c3-610b-4062-8fd6-a66b7bb44b98)

### Banner

![Screenshot 2023-12-11 at 13 33 37](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/366d20d3-68a2-4adc-a0dd-e8ab46b66e47)
