### PR TITLE
Improve header adaption

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -4,14 +4,8 @@
   }
 
   &__service-name {
-    display: inline-block;
     line-height: 1.25;
-    padding-left: nhsuk-spacing(2);
-    vertical-align: top;
-
-    @include mq($from: tablet, $until: large-desktop) {
-      max-width: 300px;
-    }
+    max-width: auto;
   }
 
   &__navigation-list {

--- a/app/assets/stylesheets/_summary-list.scss
+++ b/app/assets/stylesheets/_summary-list.scss
@@ -17,11 +17,11 @@
     border-bottom: 1px solid $nhsuk-border-color;
     display: block;
     margin-bottom: nhsuk-spacing(3);
-  }
 
-  .nhsuk-summary-list__row:last-of-type {
-    border: none;
-    margin-bottom: 0;
+    &:last-of-type {
+      border: none;
+      margin-bottom: 0;
+    }
   }
 
   .nhsuk-summary-list__key,


### PR DESCRIPTION
Removing some of the styles we’re applying to the header improves the responsiveness of the logo+service name lock-up. Possibly due to upstream improvements in NHS.UK Frontend?