### PR TITLE
Use same ordering and heading for triage question in consent journey

### DIFF
--- a/app/views/nurse_consents/edit_questions.html.erb
+++ b/app/views/nurse_consents/edit_questions.html.erb
@@ -31,21 +31,20 @@
     <% end %>
   <% end %>
 
-  <h2 class="nhsuk-card__heading nhsuk-heading-m nhsuk-u-margin-top-8">
-    Triage
-  </h2>
+  <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible">
 
   <%= f.fields_for @draft_triage do |ff| %>
 
     <% content_for(:before_content) { ff.govuk_error_summary } %>
 
-    <%= ff.govuk_text_area :notes, label: { text: 'Triage notes (optional)' },
-                                   rows: 5 %>
     <%= ff.govuk_collection_radio_buttons :status,
                                          triage_form_status_options,
                                          :first,
                                          :second,
-                                         legend: { text: 'Triage status' } %>
+                                         legend: { text: "Is it safe to vaccinate #{@patient.full_name}?" } %>
+
+    <%= ff.govuk_text_area :notes, label: { text: 'Triage notes (optional)' },
+                                   rows: 5 %>
   <% end %>
 
   <div class="nhsuk-u-margin-top-6">


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="685" alt="Screenshot 2023-12-11 at 14 34 51" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/3362015c-150a-492a-8b32-2cff644e9043"> | <img width="665" alt="Screenshot 2023-12-11 at 14 43 46" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/fc7ea9a9-035e-49fa-8070-5d317a6acadb"> |
