### PR TITLE
Display consent correctly for gillick consent

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -53,7 +53,10 @@ class AppConsentComponent < ViewComponent::Base
     @consents_grouped_by_parent ||=
       @patient_session.consents.group_by do |consent|
         response = consent.human_enum_name(:response).capitalize
-        "#{response} by #{consent.parent_name} (#{consent.who_responded})"
+        summary = "#{response} by #{consent.name}"
+        summary +=
+          " (#{consent.who_responded})" unless consent.via_self_consent?
+        summary
       end
   end
 end

--- a/app/components/app_consent_details_component.rb
+++ b/app/components/app_consent_details_component.rb
@@ -5,17 +5,19 @@ class AppConsentDetailsComponent < ViewComponent::Base
     ) do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Name" }
-        row.with_value { parent_name }
+        row.with_value { name }
       end
 
-      summary_list.with_row do |row|
-        row.with_key { "Relationship" }
-        row.with_value { who_responded }
-      end
+      unless self_consent?
+        summary_list.with_row do |row|
+          row.with_key { "Relationship" }
+          row.with_value { who_responded }
+        end
 
-      summary_list.with_row do |row|
-        row.with_key { "Contact" }
-        row.with_value { parent_phone_and_email.join("<br />").html_safe }
+        summary_list.with_row do |row|
+          row.with_key { "Contact" }
+          row.with_value { parent_phone_and_email.join("<br />").html_safe }
+        end
       end
 
       summary_list.with_row do |row|
@@ -44,8 +46,12 @@ class AppConsentDetailsComponent < ViewComponent::Base
 
   private
 
-  def parent_name
-    @consents.first.parent_name
+  def self_consent?
+    @consents.first.via_self_consent?
+  end
+
+  def name
+    @consents.first.name
   end
 
   def who_responded

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -96,6 +96,10 @@ class Consent < ApplicationRecord
             if: -> { reason_for_refusal == "other" },
             on: :edit_reason
 
+  def name
+    via_self_consent? ? patient.full_name : parent_name
+  end
+
   def triage_needed?
     response_given? &&
       (parent_relationship_other? || health_questions_require_follow_up?)

--- a/app/views/nurse_consents/edit_confirm.html.erb
+++ b/app/views/nurse_consents/edit_confirm.html.erb
@@ -31,8 +31,10 @@
         refused: "Refusal confirmed by",
         not_provided: "",
       }[@draft_consent.response.to_sym] %>
-      <%= @draft_consent.parent_name.titleize %>
-      (<%= @draft_consent.who_responded %>)
+      <%= @draft_consent.name.titleize %>
+      <% unless @draft_consent.via_self_consent? %>
+        (<%= @draft_consent.who_responded %>)
+      <% end %>
     </h2>
 
     <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|


### PR DESCRIPTION
Use the patient's name and hide the contact details and relationship.

### Before

<img width="860" alt="Screenshot 2023-12-11 at 17 00 06" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/a134a473-2613-4a44-8b5c-63d0bfee50a2">

### After

<img width="841" alt="Screenshot 2023-12-11 at 17 06 59" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/f4417c67-c8bc-4f98-9036-1e1e1d947431">

