### PR TITLE
Display attempts to contact a parent for consent

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -1,5 +1,11 @@
 <%= render AppConsentStatusComponent.new(patient_session:) %>
 
+<% if patient_session.no_consent? %>
+  <p class="app-status">
+    No response yet
+  </p>
+<% end %>
+
 <% if patient_session.consents.present? %>
   <% consents_grouped_by_parent.each do |summary, consents| %>
     <%= render AppDetailsComponent.new(summary:, open: open_consents?) do %>
@@ -7,6 +13,17 @@
 
       <% if consents.any?(&:response_refused?) %>
         <p><%= contact_parent_or_guardian_link(consents) %></p>
+      <% elsif consents.any?(&:response_not_provided?) %>
+        <%= govuk_button_link_to(
+          "Get consent",
+          edit_session_patient_nurse_consents_path(
+            session,
+            patient,
+            @route,
+            consent_id: consents.first.id
+          ),
+          class: "nhsuk-button--secondary nhsuk-u-margin-bottom-2"
+        ) %>
       <% end %>
     <% end %>
   <% end %>
@@ -21,10 +38,6 @@
     end
   end %>
 <% else %>
-  <p class="app-status">
-    No response yet
-  </p>
-
   <p>
     <%= govuk_button_link_to(
       "Get consent",

--- a/app/controllers/nurse_consents_controller.rb
+++ b/app/controllers/nurse_consents_controller.rb
@@ -174,12 +174,10 @@ class NurseConsentsController < ApplicationController
   end
 
   def record
-    unless @draft_consent.response_not_provided?
-      ActiveRecord::Base.transaction do
-        @draft_consent.update!(recorded_at: Time.zone.now)
-        @patient_session.do_consent!
-        @patient_session.do_triage! if @patient_session.triage.present?
-      end
+    ActiveRecord::Base.transaction do
+      @draft_consent.update!(recorded_at: Time.zone.now)
+      @patient_session.do_consent!
+      @patient_session.do_triage! if @patient_session.triage.present?
     end
 
     if @patient_session.triaged_ready_to_vaccinate? &&

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -40,6 +40,10 @@ module PatientSessionStateMachineConcern
                     to: :consent_refused,
                     if: :consent_refused?
 
+        transitions from: :added_to_session,
+                    to: :added_to_session,
+                    if: :no_consent?
+
         transitions from: %i[
                       added_to_session
                       consent_given_triage_needed
@@ -124,7 +128,7 @@ module PatientSessionStateMachineConcern
     end
 
     def no_consent?
-      consents.empty?
+      consents.empty? || consents.all?(&:response_not_provided?)
     end
 
     def triage_needed?

--- a/db/sample_data/model-office.json
+++ b/db/sample_data/model-office.json
@@ -83,7 +83,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "barney.klocko99@gmail.com",
-          "parentPhone": "076 8254 1751",
+          "parentPhone": "077 8254 1751",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -103,7 +103,7 @@
       ],
       "parentEmail": "barney.klocko99@gmail.com",
       "parentName": "Barney Klocko",
-      "parentPhone": "076 8254 1751",
+      "parentPhone": "077 8254 1751",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -146,7 +146,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "dina.marvin61@gmail.com",
-          "parentPhone": "076 5147 9880",
+          "parentPhone": "077 5147 9880",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -166,7 +166,7 @@
       ],
       "parentEmail": "dina.marvin61@gmail.com",
       "parentName": "Dina Marvin",
-      "parentPhone": "076 5147 9880",
+      "parentPhone": "077 5147 9880",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -209,7 +209,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "kerry.pacocha23@gmail.com",
-          "parentPhone": "0700 678300",
+          "parentPhone": "07902 678300",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -229,7 +229,7 @@
       ],
       "parentEmail": "kerry.pacocha23@gmail.com",
       "parentName": "Kerry Pacocha",
-      "parentPhone": "0700 678300",
+      "parentPhone": "07902 678300",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -248,7 +248,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "patty.gottlieb32@gmail.com",
-          "parentPhone": "076 4073 5732",
+          "parentPhone": "077 4073 5732",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -292,7 +292,7 @@
       ],
       "parentEmail": "patty.gottlieb32@gmail.com",
       "parentName": "Patty Gottlieb",
-      "parentPhone": "076 4073 5732",
+      "parentPhone": "077 4073 5732",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -350,7 +350,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "meghann.kuhic8@gmail.com",
-          "parentPhone": "076977 5099",
+          "parentPhone": "0779774 5099",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -370,7 +370,7 @@
       ],
       "parentEmail": "meghann.kuhic8@gmail.com",
       "parentName": "Meghann Kuhic",
-      "parentPhone": "076977 5099",
+      "parentPhone": "0779774 5099",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -389,7 +389,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "melina.lehner51@gmail.com",
-          "parentPhone": "0700 390743",
+          "parentPhone": "07902 390743",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -433,7 +433,7 @@
       ],
       "parentEmail": "melina.lehner51@gmail.com",
       "parentName": "Melina Lehner",
-      "parentPhone": "0700 390743",
+      "parentPhone": "07902 390743",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -491,7 +491,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "rufus.schroeder2@gmail.com",
-          "parentPhone": "07908 70545",
+          "parentPhone": "07908 870545",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -535,7 +535,7 @@
       ],
       "parentEmail": "rufus.schroeder2@gmail.com",
       "parentName": "Rufus Schroeder",
-      "parentPhone": "07908 70545",
+      "parentPhone": "07908 870545",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -656,7 +656,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "alejandra.kirlin17@gmail.com",
-          "parentPhone": "0700 451770",
+          "parentPhone": "07907 451770",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -676,7 +676,7 @@
       ],
       "parentEmail": "alejandra.kirlin17@gmail.com",
       "parentName": "Alejandra Kirlin",
-      "parentPhone": "0700 451770",
+      "parentPhone": "07907 451770",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -734,7 +734,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "rosalind.bins21@gmail.com",
-          "parentPhone": "076977 8842",
+          "parentPhone": "0779772 8842",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -754,7 +754,7 @@
       ],
       "parentEmail": "rosalind.bins21@gmail.com",
       "parentName": "Rosalind Bins",
-      "parentPhone": "076977 8842",
+      "parentPhone": "0779772 8842",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -812,7 +812,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "rosendo.fadel50@gmail.com",
-          "parentPhone": "07885 60449",
+          "parentPhone": "07885 760449",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -832,7 +832,7 @@
       ],
       "parentEmail": "rosendo.fadel50@gmail.com",
       "parentName": "Rosendo Fadel",
-      "parentPhone": "07885 60449",
+      "parentPhone": "07885 760449",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -875,7 +875,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "barbra.hirthe91@gmail.com",
-          "parentPhone": "0700 806062",
+          "parentPhone": "07908 806062",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -895,7 +895,7 @@
       ],
       "parentEmail": "barbra.hirthe91@gmail.com",
       "parentName": "Barbra Hirthe",
-      "parentPhone": "0700 806062",
+      "parentPhone": "07908 806062",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -914,7 +914,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "sharell.mraz85@gmail.com",
-          "parentPhone": "076977 8097",
+          "parentPhone": "0779771 8097",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -934,7 +934,7 @@
       ],
       "parentEmail": "sharell.mraz85@gmail.com",
       "parentName": "Sharell Mraz",
-      "parentPhone": "076977 8097",
+      "parentPhone": "0779771 8097",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -953,7 +953,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "brigid.kohler9@gmail.com",
-          "parentPhone": "07194 91502",
+          "parentPhone": "07194 091502",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -973,7 +973,7 @@
       ],
       "parentEmail": "brigid.kohler9@gmail.com",
       "parentName": "Brigid Kohler",
-      "parentPhone": "07194 91502",
+      "parentPhone": "07194 091502",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1094,7 +1094,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "tanesha.langosh4@gmail.com",
-          "parentPhone": "076 6082 3909",
+          "parentPhone": "077 6082 3909",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -1114,7 +1114,7 @@
       ],
       "parentEmail": "tanesha.langosh4@gmail.com",
       "parentName": "Tanesha Langosh",
-      "parentPhone": "076 6082 3909",
+      "parentPhone": "077 6082 3909",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1133,7 +1133,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "markus.ortiz68@gmail.com",
-          "parentPhone": "07117 29277",
+          "parentPhone": "07117 729277",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -1153,7 +1153,7 @@
       ],
       "parentEmail": "markus.ortiz68@gmail.com",
       "parentName": "Markus Ortiz",
-      "parentPhone": "07117 29277",
+      "parentPhone": "07117 729277",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1224,7 +1224,7 @@
       ],
       "parentEmail": "nga.weissnat24@gmail.com",
       "parentName": "Nga Weissnat",
-      "parentPhone": "076 2780 4713",
+      "parentPhone": "077 2780 4713",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1240,7 +1240,7 @@
       ],
       "parentEmail": "miriam.beatty19@gmail.com",
       "parentName": "Miriam Beatty",
-      "parentPhone": "0700 960338",
+      "parentPhone": "07904 960338",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1256,7 +1256,7 @@
       ],
       "parentEmail": "leland.smith71@gmail.com",
       "parentName": "Leland Smith",
-      "parentPhone": "072 1580 5875",
+      "parentPhone": "073 1580 5875",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1272,7 +1272,7 @@
       ],
       "parentEmail": "marilyn.o'kon73@gmail.com",
       "parentName": "Marilyn O'Kon",
-      "parentPhone": "076 2010 0803",
+      "parentPhone": "077 2010 0803",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1352,7 +1352,7 @@
       ],
       "parentEmail": "janean.weimann50@gmail.com",
       "parentName": "Janean Weimann",
-      "parentPhone": "0700 494 1311",
+      "parentPhone": "0790 494 1311",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1508,7 +1508,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "amanda.breitenberg85@gmail.com",
-          "parentPhone": "0721 343 2793",
+          "parentPhone": "0731 343 2793",
           "healthQuestionResponses": [
 
           ],
@@ -1517,7 +1517,7 @@
       ],
       "parentEmail": "amanda.breitenberg85@gmail.com",
       "parentName": "Amanda Breitenberg",
-      "parentPhone": "0721 343 2793",
+      "parentPhone": "0731 343 2793",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1536,7 +1536,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "kenton.zulauf71@gmail.com",
-          "parentPhone": "076 1943 1723",
+          "parentPhone": "077 1943 1723",
           "healthQuestionResponses": [
 
           ],
@@ -1545,7 +1545,7 @@
       ],
       "parentEmail": "kenton.zulauf71@gmail.com",
       "parentName": "Kenton Zulauf",
-      "parentPhone": "076 1943 1723",
+      "parentPhone": "077 1943 1723",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1592,7 +1592,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "anthony.fadel15@gmail.com",
-          "parentPhone": "076977 1732",
+          "parentPhone": "0779779 1732",
           "healthQuestionResponses": [
 
           ],
@@ -1601,7 +1601,7 @@
       ],
       "parentEmail": "anthony.fadel15@gmail.com",
       "parentName": "Anthony Fadel",
-      "parentPhone": "076977 1732",
+      "parentPhone": "0779779 1732",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1620,7 +1620,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "gertie.johns21@gmail.com",
-          "parentPhone": "0764 390 9512",
+          "parentPhone": "0774 390 9512",
           "healthQuestionResponses": [
 
           ],
@@ -1642,7 +1642,7 @@
       ],
       "parentEmail": "gertie.johns21@gmail.com",
       "parentName": "Gertie Johns",
-      "parentPhone": "0764 390 9512",
+      "parentPhone": "0774 390 9512",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1689,7 +1689,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "betsy.jaskolski40@gmail.com",
-          "parentPhone": "072091 97461",
+          "parentPhone": "073091 97461",
           "healthQuestionResponses": [
 
           ],
@@ -1711,7 +1711,7 @@
       ],
       "parentEmail": "betsy.jaskolski40@gmail.com",
       "parentName": "Betsy Jaskolski",
-      "parentPhone": "072091 97461",
+      "parentPhone": "073091 97461",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1730,7 +1730,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "robbyn.zboncak50@gmail.com",
-          "parentPhone": "0700 174296",
+          "parentPhone": "07905 174296",
           "healthQuestionResponses": [
 
           ],
@@ -1739,7 +1739,7 @@
       ],
       "parentEmail": "robbyn.zboncak50@gmail.com",
       "parentName": "Robbyn Zboncak",
-      "parentPhone": "0700 174296",
+      "parentPhone": "07905 174296",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1799,7 +1799,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "erin.haley69@gmail.com",
-          "parentPhone": "0700 789483",
+          "parentPhone": "07908 789483",
           "healthQuestionResponses": [
 
           ],
@@ -1821,7 +1821,7 @@
       ],
       "parentEmail": "erin.haley69@gmail.com",
       "parentName": "Erin Haley",
-      "parentPhone": "0700 789483",
+      "parentPhone": "07908 789483",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1840,7 +1840,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "julianne.renner60@gmail.com",
-          "parentPhone": "0700 114 3986",
+          "parentPhone": "0790 114 3986",
           "healthQuestionResponses": [
 
           ],
@@ -1849,7 +1849,7 @@
       ],
       "parentEmail": "julianne.renner60@gmail.com",
       "parentName": "Julianne Renner",
-      "parentPhone": "0700 114 3986",
+      "parentPhone": "0790 114 3986",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1868,7 +1868,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "marylin.schroeder84@gmail.com",
-          "parentPhone": "0700 638799",
+          "parentPhone": "07906 638799",
           "healthQuestionResponses": [
 
           ],
@@ -1877,7 +1877,7 @@
       ],
       "parentEmail": "marylin.schroeder84@gmail.com",
       "parentName": "Marylin Schroeder",
-      "parentPhone": "0700 638799",
+      "parentPhone": "07906 638799",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -1924,7 +1924,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "lenny.russel87@gmail.com",
-          "parentPhone": "07629 479042",
+          "parentPhone": "07729 479042",
           "healthQuestionResponses": [
 
           ],
@@ -1933,7 +1933,7 @@
       ],
       "parentEmail": "lenny.russel87@gmail.com",
       "parentName": "Lenny Russel",
-      "parentPhone": "07629 479042",
+      "parentPhone": "07729 479042",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2056,7 +2056,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "reginia.wintheiser32@gmail.com",
-          "parentPhone": "07794 78660",
+          "parentPhone": "07794 378660",
           "healthQuestionResponses": [
             {
               "question": "Does your child have any severe allergies?",
@@ -2089,7 +2089,7 @@
       ],
       "parentEmail": "reginia.wintheiser32@gmail.com",
       "parentName": "Reginia Wintheiser",
-      "parentPhone": "07794 78660",
+      "parentPhone": "07794 378660",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2108,7 +2108,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "jamal.gleichner68@gmail.com",
-          "parentPhone": "076 2375 0301",
+          "parentPhone": "077 2375 0301",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2136,7 +2136,7 @@
       ],
       "parentEmail": "jamal.gleichner68@gmail.com",
       "parentName": "Jamal Gleichner",
-      "parentPhone": "076 2375 0301",
+      "parentPhone": "077 2375 0301",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2155,7 +2155,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "lucius.thompson84@gmail.com",
-          "parentPhone": "0700 563207",
+          "parentPhone": "07905 563207",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2183,7 +2183,7 @@
       ],
       "parentEmail": "lucius.thompson84@gmail.com",
       "parentName": "Lucius Thompson",
-      "parentPhone": "0700 563207",
+      "parentPhone": "07905 563207",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2343,7 +2343,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "eufemia.fritsch92@gmail.com",
-          "parentPhone": "0725 506 7178",
+          "parentPhone": "0735 506 7178",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2371,7 +2371,7 @@
       ],
       "parentEmail": "eufemia.fritsch92@gmail.com",
       "parentName": "Eufemia Fritsch",
-      "parentPhone": "0725 506 7178",
+      "parentPhone": "0735 506 7178",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2390,7 +2390,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "hubert.effertz40@gmail.com",
-          "parentPhone": "0721 286 8143",
+          "parentPhone": "0731 286 8143",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2418,7 +2418,7 @@
       ],
       "parentEmail": "hubert.effertz40@gmail.com",
       "parentName": "Hubert Effertz",
-      "parentPhone": "0721 286 8143",
+      "parentPhone": "0731 286 8143",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2484,7 +2484,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "anissa.kling28@gmail.com",
-          "parentPhone": "0700 216 9397",
+          "parentPhone": "0790 216 9397",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2512,7 +2512,7 @@
       ],
       "parentEmail": "anissa.kling28@gmail.com",
       "parentName": "Anissa Kling",
-      "parentPhone": "0700 216 9397",
+      "parentPhone": "0790 216 9397",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2578,7 +2578,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "danyell.shanahan28@gmail.com",
-          "parentPhone": "0720 411 6797",
+          "parentPhone": "0730 411 6797",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2606,7 +2606,7 @@
       ],
       "parentEmail": "danyell.shanahan28@gmail.com",
       "parentName": "Danyell Shanahan",
-      "parentPhone": "0720 411 6797",
+      "parentPhone": "0730 411 6797",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2672,7 +2672,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "georgene.mclaughlin92@gmail.com",
-          "parentPhone": "076 9268 3924",
+          "parentPhone": "077 9268 3924",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2700,7 +2700,7 @@
       ],
       "parentEmail": "georgene.mclaughlin92@gmail.com",
       "parentName": "Georgene McLaughlin",
-      "parentPhone": "076 9268 3924",
+      "parentPhone": "077 9268 3924",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2719,7 +2719,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "audry.spencer29@gmail.com",
-          "parentPhone": "0700 582853",
+          "parentPhone": "07901 582853",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -2747,7 +2747,7 @@
       ],
       "parentEmail": "audry.spencer29@gmail.com",
       "parentName": "Audry Spencer",
-      "parentPhone": "0700 582853",
+      "parentPhone": "07901 582853",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -2932,7 +2932,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "mika.schmitt97@gmail.com",
-          "parentPhone": "0700 900360",
+          "parentPhone": "07902 900360",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction",
@@ -2960,7 +2960,7 @@
       ],
       "parentEmail": "mika.schmitt97@gmail.com",
       "parentName": "Mika Schmitt",
-      "parentPhone": "0700 900360",
+      "parentPhone": "07902 900360",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -3034,7 +3034,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "alysia.hamill60@gmail.com",
-          "parentPhone": "0767 306 2518",
+          "parentPhone": "0777 306 2518",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -3062,7 +3062,7 @@
       ],
       "parentEmail": "alysia.hamill60@gmail.com",
       "parentName": "Alysia Hamill",
-      "parentPhone": "0767 306 2518",
+      "parentPhone": "0777 306 2518",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -3238,7 +3238,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "donnie.gibson82@gmail.com",
-          "parentPhone": "0761 763 3910",
+          "parentPhone": "0771 763 3910",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -3266,7 +3266,7 @@
       ],
       "parentEmail": "donnie.gibson82@gmail.com",
       "parentName": "Donnie Gibson",
-      "parentPhone": "0761 763 3910",
+      "parentPhone": "0771 763 3910",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -3289,7 +3289,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "darnell.prosacco53@gmail.com",
-          "parentPhone": "076 8871 9091",
+          "parentPhone": "077 8871 9091",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -3317,7 +3317,7 @@
       ],
       "parentEmail": "darnell.prosacco53@gmail.com",
       "parentName": "Darnell Prosacco",
-      "parentPhone": "076 8871 9091",
+      "parentPhone": "077 8871 9091",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -3442,7 +3442,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "winnifred.wiza45@gmail.com",
-          "parentPhone": "0700 231067",
+          "parentPhone": "07906 231067",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -3470,7 +3470,7 @@
       ],
       "parentEmail": "winnifred.wiza45@gmail.com",
       "parentName": "Winnifred Wiza",
-      "parentPhone": "0700 231067",
+      "parentPhone": "07906 231067",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -3595,7 +3595,7 @@
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentEmail": "rachell.hayes37@gmail.com",
-          "parentPhone": "076 5225 1557",
+          "parentPhone": "077 5225 1557",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -3623,7 +3623,7 @@
       ],
       "parentEmail": "rachell.hayes37@gmail.com",
       "parentName": "Rachell Hayes",
-      "parentPhone": "076 5225 1557",
+      "parentPhone": "077 5225 1557",
       "parentRelationship": "mother",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",
@@ -3646,7 +3646,7 @@
           "parentRelationship": "father",
           "parentRelationshipOther": null,
           "parentEmail": "trevor.powlowski58@gmail.com",
-          "parentPhone": "07740 86151",
+          "parentPhone": "07740 486151",
           "healthQuestionResponses": [
             {
               "question": "Does the child have any severe allergies that have led to an anaphylactic reaction?",
@@ -3674,7 +3674,7 @@
       ],
       "parentEmail": "trevor.powlowski58@gmail.com",
       "parentName": "Trevor Powlowski",
-      "parentPhone": "07740 86151",
+      "parentPhone": "07740 486151",
       "parentRelationship": "father",
       "parentRelationshipOther": null,
       "parentInfoSource": "school",

--- a/spec/models/concerns/patient_session_state_machine_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_machine_concern_spec.rb
@@ -48,10 +48,12 @@ RSpec.describe PatientSessionStateMachineConcern do
     before do
       allow(consent).to receive(:response_given?).and_return(false)
       allow(consent).to receive(:response_refused?).and_return(false)
+      allow(consent).to receive(:response_not_provided?).and_return(false)
       allow(consent).to receive(:triage_needed?).and_return(false)
 
       allow(other_consent).to receive(:response_given?).and_return(false)
       allow(other_consent).to receive(:response_refused?).and_return(false)
+      allow(other_consent).to receive(:response_not_provided?).and_return(false)
       allow(other_consent).to receive(:triage_needed?).and_return(false)
     end
 

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -17,10 +17,10 @@ test("Consent - No response", async ({ page }) => {
   await then_i_see_the_consent_responses_page();
 
   await when_i_select_a_child_with_no_consent_response();
-  await and_i_click_get_consent();
-  await then_the_consent_form_is_prepopulated();
+  await then_i_see_the_previous_attempt_to_get_consent();
 
   // Consent - With response
+  await when_i_click_get_consent();
   await when_i_submit_a_consent_with_a_response();
   await then_i_see_the_consent_responses_page();
   await and_i_see_the_consent_has_been_saved();
@@ -48,6 +48,10 @@ async function when_i_click_get_consent() {
 }
 const and_i_click_get_consent = when_i_click_get_consent;
 
+async function then_i_see_the_previous_attempt_to_get_consent() {
+  await expect(p.getByText(/Not provided.*phone/)).toBeVisible();
+}
+
 async function when_i_submit_a_consent_with_no_response() {
   // Who
   await p.fill('[name="consent[parent_name]"]', fixtures.parentName);
@@ -74,8 +78,6 @@ async function and_i_see_the_consent_has_been_saved() {
 }
 
 async function when_i_submit_a_consent_with_a_response() {
-  await p.getByRole("button", { name: "Continue" }).click();
-
   // Do they agree
   await p.getByRole("radio", { name: "Yes, they agree" }).click();
   await p.getByRole("button", { name: "Continue" }).click();
@@ -99,16 +101,6 @@ async function when_i_submit_a_consent_with_a_response() {
 async function then_the_consent_form_is_prefilled() {
   await expect(p.locator('[name="consent[parent_name]"]')).not.toBeEmpty();
   await expect(p.locator('[name="consent[parent_phone]"]')).not.toBeEmpty();
-}
-
-async function then_the_consent_form_is_prepopulated() {
-  await expect(p.locator('[name="consent[parent_name]"]')).toHaveValue(
-    fixtures.parentName,
-  );
-  await expect(p.locator('[name="consent[parent_phone]"]')).toHaveValue(
-    "07700900000",
-  );
-  await expect(p.locator("text=Mum")).toBeChecked();
 }
 
 async function when_i_go_to_the_triage_completed_tab() {


### PR DESCRIPTION
Previously, we would save these as a draft consent record with no recorded_at. Attempting to submit another consent later would surface the details and you'd be able to continue.

Instead, we want to display the consent records in the consent card. The patient session should stay in the same state ("Added to session") when handling consent in this way.

The design isn't final but the functionality is there to test.

<img width="870" alt="Screenshot 2023-12-11 at 17 48 29" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/33343e64-23a7-49ab-bc20-9c0e9805dcf7">

