### PR TITLE
Add more memory to the webapp cluster

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -23,7 +23,7 @@ image:
 
 platform: linux/x86_64
 cpu: 256 # Number of CPU units for the task.
-memory: 512 # Amount of memory in MiB used by the task.
+memory: 1024 # Amount of memory in MiB used by the task.
 count: 1 # Number of tasks that should be running in your service.
 exec: true # Enable running commands in your container.
 network:


### PR DESCRIPTION
Adding more memory for the webapp cluster so the IRB console can be accessed without crashing the app.