### PR TITLE
Add ManageConsentsController

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -41,7 +41,9 @@
   <p>
     <%= govuk_button_link_to(
       "Get consent",
-      new_session_patient_nurse_consents_path(session, patient, @route)
+      Flipper.enabled?(:new_consents) ?
+        session_patient_manage_consent_path(session, patient, @route, :who) :
+        new_session_patient_nurse_consents_path(session, patient, @route)
     ) %>
 
     <% if display_gillick_consent_button? %>

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -8,7 +8,13 @@ class DevController < ApplicationController
     ActiveRecord::Base.connection.transaction do
       data_tables =
         ActiveRecord::Base.connection.tables -
-          %w[users schema_migrations ar_internal_metadata]
+          %w[
+            users
+            schema_migrations
+            ar_internal_metadata
+            flipper_features
+            flipper_gates
+          ]
       data_tables.each do |table|
         ActiveRecord::Base.connection.execute(
           "TRUNCATE #{table} RESTART IDENTITY CASCADE"

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -1,0 +1,33 @@
+class ManageConsentsController < ApplicationController
+  include Wicked::Wizard
+  include Wicked::Wizard::Translated # For custom URLs, see en.yml wicked
+
+  layout "two_thirds"
+
+  before_action :set_consent
+  before_action :set_steps
+  before_action :setup_wizard_translated
+
+  def show
+    render_wizard
+  end
+
+  def update
+    render_wizard @consent
+  end
+
+  private
+
+  def current_step
+    wizard_value(step).to_sym
+  end
+
+  def set_consent
+    @consent = Consent.find_or_initialize_by(id: params[:consent_id])
+  end
+
+  def set_steps
+    # self.steps = @consent.form_steps
+    self.steps = %i[who]
+  end
+end

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -1,0 +1,1 @@
+<%= h1 "Who are you trying to get consent from?", class: "govuk-heading-l" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
     gp: "gp"
     address: "address"
     health_question: "health-question"
+    who: "who"
   consent_form_mailer:
     reasons_for_refusal:
       contains_gelatine: "of the gelatine in the nasal spray"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,19 +71,27 @@ Rails.application.routes.draw do
         get "record-template", on: :collection
       end
 
-      resource :nurse_consents, path: ":route/consent" do
-        get "assessing-gillick", to: "nurse_consents#assessing_gillick"
+      constraints -> { Flipper.enabled?(:new_consents) } do
+        resources :manage_consents,
+                  only: %i[show update],
+                  path: ":route/consents"
+      end
 
-        get "edit/gillick", to: "nurse_consents#edit_gillick"
-        put "update/gillick", to: "nurse_consents#update_gillick"
+      constraints -> { !Flipper.enabled?(:new_consents) } do
+        resource :nurse_consents, path: ":route/consent" do
+          get "assessing-gillick", to: "nurse_consents#assessing_gillick"
 
-        get "edit/who", to: "nurse_consents#edit_who"
-        get "edit/agree", to: "nurse_consents#edit_consent"
-        get "edit/reason", to: "nurse_consents#edit_reason"
-        get "edit/questions", to: "nurse_consents#edit_questions"
-        get "edit/confirm", to: "nurse_consents#edit_confirm"
+          get "edit/gillick", to: "nurse_consents#edit_gillick"
+          put "update/gillick", to: "nurse_consents#update_gillick"
 
-        put "record"
+          get "edit/who", to: "nurse_consents#edit_who"
+          get "edit/agree", to: "nurse_consents#edit_consent"
+          get "edit/reason", to: "nurse_consents#edit_reason"
+          get "edit/questions", to: "nurse_consents#edit_questions"
+          get "edit/confirm", to: "nurse_consents#edit_confirm"
+
+          put "record"
+        end
       end
     end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,7 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+FEATURE_FLAGS = %i[make_session_in_progress_button new_consents].freeze
+
+FEATURE_FLAGS.each { |flag| Flipper.add(flag) unless Flipper.exist?(flag) }


### PR DESCRIPTION
This is the start of a Wicked rewrite of the NurseConsentsController. The new controller is hidden behind a feature flag and will be built piecemeal, in parallel to the old one.

This first PR implements a stubbed version of the first step (`/consents/who`) as well as the surrounding feature flagging machinery and route. Following PRs will implement the next steps in order.

There are no tests for this, as the intention is to reuse the existing `nurse_consents_*` tests, once the flow is working end to end, to prove that the new implementation is functionally identical to the old.

Review without significant whitespace for the changes to the `routes.rb`.