### PR TITLE
Update manage_consents#who template

### DIFF
--- a/app/components/app_consent_component.html.erb
+++ b/app/components/app_consent_component.html.erb
@@ -39,12 +39,17 @@
   end %>
 <% else %>
   <p>
-    <%= govuk_button_link_to(
-      "Get consent",
-      Flipper.enabled?(:new_consents) ?
-        session_patient_manage_consent_path(session, patient, @route, :who) :
+    <% if Flipper.enabled?(:new_consents) %>
+      <%= govuk_button_to(
+        "Get consent",
+        session_patient_manage_consents_path(session, patient, @route)
+      ) %>
+    <% else %>
+      <%= govuk_button_link_to(
+        "Get consent",
         new_session_patient_nurse_consents_path(session, patient, @route)
-    ) %>
+      ) %>
+    <% end %>
 
     <% if display_gillick_consent_button? %>
       <%= govuk_button_link_to(

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -4,15 +4,31 @@ class ManageConsentsController < ApplicationController
 
   layout "two_thirds"
 
-  before_action :set_consent
-  before_action :set_steps
-  before_action :setup_wizard_translated
+  before_action :set_route
+  before_action :set_session
+  before_action :set_patient
+  before_action :set_consent, except: %i[create]
+  before_action :set_steps, except: %i[create]
+  before_action :setup_wizard_translated, except: %i[create]
+
+  def create
+    consent =
+      Consent.create!(
+        patient: @patient,
+        campaign: @session.campaign,
+        route: "phone"
+      )
+
+    redirect_to action: :show, id: :who, consent_id: consent.id
+  end
 
   def show
     render_wizard
   end
 
   def update
+    @consent.assign_attributes(update_params)
+
     render_wizard @consent
   end
 
@@ -22,8 +38,36 @@ class ManageConsentsController < ApplicationController
     wizard_value(step).to_sym
   end
 
+  def set_route
+    @route = params[:route]
+  end
+
+  def set_session
+    @session = Session.find(params.fetch(:session_id))
+  end
+
+  def set_patient
+    @patient = @session.patients.find(params.fetch(:patient_id))
+  end
+
   def set_consent
-    @consent = Consent.find_or_initialize_by(id: params[:consent_id])
+    @consent = Consent.find(params[:consent_id])
+  end
+
+  def update_params
+    permitted_attributes = {
+      who: %i[
+        parent_name
+        parent_phone
+        parent_relationship
+        parent_relationship_other
+      ]
+    }.fetch(current_step)
+
+    params
+      .fetch(:consent, {})
+      .permit(permitted_attributes)
+      .merge(form_step: current_step)
   end
 
   def set_steps

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -27,7 +27,6 @@ class ManageConsentsController < ApplicationController
   end
 
   def set_steps
-    # self.steps = @consent.form_steps
-    self.steps = %i[who]
+    self.steps = @consent.form_steps
   end
 end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -64,37 +64,38 @@ class Consent < ApplicationRecord
   enum :gp_response, %w[yes no dont_know]
   enum :route, %i[website phone paper in_person self_consent], prefix: "via"
 
-  validates :parent_name, presence: true, on: :edit_who
-  validates :parent_phone, presence: true, on: :edit_who
-  validates :parent_phone, phone_number: true, on: :edit_who
-  validates :parent_relationship,
-            inclusion: {
-              in: parent_relationships.keys
-            },
-            presence: true,
-            on: :edit_who
-  validates :parent_relationship_other,
-            presence: true,
-            if: -> { parent_relationship == "other" },
-            on: :edit_who
+  with_options on: :edit_who do
+    validates :parent_name, presence: true
+    validates :parent_phone, presence: true
+    validates :parent_phone, phone_number: true
+    validates :parent_relationship,
+              inclusion: {
+                in: Consent.parent_relationships.keys
+              },
+              presence: true
+    validates :parent_relationship_other,
+              presence: true,
+              if: -> { parent_relationship == "other" }
+  end
 
-  validates :response,
-            inclusion: {
-              in: responses.keys
-            },
-            presence: true,
-            on: :edit_consent
+  with_options on: :edit_consent do
+    validates :response,
+              inclusion: {
+                in: Consent.responses.keys
+              },
+              presence: true
+  end
 
-  validates :reason_for_refusal,
-            inclusion: {
-              in: reason_for_refusals.keys
-            },
-            presence: true,
-            on: :edit_reason
-  validates :reason_for_refusal_other,
-            presence: true,
-            if: -> { reason_for_refusal == "other" },
-            on: :edit_reason
+  with_options on: :edit_reason do
+    validates :reason_for_refusal,
+              inclusion: {
+                in: Consent.reason_for_refusals.keys
+              },
+              presence: true
+    validates :reason_for_refusal_other,
+              presence: true,
+              if: -> { reason_for_refusal == "other" }
+  end
 
   def name
     via_self_consent? ? patient.full_name : parent_name

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -97,6 +97,10 @@ class Consent < ApplicationRecord
               if: -> { reason_for_refusal == "other" }
   end
 
+  def form_steps
+    %i[who]
+  end
+
   def name
     via_self_consent? ? patient.full_name : parent_name
   end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -99,6 +99,22 @@ class Consent < ApplicationRecord
               if: -> { reason_for_refusal == "other" }
   end
 
+  with_options on: :update do
+    with_options if: -> { required_for_step?(:who) } do
+      validates :parent_name, presence: true
+      validates :parent_phone, presence: true
+      validates :parent_phone, phone_number: true
+      validates :parent_relationship,
+                inclusion: {
+                  in: Consent.parent_relationships.keys
+                },
+                presence: true
+      validates :parent_relationship_other,
+                presence: true,
+                if: -> { parent_relationship == "other" }
+    end
+  end
+
   def form_steps
     %i[who]
   end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -44,6 +44,8 @@
 class Consent < ApplicationRecord
   audited
 
+  attr_accessor :form_step
+
   belongs_to :patient
   belongs_to :campaign
 
@@ -129,5 +131,23 @@ class Consent < ApplicationRecord
       reasons << "Health questions need triage"
     end
     reasons
+  end
+
+  private
+
+  def required_for_step?(step, exact: false)
+    # Exact means that the form_step must match the step
+    return false if exact && form_step != step
+
+    # Step can't be required if it's not in the current form_steps list
+    return false unless step.in?(form_steps)
+
+    # All fields are required if no form_step is set
+    return true if form_step.nil?
+
+    # Otherwise, all fields from previous and current steps are required
+    return true if form_steps.index(step) <= form_steps.index(form_step)
+
+    false
   end
 end

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -1,1 +1,48 @@
-<%= h1 "Who are you trying to get consent from?", class: "govuk-heading-l" %>
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: case @route
+      when 'consents'
+        session_patient_consents_path(@session, @patient)
+    end,
+    name: "patient page",
+  ) %>
+<% end %>
+
+<% page_title = "Who are you trying to get consent from?" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<%= form_for @consent, url: wizard_path, method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_text_field :parent_name, label: { text: 'Full name' } %>
+
+  <%= f.govuk_text_field :parent_phone, label: { text: 'Phone number' } %>
+
+  <%= f.govuk_radio_buttons_fieldset(:parent_relationship,
+    legend: { size: 's',
+              text: 'Relationship to the child' }) do %>
+    <%= f.govuk_radio_button :parent_relationship, "mother",
+      label: { text: 'Mum' }, link_errors: true %>
+    <%= f.govuk_radio_button :parent_relationship, "father",
+      label: { text: "Dad" } %>
+    <%= f.govuk_radio_button :parent_relationship, "guardian",
+      label: { text: 'Guardian' } %>
+    <%= f.govuk_radio_button :parent_relationship, "other",
+      label: { text: 'Other' } do %>
+      <p>They need parental responsibility to give consent.</p>
+      <%= f.govuk_text_field :parent_relationship_other,
+        label: { text: 'Relationship to the child' },
+        hint: { text: 'For example, carer' } %>
+    <% end %>
+  <% end %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit "Continue" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,9 +72,12 @@ Rails.application.routes.draw do
       end
 
       constraints -> { Flipper.enabled?(:new_consents) } do
+        post ":route/consents",
+             to: "manage_consents#create",
+             as: :manage_consents
         resources :manage_consents,
                   only: %i[show update],
-                  path: ":route/consents"
+                  path: ":route/consents/:consent_id/"
       end
 
       constraints -> { !Flipper.enabled?(:new_consents) } do

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -67,23 +67,51 @@ FactoryBot.define do
     end
 
     trait :consent_given_triage_not_needed do
-      consents { [create(:consent, :given, campaign:)] }
+      after(:create) do |patient, evaluator|
+        create(:consent, :given, campaign: evaluator.campaign, patient:)
+      end
     end
 
     trait :consent_given_triage_needed do
-      consents { [create(:consent, :given, :health_question_notes, campaign:)] }
+      after(:create) do |patient, evaluator|
+        create(
+          :consent,
+          :given,
+          :health_question_notes,
+          campaign: evaluator.campaign,
+          patient:
+        )
+      end
     end
 
     trait :consent_refused do
-      consents { [create(:consent, :refused, :from_mum, campaign:)] }
+      after(:create) do |patient, evaluator|
+        create(
+          :consent,
+          :refused,
+          :from_mum,
+          campaign: evaluator.campaign,
+          patient:
+        )
+      end
     end
 
     trait :consent_conflicting do
-      consents do
-        [
-          create(:consent, :refused, :from_mum, campaign:),
-          create(:consent, :given, :from_dad, campaign:)
-        ]
+      after(:create) do |patient, evaluator|
+        create(
+          :consent,
+          :refused,
+          :from_mum,
+          campaign: evaluator.campaign,
+          patient:
+        )
+        create(
+          :consent,
+          :given,
+          :from_dad,
+          campaign: evaluator.campaign,
+          patient:
+        )
       end
     end
 


### PR DESCRIPTION
This populates the first page of the new nurse consents journey and sets up the rest of the validations/machinery required to get the rest of the journey in.

One thing to note is that the journey now creates a Consent before the first step, in order to have an ID to allow editing of the consent on the following steps.

See commits.

### Screenshot

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/4c34eff2-c22f-48df-ba5f-4b87f10cf6a8)
