### PR TITLE
Add :confirm step to ManageConsent journey

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -27,7 +27,21 @@ class ManageConsentsController < ApplicationController
   end
 
   def update
-    @consent.assign_attributes(update_params)
+    if current_step == :confirm
+      # TODO: Handle the final step of the manage consent journey.
+      # Something like:
+      #
+      # ActiveRecord::Base.transaction do
+      #   @draft_consent.recorded_at = Time.zone.now
+      #   @draft_consent.save!(validate: false)
+      #   @patient_session.do_consent!
+      #   @patient_session.do_triage! if @patient_session.triage.present?
+      # end
+      #
+      # Plus a flash and redirect to the right location.
+    else
+      @consent.assign_attributes(update_params)
+    end
 
     render_wizard @consent
   end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -124,7 +124,7 @@ class Consent < ApplicationRecord
   end
 
   def form_steps
-    %i[who agree]
+    %i[who agree confirm].compact
   end
 
   def name

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -1,0 +1,50 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: previous_wizard_path,
+    name: "health questions page",
+  ) %>
+<% end %>
+
+<% page_title = "Check and confirm answers" %>
+
+<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @patient.full_name %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<% if @consent.via_self_consent? %>
+  <%= render AppGillickCardComponent.new(
+    consent: @consent,
+    patient_session: @patient_session) %>
+<% else %>
+  <%= render AppConsentCardComponent.new(
+    consent: @consent,
+    current_user:) %>
+<% end %>
+
+<% if @consent.response_given? %>
+  <%= render AppCardComponent.new(heading: "Health questions") do %>
+    <%= render AppHealthQuestionsComponent.new(
+      consents: [@consent]) %>
+  <% end %>
+<% end %>
+
+<% if @consent.response_given? && @draft_triage.status.present? %>
+  <%= render AppCardComponent.new(heading: "Triage") do %>
+    <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { "Status" }
+        row.with_value { @draft_triage.status.humanize }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Triage notes" }
+        row.with_value { @draft_triage.notes.presence || "No notes" }
+      end
+    end %>
+  <% end %>
+<% end %>
+
+<%= govuk_button_to "Confirm", wizard_path, method: :put %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
     # Consent
     who: "who"
     agree: "agree"
+    confirm: "confirm"
   consent_form_mailer:
     reasons_for_refusal:
       contains_gelatine: "of the gelatine in the nasal spray"


### PR DESCRIPTION
Implements a streamlined version of the edit_confirm page from the old journey.

![Screenshot 2023-12-19 at 11 47 13](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/2f185589-6e1c-4cd0-97cb-20434d92c71b)
