### PR TITLE
Move feature initialization from seeds

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,8 @@
+if Rails.env.test?
+  require "flipper/adapters/memory"
+  require "flipper"
+
+  Flipper.configure do |config|
+    config.default { Flipper.new(Flipper::Adapters::Memory.new) }
+  end
+end


### PR DESCRIPTION
We were getting warnings pop up during tests after a database reset (rails db:reset). This approach appears to remove the warnings when testing.
