### PR TITLE
Successfully submit consent in ManageConsents journey

### DIFF
--- a/app/components/app_health_questions_component.rb
+++ b/app/components/app_health_questions_component.rb
@@ -14,10 +14,11 @@ class AppHealthQuestionsComponent < ViewComponent::Base
     </dl>
   ERB
 
-  def initialize(consents:)
+  def initialize(consents:, use_health_answers: false)
     super
 
     @consents = consents
+    @use_health_answers = use_health_answers
   end
 
   def health_questions
@@ -34,7 +35,19 @@ class AppHealthQuestionsComponent < ViewComponent::Base
     # }
     dict =
       @consents.each_with_object({}) do |consent, acc|
-        consent.health_questions.each do |health_question|
+        questions =
+          if @use_health_answers
+            consent.health_answers.map do |health_answer|
+              {
+                "question" => health_answer.question,
+                "response" => health_answer.response,
+                "notes" => health_answer.notes
+              }
+            end
+          else
+            consent.health_questions
+          end
+        questions.each do |health_question|
           question = health_question["question"]
           response = health_question["response"]
           notes = health_question["notes"]

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -10,7 +10,9 @@ class ManageConsentsController < ApplicationController
   before_action :set_consent, except: %i[create]
   before_action :set_steps, except: %i[create]
   before_action :setup_wizard_translated, except: %i[create]
-  before_action :set_triage, except: %i[create], if: -> { step == "questions" }
+  before_action :set_triage,
+                except: %i[create],
+                if: -> { step.in?(%w[questions confirm]) }
 
   def create
     consent =

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -68,6 +68,28 @@ class ManageConsentsController < ApplicationController
     wizard_value(step).to_sym
   end
 
+  def finish_wizard_path
+    redirect_path =
+      case @route
+      when "consents"
+        consents_session_path(@session)
+      when "triage"
+        triage_session_path(@session)
+      else
+        vaccinations_session_path(@session)
+      end
+
+    flash[:success] = {
+      heading: "Record saved for #{@patient.full_name}",
+      body:
+        ActionController::Base.helpers.link_to(
+          "View child record",
+          session_patient_triage_path(@session, @patient)
+        )
+    }
+    redirect_path
+  end
+
   def set_route
     @route = params[:route]
   end

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -45,7 +45,7 @@
 class Consent < ApplicationRecord
   audited
 
-  attr_accessor :form_step
+  attr_accessor :form_step, :triage
 
   belongs_to :patient
   belongs_to :campaign
@@ -139,6 +139,10 @@ class Consent < ApplicationRecord
     with_options if: -> { required_for_step?(:questions) } do
       validate :health_answers_valid?
     end
+
+    with_options if: -> { required_for_step?(:questions, exact: true) } do
+      validate :triage_valid?
+    end
   end
 
   def form_steps
@@ -193,6 +197,12 @@ class Consent < ApplicationRecord
         end
       end
     end
+  end
+
+  def triage_valid?
+    return if triage.valid?(:consent)
+
+    errors.add(:triage_status, triage.errors.messages[:status].first)
   end
 
   def required_for_step?(step, exact: false)

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -31,17 +31,17 @@
   <% end %>
 <% end %>
 
-<% if @consent.response_given? && @draft_triage.status.present? %>
+<% if @consent.response_given? && @triage.status.present? %>
   <%= render AppCardComponent.new(heading: "Triage") do %>
     <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|
       summary_list.with_row do |row|
         row.with_key { "Status" }
-        row.with_value { @draft_triage.status.humanize }
+        row.with_value { @triage.status.humanize }
       end
 
       summary_list.with_row do |row|
         row.with_key { "Triage notes" }
-        row.with_value { @draft_triage.notes.presence || "No notes" }
+        row.with_value { @triage.notes.presence || "No notes" }
       end
     end %>
   <% end %>

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -27,7 +27,9 @@
 <% if @consent.response_given? %>
   <%= render AppCardComponent.new(heading: "Health questions") do %>
     <%= render AppHealthQuestionsComponent.new(
-      consents: [@consent]) %>
+      consents: [@consent],
+      use_health_answers: true,
+    ) %>
   <% end %>
 <% end %>
 

--- a/app/views/manage_consents/questions.html.erb
+++ b/app/views/manage_consents/questions.html.erb
@@ -37,8 +37,6 @@
   <hr class="nhsuk-section-break nhsuk-section-break--l nhsuk-section-break--visible">
 
   <%= f.fields_for @triage do |ff| %>
-    <% content_for(:before_content) { ff.govuk_error_summary } %>
-
     <%= ff.govuk_collection_radio_buttons :status,
      triage_form_status_options,
      :first,

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -3,7 +3,11 @@
     href: case @route
       when 'consents'
         session_patient_consents_path(@session, @patient)
-    end,
+      when "triage"
+        session_patient_triage_path(@session)
+      else
+        session_patient_vaccinations_path(@session)
+      end,
     name: "patient page",
   ) %>
 <% end %>


### PR DESCRIPTION
This completes the end to end ManageConsent journey.

Gillick competence is next to do in a follow-up, and then we can flip the feature flag and run the tests against the new journey to see what else needs aligning.