### PR TITLE
Enable :new_consents

### DIFF
--- a/app/components/app_health_questions_component.rb
+++ b/app/components/app_health_questions_component.rb
@@ -14,11 +14,10 @@ class AppHealthQuestionsComponent < ViewComponent::Base
     </dl>
   ERB
 
-  def initialize(consents:, use_health_answers: false)
+  def initialize(consents:)
     super
 
     @consents = consents
-    @use_health_answers = use_health_answers
   end
 
   def health_questions
@@ -35,22 +34,10 @@ class AppHealthQuestionsComponent < ViewComponent::Base
     # }
     dict =
       @consents.each_with_object({}) do |consent, acc|
-        questions =
-          if @use_health_answers
-            consent.health_answers.map do |health_answer|
-              {
-                "question" => health_answer.question,
-                "response" => health_answer.response,
-                "notes" => health_answer.notes
-              }
-            end
-          else
-            consent.health_questions
-          end
-        questions.each do |health_question|
-          question = health_question["question"]
-          response = health_question["response"]
-          notes = health_question["notes"]
+        consent.health_answers.each do |health_question|
+          question = health_question.question
+          response = health_question.response
+          notes = health_question.notes
 
           formatted_answer = response.humanize
           formatted_answer += " – #{notes}" if notes.present?

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -47,6 +47,17 @@ class ManageConsentsController < ApplicationController
           @patient_session.do_consent!
         end
       end
+    when :agree
+      response_was_given = @consent.response_given?
+      @consent.assign_attributes(update_params)
+
+      if !response_was_given && @consent.response_given?
+        @consent.health_answers = @session.health_questions.to_health_answers
+        @consent.reason_for_refusal = nil
+      elsif response_was_given && !@consent.response_given?
+        @consent.health_answers = []
+        @consent.reason_for_refusal = nil
+      end
     when :gillick
       @patient_session.update! gillick_params
 

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -26,10 +26,7 @@
 
 <% if @consent.response_given? %>
   <%= render AppCardComponent.new(heading: "Health questions") do %>
-    <%= render AppHealthQuestionsComponent.new(
-      consents: [@consent],
-      use_health_answers: true,
-    ) %>
+    <%= render AppHealthQuestionsComponent.new(consents: [@consent]) %>
   <% end %>
 <% end %>
 

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,8 +1,12 @@
 if Rails.env.test?
-  require "flipper/adapters/memory"
+  require "flipper/adapters/pstore"
   require "flipper"
 
   Flipper.configure do |config|
-    config.default { Flipper.new(Flipper::Adapters::Memory.new) }
+    config.default do
+      Flipper.new(Flipper::Adapters::PStore.new("tmp/flipper.test.pstore"))
+    end
   end
+
+  Flipper.enable :new_consents
 end

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe AppConsentComponent, type: :component do
     it { should_not have_css("details", text: /Consent (given|refused) by/) }
     it { should_not have_css("details", text: "Responses to health questions") }
     it { should have_css("p", text: "No response yet") }
-    it { should have_css("a", text: "Get consent") }
-    it { should have_css("a", text: "Assess Gillick competence") }
+    it { should have_css("button", text: "Get consent") }
+    it { should have_css("button", text: "Assess Gillick competence") }
   end
 
   context "consent is refused" do

--- a/spec/components/app_health_questions_component_spec.rb
+++ b/spec/components/app_health_questions_component_spec.rb
@@ -14,9 +14,13 @@ RSpec.describe AppHealthQuestionsComponent, type: :component do
           :consent,
           :given,
           :from_mum,
-          health_questions: [
-            { question: "First question?", response: "no" },
-            { question: "Second question?", response: "yes", notes: "Notes" }
+          health_answers: [
+            HealthAnswer.new(question: "First question?", response: "no"),
+            HealthAnswer.new(
+              question: "Second question?",
+              response: "yes",
+              notes: "Notes"
+            )
           ]
         )
       ]
@@ -33,18 +37,22 @@ RSpec.describe AppHealthQuestionsComponent, type: :component do
           :consent,
           :given,
           :from_mum,
-          health_questions: [
-            { question: "First question?", response: "no" },
-            { question: "Second question?", response: "no" }
+          health_answers: [
+            HealthAnswer.new(question: "First question?", response: "no"),
+            HealthAnswer.new(question: "Second question?", response: "no")
           ]
         ),
         create(
           :consent,
           :given,
           :from_dad,
-          health_questions: [
-            { question: "First question?", response: "no" },
-            { question: "Second question?", response: "yes", notes: "Notes" }
+          health_answers: [
+            HealthAnswer.new(question: "First question?", response: "no"),
+            HealthAnswer.new(
+              question: "Second question?",
+              response: "yes",
+              notes: "Notes"
+            )
           ]
         )
       ]
@@ -65,9 +73,9 @@ RSpec.describe AppHealthQuestionsComponent, type: :component do
           :consent,
           :given,
           :from_mum,
-          health_questions: [
-            { question: "First question?", response: "no" },
-            { question: "Second question?", response: "no" }
+          health_answers: [
+            HealthAnswer.new(question: "First question?", response: "no"),
+            HealthAnswer.new(question: "Second question?", response: "no")
           ]
         ),
         create(:consent, :refused, :from_dad)

--- a/tests/full_journey.spec.ts
+++ b/tests/full_journey.spec.ts
@@ -50,7 +50,7 @@ async function then_i_see_there_is_no_response() {
 async function given_i_call_the_parent_and_receive_consent() {}
 
 async function when_i_record_the_consent_given() {
-  await p.getByRole("link", { name: "Get consent" }).click();
+  await p.getByRole("button", { name: "Get consent" }).click();
   await p.fill('[name="consent[parent_name]"]', fixtures.parentName);
   await p.fill('[name="consent[parent_phone]"]', "07700900000");
   await p.getByRole("radio", { name: fixtures.parentRole }).click();

--- a/tests/nurse_consent_during_vaccination.spec.ts
+++ b/tests/nurse_consent_during_vaccination.spec.ts
@@ -16,7 +16,7 @@ test("Records consent and then allows vaccination", async ({ page }) => {
   await then_i_see_the_new_consent_form();
 
   await when_i_go_through_the_consent_and_triage_forms();
-  await then_i_see_the_vaccination_form();
+  await then_i_see_the_vaccinations_page();
 });
 
 async function given_the_app_is_setup() {
@@ -80,6 +80,6 @@ async function when_i_go_through_the_consent_and_triage_forms() {
   await p.getByRole("button", { name: "Confirm" }).click();
 }
 
-async function then_i_see_the_vaccination_form() {
-  expect(await p.innerText("h1")).toContain("Did they get the vaccine?");
+async function then_i_see_the_vaccinations_page() {
+  expect(await p.innerText("h1")).toContain("Record vaccinations");
 }

--- a/tests/nurse_consent_during_vaccination.spec.ts
+++ b/tests/nurse_consent_during_vaccination.spec.ts
@@ -43,10 +43,6 @@ async function when_i_click_yes_i_am_contacting_a_parent() {
   await p.click("text=Get consent");
 }
 
-async function and_i_click_continue() {
-  await p.click("text=Continue");
-}
-
 async function then_i_see_the_new_consent_form() {
   expect(await p.innerText("h1")).toContain(
     "Who are you trying to get consent from?",

--- a/tests/nurse_consent_gillick.spec.ts
+++ b/tests/nurse_consent_gillick.spec.ts
@@ -35,7 +35,7 @@ test("Records gillick consent", async ({ page }) => {
   await and_it_contains_gillick_assessment_details();
 
   await when_i_click_confirm();
-  await then_i_see_the_vaccination_new_page();
+  await then_i_see_the_vaccination_index_page();
 
   // Not Gillick competent
   await when_i_go_to_the_vaccinations_page();
@@ -158,6 +158,6 @@ async function and_i_triage_the_patient() {
   await p.getByRole("radio", { name: "Yes, it's safe to vaccinate" }).click();
 }
 
-async function then_i_see_the_vaccination_new_page() {
-  await expect(p.locator("h1")).toContainText("Did they get the vaccine?");
+async function then_i_see_the_vaccination_index_page() {
+  await expect(p.locator("h1")).toContainText("Record vaccinations");
 }

--- a/tests/nurse_consent_gillick_refused.spec.ts
+++ b/tests/nurse_consent_gillick_refused.spec.ts
@@ -81,6 +81,6 @@ async function when_i_record_that_they_dont_agree() {
 
 async function then_i_see_a_banner_showing_the_gillick_assessment_was_saved() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
-    "Gillick assessment saved",
+    "Record saved",
   );
 }

--- a/tests/nurse_consent_gillick_refused.spec.ts
+++ b/tests/nurse_consent_gillick_refused.spec.ts
@@ -46,7 +46,7 @@ async function then_i_see_the_no_consent_banner() {
 }
 
 async function when_i_select_that_i_am_assessing_gillick_competence() {
-  await p.getByRole("link", { name: "Assess Gillick competence" }).click();
+  await p.getByRole("button", { name: "Assess Gillick competence" }).click();
   await p.getByRole("button", { name: "Give your assessment" }).click();
 }
 

--- a/tests/nurse_consent_gillick_validations.spec.ts
+++ b/tests/nurse_consent_gillick_validations.spec.ts
@@ -26,7 +26,7 @@ async function given_i_am_assessing_a_child_for_gillick_competence() {
   await p.getByRole("tab", { name: "Action needed" }).click();
   await p.getByRole("link", { name: fixtures.patientThatNeedsConsent }).click();
 
-  await p.getByRole("link", { name: "Assess Gillick competence" }).click();
+  await p.getByRole("button", { name: "Assess Gillick competence" }).click();
 
   await p.getByRole("button", { name: "Give your assessment" }).click();
 }

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -44,7 +44,7 @@ async function when_i_select_a_child_with_no_consent_response() {
 }
 
 async function when_i_click_get_consent() {
-  await p.getByRole("link", { name: "Get consent" }).click();
+  await p.getByText("Get consent").click();
 }
 const and_i_click_get_consent = when_i_click_get_consent;
 

--- a/tests/nurse_consent_refused.spec.ts
+++ b/tests/nurse_consent_refused.spec.ts
@@ -39,7 +39,7 @@ async function when_i_select_a_child_with_no_consent_response() {
 }
 
 async function when_i_click_get_consent() {
-  await p.getByRole("link", { name: "Get consent" }).click();
+  await p.getByRole("button", { name: "Get consent" }).click();
 }
 const and_i_click_get_consent = when_i_click_get_consent;
 

--- a/tests/nurse_consent_refused_validations.spec.ts
+++ b/tests/nurse_consent_refused_validations.spec.ts
@@ -29,7 +29,7 @@ async function given_i_am_on_the_reasons_for_consent_refusal_page() {
   await p.goto("/sessions/1/consents");
   await p.getByRole("tab", { name: "No response" }).click();
   await p.getByRole("link", { name: fixtures.patientThatNeedsConsent }).click();
-  await p.getByRole("link", { name: "Get consent" }).click();
+  await p.getByRole("button", { name: "Get consent" }).click();
 
   await p.fill('[name="consent[parent_name]"]', "Carl Sipes");
   await p.fill('[name="consent[parent_phone]"]', "07700900000");

--- a/tests/nurse_consent_validations.spec.ts
+++ b/tests/nurse_consent_validations.spec.ts
@@ -43,7 +43,7 @@ async function given_i_am_on_the_who_am_i_contacting_for_consent_page() {
   await p.goto("/sessions/1/consents");
   await p.getByRole("tab", { name: "No response" }).click();
   await p.getByRole("link", { name: fixtures.patientThatNeedsConsent }).click();
-  await p.getByRole("link", { name: "Get consent" }).click();
+  await p.getByRole("button", { name: "Get consent" }).click();
 }
 
 async function then_the_page_is_prefilled_with_the_parent_details() {


### PR DESCRIPTION
Depends on https://github.com/nhsuk/manage-childrens-vaccinations/pull/763.

Switches to the new `ManageConsents` journey and `health_answers` for handling all nurse-facing consent flows. Updates the tests where necessary.

See commits.