### PR TITLE
Generate unmatched example consent forms

### DIFF
--- a/db/sample_data/example-flu-campaign.json
+++ b/db/sample_data/example-flu-campaign.json
@@ -17,16 +17,16 @@
       "method": "nasal",
       "batches": [
         {
-          "name": "XD7699",
-          "expiry": "2024-06-08"
+          "name": "ST4683",
+          "expiry": "2024-06-17"
         },
         {
-          "name": "QB8526",
-          "expiry": "2024-06-06"
+          "name": "RS6443",
+          "expiry": "2024-05-19"
         },
         {
-          "name": "GW7331",
-          "expiry": "2024-05-13"
+          "name": "HK4533",
+          "expiry": "2024-04-25"
         }
       ]
     }
@@ -110,7 +110,7 @@
         {
           "firstName": "Kayleigh",
           "lastName": "O'Hara",
-          "dob": "2016-10-09",
+          "dob": "2016-10-15",
           "nhsNumber": 4915024059,
           "consents": [
             {
@@ -177,7 +177,7 @@
         {
           "firstName": "Particia",
           "lastName": "Brown",
-          "dob": "2018-03-06",
+          "dob": "2018-03-12",
           "nhsNumber": 4441048041,
           "consents": [
             {
@@ -296,7 +296,7 @@
         {
           "firstName": "Zenaida",
           "lastName": "Powlowski",
-          "dob": "2018-03-14",
+          "dob": "2018-03-20",
           "nhsNumber": 4174128626,
           "consents": [
 
@@ -312,7 +312,7 @@
         {
           "firstName": "Deborah",
           "lastName": "Kreiger",
-          "dob": "2018-03-15",
+          "dob": "2018-03-21",
           "nhsNumber": 4111525369,
           "consents": [
 
@@ -328,35 +328,10 @@
         {
           "firstName": "Celinda",
           "lastName": "Hartmann",
-          "dob": "2016-06-05",
+          "dob": "2016-06-11",
           "nhsNumber": 4929466857,
           "consents": [
-            {
-              "response": "refused",
-              "reasonForRefusal": "medical",
-              "parentName": "German Hartmann",
-              "parentRelationship": "father",
-              "parentRelationshipOther": null,
-              "parentEmail": "german.hartmann21@gmail.com",
-              "parentPhone": "07419 798185",
-              "healthQuestionResponses": [
 
-              ],
-              "route": "website"
-            },
-            {
-              "response": "refused",
-              "reasonForRefusal": "medical",
-              "parentName": "Charleen Hartmann",
-              "parentRelationship": "mother",
-              "parentRelationshipOther": null,
-              "parentEmail": "charleen.hartmann87@gmail.com",
-              "parentPhone": "07124 518022",
-              "healthQuestionResponses": [
-
-              ],
-              "route": "website"
-            }
           ],
           "parentEmail": "charleen.hartmann87@gmail.com",
           "parentName": "Charleen Hartmann",
@@ -367,46 +342,90 @@
           "triage": null
         },
         {
-          "firstName": "Edwardo",
-          "lastName": "Bahringer",
-          "dob": "2016-08-18",
-          "nhsNumber": 4579822331,
+          "firstName": "Carlena",
+          "lastName": "Harris",
+          "dob": "2018-11-18",
+          "nhsNumber": 4831150630,
           "consents": [
-            {
-              "response": "refused",
-              "reasonForRefusal": "personal_choice",
-              "parentName": "Lizbeth Bahringer",
-              "parentRelationship": "mother",
-              "parentRelationshipOther": null,
-              "parentEmail": "lizbeth.bahringer10@gmail.com",
-              "parentPhone": "07197 890775",
-              "healthQuestionResponses": [
 
-              ],
-              "route": "website"
-            }
           ],
-          "parentEmail": "lizbeth.bahringer10@gmail.com",
-          "parentName": "Lizbeth Bahringer",
-          "parentPhone": "07197 890775",
+          "parentEmail": "simonne.harris0@gmail.com",
+          "parentName": "Simonne Harris",
+          "parentPhone": "07191 816021",
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentInfoSource": "school",
           "triage": null
         },
         {
-          "firstName": "Lakeisha",
-          "lastName": "Schmidt",
-          "dob": "2016-06-30",
-          "nhsNumber": 4801007880,
+          "firstName": "Mohammad",
+          "lastName": "West",
+          "dob": "2016-11-20",
+          "nhsNumber": 4124017189,
+          "consents": [
+            {
+              "response": "refused",
+              "reasonForRefusal": "personal_choice",
+              "parentName": "Talia West",
+              "parentRelationship": "mother",
+              "parentRelationshipOther": null,
+              "parentEmail": "talia.west24@gmail.com",
+              "parentPhone": "07530 550135",
+              "healthQuestionResponses": [
+
+              ],
+              "route": "website"
+            }
+          ],
+          "parentEmail": "talia.west24@gmail.com",
+          "parentName": "Talia West",
+          "parentPhone": "07530 550135",
+          "parentRelationship": "mother",
+          "parentRelationshipOther": null,
+          "parentInfoSource": "school",
+          "triage": null
+        },
+        {
+          "firstName": "Derek",
+          "lastName": "Greenfelder",
+          "dob": "2016-03-30",
+          "nhsNumber": 4013617781,
+          "consents": [
+            {
+              "response": "refused",
+              "reasonForRefusal": "personal_choice",
+              "parentName": "Derick Greenfelder",
+              "parentRelationship": "father",
+              "parentRelationshipOther": null,
+              "parentEmail": "derick.greenfelder68@gmail.com",
+              "parentPhone": "07384 288789",
+              "healthQuestionResponses": [
+
+              ],
+              "route": "website"
+            }
+          ],
+          "parentEmail": "derick.greenfelder68@gmail.com",
+          "parentName": "Derick Greenfelder",
+          "parentPhone": "07384 288789",
+          "parentRelationship": "father",
+          "parentRelationshipOther": null,
+          "parentInfoSource": "school",
+          "triage": null
+        },
+        {
+          "firstName": "Latashia",
+          "lastName": "Schuster",
+          "dob": "2016-04-25",
+          "nhsNumber": 4468867620,
           "consents": [
             {
               "response": "refused",
               "reasonForRefusal": "will_be_vaccinated_elsewhere",
-              "parentName": "Abraham Schmidt",
+              "parentName": "Abraham Schuster",
               "parentRelationship": "father",
               "parentRelationshipOther": null,
-              "parentEmail": "abraham.schmidt8@gmail.com",
+              "parentEmail": "abraham.schuster8@gmail.com",
               "parentPhone": "07341 658241",
               "healthQuestionResponses": [
 
@@ -416,11 +435,11 @@
             {
               "response": "given",
               "reasonForRefusal": null,
-              "parentName": "Mayola Schmidt",
+              "parentName": "Giovanna Schuster",
               "parentRelationship": "mother",
               "parentRelationshipOther": null,
-              "parentEmail": "mayola.schmidt45@gmail.com",
-              "parentPhone": "07334 873732",
+              "parentEmail": "giovanna.schuster89@gmail.com",
+              "parentPhone": "07429 124873",
               "healthQuestionResponses": [
                 {
                   "question": "Has your child been diagnosed with asthma?",
@@ -466,9 +485,9 @@
               "route": "website"
             }
           ],
-          "parentEmail": "mayola.schmidt45@gmail.com",
-          "parentName": "Mayola Schmidt",
-          "parentPhone": "07334 873732",
+          "parentEmail": "giovanna.schuster89@gmail.com",
+          "parentName": "Giovanna Schuster",
+          "parentPhone": "07429 124873",
           "parentRelationship": "mother",
           "parentRelationshipOther": null,
           "parentInfoSource": "school",
@@ -477,7 +496,7 @@
         {
           "firstName": "Irvin",
           "lastName": "Kuhlman",
-          "dob": "2015-07-02",
+          "dob": "2015-07-08",
           "nhsNumber": 4436262561,
           "consents": [
             {
@@ -557,7 +576,7 @@
         {
           "firstName": "Pearline",
           "lastName": "Huels",
-          "dob": "2018-01-12",
+          "dob": "2018-01-18",
           "nhsNumber": 4965054016,
           "consents": [
             {
@@ -644,7 +663,7 @@
         {
           "firstName": "Dannie",
           "lastName": "Dare",
-          "dob": "2016-04-04",
+          "dob": "2016-04-10",
           "nhsNumber": 4629705619,
           "consents": [
             {
@@ -731,7 +750,7 @@
         {
           "firstName": "Chassidy",
           "lastName": "Aufderhar",
-          "dob": "2019-10-03",
+          "dob": "2019-10-09",
           "nhsNumber": 4414132967,
           "consents": [
             {
@@ -822,7 +841,7 @@
         {
           "firstName": "Collette",
           "lastName": "Considine",
-          "dob": "2017-06-17",
+          "dob": "2017-06-23",
           "nhsNumber": 4285046377,
           "consents": [
             {
@@ -985,7 +1004,7 @@
         {
           "firstName": "Lashon",
           "lastName": "Crona",
-          "dob": "2018-03-26",
+          "dob": "2018-04-01",
           "nhsNumber": 4751476661,
           "consents": [
             {
@@ -1076,7 +1095,7 @@
         {
           "firstName": "Asa",
           "lastName": "Stokes",
-          "dob": "2017-10-08",
+          "dob": "2017-10-14",
           "nhsNumber": 4829048271,
           "consents": [
             {
@@ -1163,6 +1182,116 @@
             "notes": "Checked with GP, OK to proceed",
             "user_email": "nurse.jackie@example.com"
           }
+        }
+      ],
+      "consent_forms": [
+        {
+          "first_name": "Bao",
+          "last_name": "Wolff",
+          "use_common_name": false,
+          "date_of_birth": "2016-03-09",
+          "parent_name": "Sueann Stokes",
+          "parent_relationship": "mother",
+          "parent_email": "sueann.stokes@schimmel-klocko.example",
+          "parent_phone": "07895 352333",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Prof. Lorenzo Kreiger",
+          "gp_response": "yes",
+          "address_line_1": "222 Shanahan Pines",
+          "address_town": "Harleyfort",
+          "address_postcode": "UD0 9LB",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
+        },
+        {
+          "first_name": "Norbert",
+          "last_name": "Hayes",
+          "use_common_name": false,
+          "date_of_birth": "2018-12-16",
+          "parent_name": "Neil Murphy",
+          "parent_relationship": "mother",
+          "parent_email": "murphy_neil@crona.test",
+          "parent_phone": "07527 076216",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Karon Wyman",
+          "gp_response": "yes",
+          "address_line_1": "6302 Dietrich Motorway",
+          "address_town": "Hectortown",
+          "address_postcode": "ZD6H 0BB",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
+        },
+        {
+          "first_name": "Quinton",
+          "last_name": "Greenfelder",
+          "use_common_name": false,
+          "date_of_birth": "2020-10-21",
+          "parent_name": "Eli Boyer DO",
+          "parent_relationship": "mother",
+          "parent_email": "do.eli.boyer@dare.test",
+          "parent_phone": "07856 287255",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Rochel Reynolds DVM",
+          "gp_response": "yes",
+          "address_line_1": "838 Reichert Glens",
+          "address_town": "Port Chance",
+          "address_postcode": "ZE9 8HL",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
+        },
+        {
+          "first_name": "Chassidy",
+          "last_name": "Brown",
+          "use_common_name": false,
+          "date_of_birth": "2020-08-13",
+          "parent_name": "Amb. Gavin Schimmel",
+          "parent_relationship": "mother",
+          "parent_email": "amb.schimmel.gavin@jenkins.example",
+          "parent_phone": "07598 425170",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Violeta Boyle",
+          "gp_response": "yes",
+          "address_line_1": "28346 Brandon Plaza",
+          "address_town": "West Eviaview",
+          "address_postcode": "W7E 3LJ",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
         }
       ]
     }

--- a/db/sample_data/example-hpv-campaign.json
+++ b/db/sample_data/example-hpv-campaign.json
@@ -17,16 +17,16 @@
       "method": "injection",
       "batches": [
         {
-          "name": "CV2898",
-          "expiry": "2024-06-06"
+          "name": "QS3186",
+          "expiry": "2024-06-15"
         },
         {
-          "name": "ZD0600",
-          "expiry": "2024-05-01"
+          "name": "NI2599",
+          "expiry": "2024-05-31"
         },
         {
-          "name": "YR9510",
-          "expiry": "2024-04-03"
+          "name": "MZ7368",
+          "expiry": "2024-04-17"
         }
       ]
     }
@@ -71,7 +71,7 @@
         {
           "firstName": "Brittany",
           "lastName": "Klocko",
-          "dob": "2011-11-17",
+          "dob": "2011-11-23",
           "nhsNumber": 4656828688,
           "consents": [
             {
@@ -134,7 +134,7 @@
         {
           "firstName": "Brenton",
           "lastName": "Kautzer",
-          "dob": "2011-11-14",
+          "dob": "2011-11-20",
           "nhsNumber": 4861178665,
           "consents": [
             {
@@ -173,7 +173,7 @@
         {
           "firstName": "Sebastian",
           "lastName": "Farrell",
-          "dob": "2011-02-03",
+          "dob": "2011-02-09",
           "nhsNumber": 4617774696,
           "consents": [
 
@@ -189,7 +189,7 @@
         {
           "firstName": "Jose",
           "lastName": "Pacocha",
-          "dob": "2011-06-04",
+          "dob": "2011-06-10",
           "nhsNumber": 4378766841,
           "consents": [
 
@@ -205,35 +205,10 @@
         {
           "firstName": "Silvia",
           "lastName": "Waters",
-          "dob": "2011-03-12",
+          "dob": "2011-03-18",
           "nhsNumber": 4076549104,
           "consents": [
-            {
-              "response": "refused",
-              "reasonForRefusal": "personal_choice",
-              "parentName": "Scarlet Waters",
-              "parentRelationship": "mother",
-              "parentRelationshipOther": null,
-              "parentEmail": "scarlet.waters74@gmail.com",
-              "parentPhone": "07415 743155",
-              "healthQuestionResponses": [
 
-              ],
-              "route": "website"
-            },
-            {
-              "response": "refused",
-              "reasonForRefusal": "personal_choice",
-              "parentName": "Blair Waters",
-              "parentRelationship": "father",
-              "parentRelationshipOther": null,
-              "parentEmail": "blair.waters1@gmail.com",
-              "parentPhone": "07366 400214",
-              "healthQuestionResponses": [
-
-              ],
-              "route": "website"
-            }
           ],
           "parentEmail": "blair.waters1@gmail.com",
           "parentName": "Blair Waters",
@@ -244,10 +219,54 @@
           "triage": null
         },
         {
+          "firstName": "Clark",
+          "lastName": "Hudson",
+          "dob": "2011-04-29",
+          "nhsNumber": 4889176764,
+          "consents": [
+
+          ],
+          "parentEmail": "luther.hudson37@gmail.com",
+          "parentName": "Luther Hudson",
+          "parentPhone": "07741 550852",
+          "parentRelationship": "father",
+          "parentRelationshipOther": null,
+          "parentInfoSource": "school",
+          "triage": null
+        },
+        {
+          "firstName": "Bryant",
+          "lastName": "Haley",
+          "dob": "2011-12-14",
+          "nhsNumber": 4578055647,
+          "consents": [
+            {
+              "response": "refused",
+              "reasonForRefusal": "personal_choice",
+              "parentName": "Graig Haley",
+              "parentRelationship": "father",
+              "parentRelationshipOther": null,
+              "parentEmail": "graig.haley32@gmail.com",
+              "parentPhone": "07927 088169",
+              "healthQuestionResponses": [
+
+              ],
+              "route": "website"
+            }
+          ],
+          "parentEmail": "graig.haley32@gmail.com",
+          "parentName": "Graig Haley",
+          "parentPhone": "07927 088169",
+          "parentRelationship": "father",
+          "parentRelationshipOther": null,
+          "parentInfoSource": "school",
+          "triage": null
+        },
+        {
           "firstName": "Victor",
           "lastName": "Jerde",
-          "dob": "2011-04-28",
-          "nhsNumber": 4776330911,
+          "dob": "2011-05-04",
+          "nhsNumber": 4237052575,
           "consents": [
             {
               "response": "refused",
@@ -287,7 +306,7 @@
         {
           "firstName": "Odilia",
           "lastName": "Cassin",
-          "dob": "2011-04-08",
+          "dob": "2011-04-14",
           "nhsNumber": 4945559198,
           "consents": [
             {
@@ -339,7 +358,7 @@
         {
           "firstName": "Gus",
           "lastName": "Langworth",
-          "dob": "2011-01-25",
+          "dob": "2011-01-31",
           "nhsNumber": 4823962036,
           "consents": [
             {
@@ -391,7 +410,7 @@
         {
           "firstName": "Freddie",
           "lastName": "Russel",
-          "dob": "2011-06-21",
+          "dob": "2011-06-27",
           "nhsNumber": 4740927616,
           "consents": [
             {
@@ -438,7 +457,7 @@
         {
           "firstName": "Marcelino",
           "lastName": "Wintheiser",
-          "dob": "2011-12-14",
+          "dob": "2011-12-20",
           "nhsNumber": 4395215394,
           "consents": [
             {
@@ -485,7 +504,7 @@
         {
           "firstName": "Caprice",
           "lastName": "Schultz",
-          "dob": "2011-10-28",
+          "dob": "2011-11-03",
           "nhsNumber": 4282671858,
           "consents": [
             {
@@ -568,7 +587,7 @@
         {
           "firstName": "Rubye",
           "lastName": "Stamm",
-          "dob": "2010-12-29",
+          "dob": "2011-01-04",
           "nhsNumber": 4360813872,
           "consents": [
             {
@@ -651,7 +670,7 @@
         {
           "firstName": "Danna",
           "lastName": "Willms",
-          "dob": "2011-08-07",
+          "dob": "2011-08-13",
           "nhsNumber": 4592929926,
           "consents": [
             {
@@ -702,7 +721,7 @@
         {
           "firstName": "Yasmine",
           "lastName": "Gulgowski",
-          "dob": "2011-02-06",
+          "dob": "2011-02-12",
           "nhsNumber": 4480144544,
           "consents": [
             {
@@ -749,6 +768,116 @@
             "notes": "Checked with GP, not OK to proceed",
             "user_email": "nurse.joy@example.com"
           }
+        }
+      ],
+      "consent_forms": [
+        {
+          "first_name": "Michaele",
+          "last_name": "Schmitt",
+          "use_common_name": false,
+          "date_of_birth": "2015-03-15",
+          "parent_name": "Dorla Dibbert Ret.",
+          "parent_relationship": "father",
+          "parent_email": "dorla_dibbert_ret@gleason.example",
+          "parent_phone": "07918 006147",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Jamel Shields",
+          "gp_response": "yes",
+          "address_line_1": "893 Pete Route",
+          "address_town": "Lake Deliciatown",
+          "address_postcode": "Z4T 0SJ",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
+        },
+        {
+          "first_name": "Aline",
+          "last_name": "Flatley",
+          "use_common_name": false,
+          "date_of_birth": "2020-05-05",
+          "parent_name": "Adolph Lind",
+          "parent_relationship": "father",
+          "parent_email": "adolph_lind@kassulke-beahan.example",
+          "parent_phone": "07381 807334",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Ronny Dickinson",
+          "gp_response": "yes",
+          "address_line_1": "952 Jenna Fall",
+          "address_town": "New Robbietown",
+          "address_postcode": "CG8 4QJ",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
+        },
+        {
+          "first_name": "Raquel",
+          "last_name": "Cassin",
+          "use_common_name": false,
+          "date_of_birth": "2017-07-23",
+          "parent_name": "Emeline Hand",
+          "parent_relationship": "mother",
+          "parent_email": "hand_emeline@rempel-heaney.example",
+          "parent_phone": "07769 140603",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Mr. Sterling Jacobs",
+          "gp_response": "yes",
+          "address_line_1": "70627 Del Field",
+          "address_town": "New Santiagoside",
+          "address_postcode": "SP0 1FN",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
+        },
+        {
+          "first_name": "Wilmer",
+          "last_name": "Kautzer",
+          "use_common_name": false,
+          "date_of_birth": "2017-04-08",
+          "parent_name": "Fr. Azalee Bruen",
+          "parent_relationship": "mother",
+          "parent_email": "azalee.fr.bruen@doyle.test",
+          "parent_phone": "07487 334546",
+          "contact_method": "any",
+          "response": "given",
+          "gp_name": "Lael Daugherty DO",
+          "gp_response": "yes",
+          "address_line_1": "33110 Rudy Parkways",
+          "address_town": "Danteberg",
+          "address_postcode": "W4U 3UX",
+          "health_answers": [
+            {
+              "question": "Is there anything we should know?",
+              "response": null,
+              "notes": null,
+              "hint": null,
+              "next_question": null,
+              "follow_up_question": null
+            }
+          ]
         }
       ]
     }

--- a/lib/example_campaign_data.rb
+++ b/lib/example_campaign_data.rb
@@ -160,4 +160,8 @@ class ExampleCampaignData
         end
     }.with_indifferent_access
   end
+
+  def consent_form_attributes(session_attributes:)
+    session_attributes["consent_forms"]
+  end
 end

--- a/lib/example_campaign_generator.rb
+++ b/lib/example_campaign_generator.rb
@@ -4,6 +4,7 @@ class ExampleCampaignGenerator
   def self.patient_options
     %i[
       consent_forms_that_do_not_match
+      consent_forms_that_partially_match
       patients_with_no_consent_response
       patients_with_consent_given_and_ready_to_vaccinate
       patients_with_consent_refused
@@ -22,8 +23,9 @@ class ExampleCampaignGenerator
     @presettings ||= {
       default: {
         consent_forms_that_do_not_match: 2,
+        consent_forms_that_partially_match: 2,
         patients_with_consent_given_and_ready_to_vaccinate: 2,
-        patients_with_no_consent_response: 2,
+        patients_with_no_consent_response: 4,
         patients_with_consent_refused: 2,
         patients_with_conflicting_consent: 2,
         patients_that_still_need_triage: 2,
@@ -673,6 +675,8 @@ class ExampleCampaignGenerator
     consent_forms = []
     consent_forms +=
       build_consent_forms_that_do_not_match_patients(patients_data)
+    consent_forms +=
+      build_consent_forms_that_partially_match_patients(patients_data)
 
     consent_forms.map do |consent_form|
       consent_form.attributes.tap do |attrs|
@@ -696,6 +700,24 @@ class ExampleCampaignGenerator
 
       redo if patient_exists
       cf
+    end
+  end
+
+  def build_consent_forms_that_partially_match_patients(patients_data)
+    return [] unless options.key?(:consent_forms_that_partially_match)
+
+    patients_data = patients_data.dup
+    options[:consent_forms_that_partially_match].times.map do
+      patient = patients_data.delete(patients_data.sample(random:))
+      match_patient_on = %i[firstName lastName].sample(random:)
+
+      FactoryBot
+        .build(:consent_form, random:, session: nil)
+        .tap do |cf|
+          cf[match_patient_on.to_s.underscore.to_sym] = patient[
+            match_patient_on
+          ]
+        end
     end
   end
 end

--- a/lib/load_example_campaign.rb
+++ b/lib/load_example_campaign.rb
@@ -35,6 +35,10 @@ module LoadExampleCampaign
         session = create_session(session_attributes, campaign:, school:)
         children_attributes = example.children_attributes(session_attributes:)
         create_children(children_attributes:, campaign:, session:)
+
+        consent_forms =
+          example.consent_form_attributes(session_attributes:) || []
+        create_consent_forms(consent_forms:, session:)
       end
     end
   end
@@ -150,6 +154,18 @@ module LoadExampleCampaign
       end
 
       transition_states(patient.patient_sessions.first)
+    end
+  end
+
+  def self.create_consent_forms(consent_forms:, session:)
+    consent_forms.each do |attributes|
+      health_answers =
+        attributes
+          .delete("health_answers")
+          .map { |answer| HealthAnswer.new(answer) }
+      session.consent_forms << ConsentForm.new(
+        attributes.merge(health_answers:)
+      )
     end
   end
 end

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -41,13 +41,15 @@
 #
 FactoryBot.define do
   factory :consent_form do
+    transient { random { Random.new } }
+
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     use_common_name { false }
     date_of_birth { Faker::Date.birthday(min_age: 3, max_age: 9) }
     parent_name { Faker::Name.name }
     parent_relationship do
-      ConsentForm.parent_relationships.keys.first(2).sample
+      ConsentForm.parent_relationships.keys.first(2).sample(random:)
     end
     parent_email { Faker::Internet.email name: parent_name }
     parent_phone { Faker::PhoneNumber.cell_phone }

--- a/spec/lib/example_campaign_generator_spec.rb
+++ b/spec/lib/example_campaign_generator_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ExampleCampaignGenerator do
     #       presets=default \
     #       type=hpv \
     #       username="Nurse Joy" > db/sample_data/example-hpv-campaign.json
-    Timecop.freeze(2023, 12, 22, 12, 0, 0) do
+    Timecop.freeze(2023, 12, 28, 12, 0, 0) do
       generator =
         ExampleCampaignGenerator.new(
           seed: 42,
@@ -61,7 +61,7 @@ RSpec.describe ExampleCampaignGenerator do
     #       presets=default \
     #       type=flu \
     #       username="Nurse Jackie" > db/sample_data/example-flu-campaign.json
-    Timecop.freeze(2023, 12, 22, 12, 0, 0) do
+    Timecop.freeze(2023, 12, 28, 12, 0, 0) do
       generator =
         ExampleCampaignGenerator.new(
           seed: 43,

--- a/tests/parental_consent_authentication.spec.ts
+++ b/tests/parental_consent_authentication.spec.ts
@@ -40,13 +40,13 @@ async function then_i_see_the_consent_start_page() {
 }
 
 async function then_i_see_the_edit_name_page_for_the_first_form() {
-  expect(p.url()).toContain("/1/edit/name");
+  expect(p.url()).toContain("/9/edit/name");
 }
 
 async function then_i_see_the_edit_name_page_for_the_second_form() {
-  expect(p.url()).toContain("/2/edit/name");
+  expect(p.url()).toContain("/10/edit/name");
 }
 
 async function when_i_go_to_the_first_form() {
-  await p.goto("/sessions/1/consents/1/edit/name");
+  await p.goto("/sessions/1/consents/9/edit/name");
 }

--- a/tests/shared/index.ts
+++ b/tests/shared/index.ts
@@ -23,7 +23,7 @@ export const fixtures = {
   secondPatientThatNeedsVaccination: "Brenton Kautzer",
 
   // Get from /sessions/1/patients/Y/vaccinations/batch/edit
-  vaccineBatch: "CV2898",
+  vaccineBatch: "QS3186",
 
   // Get from /sessions, signed in as Nurse Jackie
   schoolName: /Crompton Primary School/,

--- a/tests/vaccination_authorisation.spec.ts
+++ b/tests/vaccination_authorisation.spec.ts
@@ -36,8 +36,8 @@ async function and_i_go_to_the_vaccinations_page() {
 
 async function then_i_should_only_see_my_patients() {
   await expect(
-    p.locator("div[id^='action-needed'] .nhsuk-table__body .nhsuk-table__row"),
-  ).toHaveCount(14);
+    p.locator("div#action-needed .nhsuk-table__body .nhsuk-table__row"),
+  ).toHaveCount(16);
 }
 
 async function when_i_go_to_the_vaccinations_page_of_another_team() {


### PR DESCRIPTION
Starter for 10 of generating example consent forms. The db structure for these may change, but this data is meant to help us start to build the consent form matching pages out and we can roll-forward changes.