### PR TITLE
Add support for rendering patient and consent_form objects to AppPatientDetailsComponent

### DIFF
--- a/app/components/app_patient_details_component.html.erb
+++ b/app/components/app_patient_details_component.html.erb
@@ -2,17 +2,54 @@
   <%= govuk_summary_list do |summary_list|
     summary_list.with_row do |row|
       row.with_key { "Name" }
-      row.with_value { @patient.full_name }
+      row.with_value { @object.full_name }
+    end
+
+    if known_as.present?
+      summary_list.with_row do |row|
+        row.with_key { "Known as" }
+        row.with_value { known_as }
+      end
     end
 
     summary_list.with_row do |row|
       row.with_key { "Date of birth" }
-      row.with_value { "#{@patient.dob.to_fs(:nhsuk_date)} #{aged}" }
+      row.with_value { "#{date_of_birth.to_fs(:nhsuk_date)} (#{aged})" }
     end
 
-    summary_list.with_row do |row|
-      row.with_key { "NHS Number" }
-      row.with_value { nhs_number }
+    if address_present?
+      summary_list.with_row do |row|
+        row.with_key { "Address" }
+        row.with_value { address_formatted }
+      end
+    end
+
+    if @school.present?
+      summary_list.with_row do |row|
+        row.with_key { "School" }
+        row.with_value { @school.name }
+      end
+    end
+
+    if gp_response_present?
+      if @object.gp_response_yes?
+        summary_list.with_row do |row|
+          row.with_key { "GP" }
+          row.with_value { @object.gp_name }
+        end
+      else
+        summary_list.with_row do |row|
+          row.with_key { "Registered with a GP" }
+          row.with_value { @object.gp_response_no? ? "No" : "I don’t know" }
+        end
+      end
+    end
+
+    if nhs_number.present?
+      summary_list.with_row do |row|
+        row.with_key { "NHS Number" }
+        row.with_value { nhs_number_formatted }
+      end
     end
   end %>
 </dl>

--- a/app/components/app_patient_details_component.html.erb
+++ b/app/components/app_patient_details_component.html.erb
@@ -1,43 +1,18 @@
 <dl class="nhsuk-summary-list app-summary-list--no-bottom-border nhsuk-u-margin-bottom-0">
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Name
-    </dt>
-    <dd class="nhsuk-summary-list__value" data-testid="full-name">
-      <%= @patient.full_name %>
-    </dd>
-  </div>
+  <%= govuk_summary_list do |summary_list|
+    summary_list.with_row do |row|
+      row.with_key { "Name" }
+      row.with_value { @patient.full_name }
+    end
 
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      Date of birth
-    </dt>
-    <dd class="nhsuk-summary-list__value" data-testid="dob">
-      <%= @patient.dob&.to_fs(:nhsuk_date) %> (<%= aged %>)
-    </dd>
-  </div>
+    summary_list.with_row do |row|
+      row.with_key { "Date of birth" }
+      row.with_value { "#{@patient.dob.to_fs(:nhsuk_date)} #{aged}" }
+    end
 
-  <div class="nhsuk-summary-list__row">
-    <dt class="nhsuk-summary-list__key">
-      NHS Number
-    </dt>
-    <dd class="nhsuk-summary-list__value" data-testid="nhs-number">
-      <%= nhs_number %>
-    </dd>
-  </div>
-
-  <% if Settings.features.fhir_server_integration %>
-    <div class="nhsuk-summary-list__row">
-      <dt class="nhsuk-summary-list__key">
-        Vaccination history
-      </dt>
-      <dd class="nhsuk-summary-list__value">
-        <%= link_to "Record available",
-           history_session_patient_vaccinations_path(
-             session_id: @session.id,
-             id: (@patient.id || ":id")
-           ) %>
-      </dd>
-    </div>
-  <% end %>
+    summary_list.with_row do |row|
+      row.with_key { "NHS Number" }
+      row.with_value { nhs_number }
+    end
+  end %>
 </dl>

--- a/app/components/app_patient_details_component.rb
+++ b/app/components/app_patient_details_component.rb
@@ -1,26 +1,76 @@
 # frozen_string_literal: true
 
 class AppPatientDetailsComponent < ViewComponent::Base
-  def initialize(patient:, session:)
+  def initialize(session:, patient: nil, consent_form: nil, school: nil)
     super
 
-    @patient = patient
+    unless patient || consent_form
+      raise ArgumentError, "patient or consent_form must be provided"
+    end
+
     @session = session
+    @object = patient || consent_form
+    @school = school
+  end
+
+  private
+
+  def known_as
+    if @object.respond_to? :common_name
+      @object.common_name
+    elsif @object.respond_to? :preferred_name
+      @object.preferred_name
+    end
+  end
+
+  def date_of_birth
+    if @object.respond_to? :dob
+      @object.dob
+    else
+      @object.date_of_birth
+    end
   end
 
   def aged
-    "aged #{@patient.dob ? @patient.age : ""}"
-  end
-
-  def nhs_number
-    @patient.nhs_number.to_s.gsub(/(\d{3})(\d{3})(\d{4})/, "\\1 \\2 \\3")
+    "aged #{date_of_birth ? @object.age : ""}"
   end
 
   def parent_guardian_or_other
-    if @patient.parent_relationship == "other"
-      @patient.human_enum_name(:parent_relationship_other)
+    if @object.parent_relationship == "other"
+      @object.human_enum_name(:parent_relationship_other)
     else
-      @patient.human_enum_name(:parent_relationship)
+      @object.human_enum_name(:parent_relationship)
     end
+  end
+
+  def address_present?
+    @object.try(:address_line_1).present? ||
+      @object.try(:address_line_2).present? ||
+      @object.try(:address_town).present? ||
+      @object.try(:address_postcode).present?
+  end
+
+  def address_formatted
+    safe_join(
+      [
+        @object.address_line_1,
+        @object.address_line_2,
+        @object.address_town,
+        @object.address_postcode
+      ].reject(&:blank?),
+      tag.br
+    )
+  end
+
+  def gp_response_present?
+    @object.try(:gp_response).present?
+  end
+
+  def nhs_number
+    @object.nhs_number if @object.respond_to? :nhs_number
+  end
+
+  def nhs_number_formatted
+    nhs_number.to_s.gsub(/(\d{3})(\d{3})(\d{4})/, "\\1 \\2 \\3")
   end
 end

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -5,29 +5,197 @@ RSpec.describe AppPatientDetailsComponent, type: :component do
 
   subject { page }
 
-  let(:patient) { FactoryBot.create(:patient, nhs_number: 1_234_567_890) }
   let(:session) { FactoryBot.create(:session) }
-  let(:component) { described_class.new(patient:, session:) }
 
-  it "should render the patient's full name" do
-    expect(page).to have_css(
-      '.nhsuk-summary-list__value[data-testid="full-name"]',
-      text: patient.full_name
-    )
+  context "with a patient object" do
+    let(:patient) do
+      FactoryBot.create(
+        :patient,
+        nhs_number: 1_234_567_890,
+        preferred_name: "Homer"
+      )
+    end
+    let(:school) { FactoryBot.create(:location) }
+    let(:component) { described_class.new(patient:, session:, school:) }
+
+    it "should render the patient's full name" do
+      expect(page).to(
+        have_css(".nhsuk-summary-list__row", text: "Name#{patient.full_name}")
+      )
+    end
+
+    it "should render the patient's preferred name" do
+      expect(page).to(
+        have_css(".nhsuk-summary-list__row", text: "Known asHomer")
+      )
+    end
+
+    it "should render the patient's date of birth" do
+      expected_dob = "#{patient.dob.to_fs(:nhsuk_date)} (aged #{patient.age})"
+      expect(page).to(
+        have_css(
+          ".nhsuk-summary-list__row",
+          text: "Date of birth#{expected_dob}"
+        )
+      )
+    end
+
+    it "should not render the address" do
+      expect(page).not_to have_css(".nhsuk-summary-list__row", text: "Address")
+    end
+
+    it "should render the school name" do
+      expect(page).to(
+        have_css(".nhsuk-summary-list__row", text: "School#{school.name}")
+      )
+    end
+
+    it "should not render a GP name" do
+      expect(page).not_to have_css(".nhsuk-summary-list__row", text: /^GP/)
+    end
+
+    it "should not render a GP response" do
+      expect(page).not_to(
+        have_css(".nhsuk-summary-list__row", text: "Registered with a GP")
+      )
+    end
+
+    it "should render the patient's NHS number" do
+      expect(page).to(
+        have_css(".nhsuk-summary-list__row", text: "NHS Number123 456 7890")
+      )
+    end
+
+    context "without a preferred name" do
+      let(:patient) { FactoryBot.create(:patient, preferred_name: nil) }
+
+      it "should not render known as" do
+        expect(page).not_to(
+          have_css(".nhsuk-summary-list__row", text: "Known as")
+        )
+      end
+    end
   end
 
-  it "should render the patient's date of birth" do
-    expected_dob = "#{patient.dob.to_fs(:nhsuk_date)} (aged #{patient.age})"
-    expect(page).to have_css(
-      '.nhsuk-summary-list__value[data-testid="dob"]',
-      text: expected_dob
-    )
-  end
+  context "with a consent_form object" do
+    let(:consent_form) do
+      FactoryBot.create(:consent_form, common_name: "Homer")
+    end
+    let(:school) { FactoryBot.create(:location) }
+    let(:component) { described_class.new(consent_form:, session:, school:) }
 
-  it "should render the patient's NHS number" do
-    expect(page).to have_css(
-      '.nhsuk-summary-list__value[data-testid="nhs-number"]',
-      text: "123 456 7890"
-    )
+    it "should render the child's full name" do
+      expect(page).to(
+        have_css(
+          ".nhsuk-summary-list__row",
+          text: "Name#{consent_form.full_name}"
+        )
+      )
+    end
+
+    it "should render the child's common name" do
+      expect(page).to have_css(
+        ".nhsuk-summary-list__row",
+        text: "Known asHomer"
+      )
+    end
+
+    it "should render the child's date of birth" do
+      formatted_date = consent_form.date_of_birth.to_fs(:nhsuk_date)
+      expected_dob = "#{formatted_date} (aged #{consent_form.age})"
+      expect(page).to(
+        have_css(
+          ".nhsuk-summary-list__row",
+          text: "Date of birth#{expected_dob}"
+        )
+      )
+    end
+
+    it "should render the child's address" do
+      expect(page).to(
+        have_css(
+          ".nhsuk-summary-list__row",
+          text:
+            "Address" \
+              "#{consent_form.address_line_1}" \
+              "#{consent_form.address_line_2}" \
+              "#{consent_form.address_town}" \
+              "#{consent_form.address_postcode}"
+        )
+      )
+    end
+
+    it "should render the school name" do
+      expect(page).to(
+        have_css(".nhsuk-summary-list__row", text: "School#{school.name}")
+      )
+    end
+
+    it "should render the GP name" do
+      expect(page).to(
+        have_css(".nhsuk-summary-list__row", text: "GP#{consent_form.gp_name}")
+      )
+    end
+
+    it "should not render an NHS number" do
+      expect(page).not_to(
+        have_css(".nhsuk-summary-list__row", text: "NHS Number")
+      )
+    end
+
+    context "without a common name" do
+      let(:consent_form) { FactoryBot.create(:consent_form, common_name: nil) }
+
+      it "should not render known as" do
+        expect(page).not_to(
+          have_css(".nhsuk-summary-list__row", text: "Known as")
+        )
+      end
+    end
+
+    context "when child does not have a GP" do
+      let(:consent_form) do
+        FactoryBot.create(
+          :consent_form,
+          common_name: "Homer",
+          gp_name: nil,
+          gp_response: "no"
+        )
+      end
+
+      it "should not render a GP name" do
+        expect(page).not_to(have_css(".nhsuk-summary-list__row", text: /^GP/))
+      end
+
+      it "should render GP response" do
+        expect(page).to(
+          have_css(".nhsuk-summary-list__row", text: "Registered with a GPNo")
+        )
+      end
+    end
+
+    context "when it's unknown whether the child has a GP" do
+      let(:consent_form) do
+        FactoryBot.create(
+          :consent_form,
+          common_name: "Homer",
+          gp_name: nil,
+          gp_response: "dont_know"
+        )
+      end
+
+      it "should not render a GP name" do
+        expect(page).not_to(have_css(".nhsuk-summary-list__row", text: /^GP/))
+      end
+
+      it "should render GP response" do
+        expect(page).to(
+          have_css(
+            ".nhsuk-summary-list__row",
+            text: "Registered with a GPI don’t know"
+          )
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
> [!Important]
> This PR based on #775 and requires it be merged first.

This should not change how patient details are currently rendered, but adds support necessary to render patient details from a consent form. Looking at the prototype it appears that most if not all the fields should be renderable the same for these two cases.

This will be used in an upcoming commit to add a show page for `ConsentForm` objects.