### PR TITLE
Remove encryption check in production

### DIFF
--- a/config/initializers/check_production.rb
+++ b/config/initializers/check_production.rb
@@ -1,16 +1,5 @@
-if Rails.env.production? && ENV["SKIP_PRODUCTION_CHECKS"].blank?
-  if Rails
-       .application
-       .credentials
-       .dig(:active_record_encryption, :primary_key)
-       .blank?
-    raise "Application is running in production mode but Active Record
-    Encryption is not set up. Please set up Active Record Encryption. See
-    https://edgeguides.rubyonrails.org/active_record_encryption.html"
-  end
-
-  if ENV.fetch("SENTRY_DSN", "").blank?
-    raise "Application is running in production mode but SENTRY_DSN is not set
+if Rails.env.production? && ENV["SKIP_PRODUCTION_CHECKS"].blank? &&
+     ENV.fetch("SENTRY_DSN", "").blank?
+  raise "Application is running in production mode but SENTRY_DSN is not set
     up. Please set up Sentry."
-  end
 end

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -59,7 +59,6 @@ environments:
       RAILS_ENV: production
       RCVAPP__SUPPORT_USERNAME: manage
       RCVAPP__SUPPORT_PASSWORD: vaccinations
-      SKIP_PRODUCTION_CHECKS: please
   staging:
     http:
       alias:


### PR DESCRIPTION
Encryption is now on by default in all environments.

Remove `SKIP_PRODUCTION_CHECKS` env var in the pentest env as it's no longer necessary.