### PR TITLE
Set up secure cookies in production

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+Rails.application.config.session_store :cookie_store,
+                                       secure: Rails.env.production?,
+                                       expire_after: 2.hours


### PR DESCRIPTION
This prevents the browser from sending cookies if it's not connecting over HTTPS.