### PR TITLE
Display errors correctly when not signed in

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user!
 
   layout "two_thirds"
 


### PR DESCRIPTION
Errors should not require the user to be signed in to display correctly.