### PR TITLE
Use Settings.host instead of HEROKU_APP_DEFAULT_DOMAIN_NAME 

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,9 +5,9 @@
   "environments": {
     "review": {
       "env": {
-        "IS_REVIEW": "true",
         "RACK_ENV": "staging",
         "RAILS_ENV": "staging",
+        "RCVAPP__IS_REVIEW": "true",
         "RCVAPP__SUPPORT_USERNAME": "test",
         "RCVAPP__SUPPORT_PASSWORD": "test"
       }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,7 +109,7 @@ Rails.application.configure do
       if Settings.is_review
         "#{ENV["HEROKU_APP_NAME"]}.herokuapp.com"
       else
-        ENV["HEROKU_APP_DEFAULT_DOMAIN_NAME"]
+        Settings.host
       end,
     protocol: "https"
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -106,7 +106,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = {
     host:
-      if ENV["IS_REVIEW"].present?
+      if Settings.is_review
         "#{ENV["HEROKU_APP_NAME"]}.herokuapp.com"
       else
         ENV["HEROKU_APP_DEFAULT_DOMAIN_NAME"]

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -57,6 +57,7 @@ environments:
       rolling: recreate
     variables:
       RAILS_ENV: production
+      RCVAPP__HOST: "pentest.manage-vaccinations-in-schools.nhs.uk"
       RCVAPP__SUPPORT_USERNAME: manage
       RCVAPP__SUPPORT_PASSWORD: vaccinations
   staging:
@@ -68,5 +69,6 @@ environments:
       rolling: recreate
     variables:
       RAILS_ENV: staging
+      RCVAPP__HOST: "staging.manage-vaccinations-in-schools.nhs.uk"
       RCVAPP__SUPPORT_USERNAME: manage
       RCVAPP__SUPPORT_PASSWORD: vaccinations


### PR DESCRIPTION
Makes the default host setting in prod-like envs more agnostic of the hosting environment.

Also use `RCVAPP__IS_REVIEW` instead of `ENV["IS_REVIEW"]`, and populate `Settings.host` in the AWS envs.