### PR TITLE
Ignore settings.local.yml files in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,3 +42,7 @@
 /spec
 /tests
 /terraform
+
+/config/settings.local.yml
+/config/settings/*.local.yml
+/config/environments/*.local.yml


### PR DESCRIPTION
These might contain local secrets that shouldn't make it into the container.