### PR TITLE
Don't run npm scripts when building docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ARG YARN_VERSION=1.22.19
 ENV PATH=/usr/local/node/bin:$PATH
 RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
     /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
-    npm install -g yarn@$YARN_VERSION && \
+    npm install --ignore-scripts -g yarn@$YARN_VERSION && \
     rm -rf /tmp/node-build-master
 
 # Install application gems
@@ -42,7 +42,7 @@ RUN bundle install && \
 # Install node modules
 COPY --link .yarnrc package.json yarn.lock ./
 COPY --link .yarn/releases/* .yarn/releases/
-RUN yarn install --frozen-lockfile
+RUN yarn install --ignore-scripts --frozen-lockfile
 
 # Copy application code
 COPY --link . .


### PR DESCRIPTION
Running `npm` scripts can lead to running malware if packages are compromised.