### PR TITLE
Add length validation on (most) text fields

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -254,7 +254,9 @@ class Consent < ApplicationRecord
   def triage_valid?
     return if triage.valid?(:consent)
 
-    errors.add(:triage_status, triage.errors.messages[:status].first)
+    triage.errors.each do |error|
+      errors.add(:"triage_#{error.attribute}", error.message)
+    end
   end
 
   def required_for_step?(step, exact: false)

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -84,6 +84,24 @@ class Consent < ApplicationRecord
            :parent_relationship_other,
            :reason_for_refusal_other
 
+  validates :address_line_1,
+            :address_line_2,
+            :address_postcode,
+            :address_town,
+            :childs_common_name,
+            :childs_name,
+            :gp_name,
+            :parent_contact_method_other,
+            :parent_email,
+            :parent_name,
+            :parent_phone,
+            :parent_relationship_other,
+            length: {
+              maximum: 255
+            }
+
+  validates :reason_for_refusal_other, length: { maximum: 1023 }
+
   with_options on: :edit_who do
     validates :parent_name, presence: true
     validates :parent_phone, presence: true

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -89,6 +89,24 @@ class ConsentForm < ApplicationRecord
            :parent_relationship_other,
            :reason_notes
 
+  validates :address_line_1,
+            :address_line_2,
+            :address_town,
+            :common_name,
+            :contact_method_other,
+            :first_name,
+            :gp_name,
+            :last_name,
+            :parent_email,
+            :parent_name,
+            :parent_phone,
+            :parent_relationship_other,
+            length: {
+              maximum: 255
+            }
+
+  validates :reason_notes, length: { maximum: 1023 }
+
   with_options on: :update do
     with_options if: -> { required_for_step?(:name) } do
       validates :first_name, presence: true

--- a/app/models/health_answer.rb
+++ b/app/models/health_answer.rb
@@ -9,6 +9,8 @@ class HealthAnswer
                 :next_question,
                 :follow_up_question
 
+  validates :notes, length: { maximum: 1023 }
+
   validates :response, presence: true, inclusion: { in: %w[yes no] }
   validates :notes, presence: true, if: -> { response == "yes" }
 

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -43,6 +43,8 @@ class PatientSession < ApplicationRecord
 
   encrypts :gillick_competence_notes
 
+  validates :gillick_competence_notes, length: { maximum: 1023 }
+
   def vaccination_record
     vaccination_records.where.not(recorded_at: nil).last
   end

--- a/app/models/triage.rb
+++ b/app/models/triage.rb
@@ -34,6 +34,8 @@ class Triage < ApplicationRecord
 
   encrypts :notes
 
+  validates :notes, length: { maximum: 1023 }
+
   validates :status,
             presence: true,
             inclusion: {

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -62,6 +62,8 @@ class VaccinationRecord < ApplicationRecord
 
   encrypts :notes
 
+  validates :notes, length: { maximum: 1023 }
+
   validates :administered, inclusion: [true, false]
   validates :batch_id, presence: true, on: :edit_batch, if: -> { administered }
   validates :delivery_site,

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -96,6 +96,9 @@
       id: @patient.id,
     ),
  method: :put do |f| %>
+
+    <% content_for(:before_content) { f.govuk_error_summary } %>
+
     <div class="nhsuk-card">
       <div class="nhsuk-card__content">
         <%= f.govuk_text_area :notes,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -234,10 +234,13 @@ en:
               missing_day: Enter a day
             common_name:
               blank: Enter a name
+              too_long: Enter a name that is less than 255 characters long
             first_name:
               blank: Enter a first name
+              too_long: Enter a first name that is less than 255 characters long
             last_name:
               blank: Enter a last name
+              too_long: Enter a last name that is less than 255 characters long
             use_common_name:
               inclusion: Tell us whether they use a different name
             is_this_their_school:
@@ -245,34 +248,46 @@ en:
               blank: Tell us if this is their school
             parent_name:
               blank: Enter your name
+              too_long: Enter a name that is less than 255 characters long
             parent_relationship:
               blank: Choose your relationship
               inclusion: Choose a relationship
             parent_relationship_other:
               blank: Enter your relationship
+              too_long: Enter a relationship that are less than 255 characters long
             parent_email:
               blank: Enter your email address
               invalid: Enter a valid email address, such as j.doe@gmail.com
+              too_long: Enter an email address that is less than 255 characters long
             parent_phone:
               invalid: Enter a valid phone number, like 07632 960 001
+              too_long: Enter a phone number that is less than 255 characters long
             contact_method:
               inclusion: Choose a contact method
             contact_method_other:
               blank: Enter details about how to contact you
+              too_long: Enter details that are less than 255 characters long
             response:
               blank: Choose if you consent
             reason:
               blank: Choose a reason
+            reason_notes:
+              too_long: Enter details for refusal that are less than 1023 characters long
             contact_injection:
               inclusion: Choose if you want to be contacted
             gp_response:
               blank: Choose if your child is registered with a GP
             gp_name:
               blank: Enter the GP surgery name
+              too_long: Enter a GP name that is less than 255 characters long
             address_line_1:
               blank: Enter the first line of your address
+              too_long: Enter a first line of address that is less than 255 characters long
+            address_line_2:
+              too_long: Enter a second line of address that is less than 255 characters long
             address_town:
               blank: Enter a town or city
+              too_long: Enter a town or city that is less than 255 characters long
             address_postcode:
               blank: Enter a postcode
         user:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,7 @@ en:
               inclusion: Choose an answer
             notes:
               blank: Enter details
+              too_long: Enter details that are less than 1023 characters long
   activerecord:
     attributes:
       consent:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,6 +207,7 @@ en:
               inclusion: Choose if they are Gillick competent
             gillick_competence_notes:
               blank: Enter details of your assessment
+              too_long: Enter details that are less than 1023 characters long
         consent:
           attributes:
             parent_name:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -208,20 +208,24 @@ en:
           attributes:
             parent_name:
               blank: Enter a name
+              too_long: Enter a name that is less than 255 characters long
             parent_phone:
               blank: Enter a phone number
               invalid: Enter a valid phone number, like 07632 960 001
+              too_long: Enter a phone number that is less than 255 characters long
             parent_relationship:
               blank: Choose a relationship
               inclusion: Choose a relationship
             parent_relationship_other:
               blank: Enter a relationship
+              too_long: Enter a relationship that is less than 255 characters long
             response:
               inclusion: Choose if they consent
             reason_for_refusal:
               inclusion: Choose a reason
             reason_for_refusal_other:
               blank: Enter a reason
+              too_long: Enter a reason that is less than 1023 characters long
         consent_form:
           attributes:
             date_of_birth:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -311,3 +311,4 @@ en:
               inclusion: Choose a status
             notes:
               blank: Enter triage notes
+              too_long: Enter triage notes that are less than 1023 characters long

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -195,6 +195,8 @@ en:
               blank: Choose a method of delivery
             delivery_site:
               blank: Choose a delivery site
+            notes:
+              too_long: Enter notes that are less than 1023 characters long
             site:
               blank: Choose a site
             reason:


### PR DESCRIPTION
These are intended as a backstop to ensure that nobody can enter in large amounts of data which could serve as a DOS. In cases where validations are scoped to specific steps in a form wizard, this protection is implemented outside of that scope so that if someone circumvents the wizard step for whatever reason, we are still protected. 

The size limits here follow the general rule of thumb where fields that are entered on a single line have a maximum of 255 chars and fields that use a text area have a max of 1023. These numbers are guesses as to what's best, I'd almost prefer to just use 1000 everywhere. Also, the wording is my best guess.

Discussion and suggestions welcome, but we should probably get this merged in before Monday and we can look at updating size limits, wording, etc, later. If anyone spots fields that aren't protected that should be I'll fix them in this PR.


## Nurse consent journey:
![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/d1c828ef-090c-4b1c-a5f8-422cc6d5bb29)

NB: On the page below there's also a `triage notes` input that is also protected, however due to implementation reasons it results in a 500 error instead of a nice validation message. This may be considered tech debt, but not a blocker to this chance since we'd rather have a 500 error than 1GB of data in the triage notes.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/751e9df5-b71c-4091-b4d6-683a9feb386f)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/3ed37069-6574-4976-b54e-d4b20e7a91e9)

## Gillick assessment journey:

The nurse's notes are protected but similar to the triage notes issue above, overflowing this field triggers a 500 error instead of a nice error.

## Triage card of patient page:
![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/73a6adef-874f-4230-ba87-7eeceb35990f)

## Vaccination journey:
![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/bd187656-efb9-43c4-a4d5-c4a00318ee8e)

## Parental consent journey:
![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/30c4ac91-12ea-4d59-a36a-890b67cd362e)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/f8e9f1de-6ca5-4075-afcd-1c1b7007f314)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/852a2a3f-b35c-409e-b0bf-4f78ac0664d5)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/76ba2b47-9db6-4145-a824-a2bbcd9fda66)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/0b25ba49-d51b-4ec5-b86a-c39d9bd60d2d)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/c17f5ce5-db8f-47ab-81a5-6ac31724d750)

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/fa52950c-128e-4ca1-ae77-a3b525f5da42)
