### PR TITLE
Remove pen testers from pentest campaigns

### DIFF
--- a/db/sample_data/pentest-campaign-1.json
+++ b/db/sample_data/pentest-campaign-1.json
@@ -6,10 +6,6 @@
     "name": "SAIS team 625615",
     "users": [
       {
-        "full_name": "Liam Follin",
-        "email": "liam.follin@kpmg.co.uk"
-      },
-      {
         "full_name": "Nurse Joy",
         "email": "nurse.joy@example.com"
       }

--- a/db/sample_data/pentest-campaign-2.json
+++ b/db/sample_data/pentest-campaign-2.json
@@ -6,10 +6,6 @@
     "name": "SAIS team 99751",
     "users": [
       {
-        "full_name": "Jack Walsh",
-        "email": "jack.walsh@kpmg.co.uk"
-      },
-      {
         "full_name": "Nurse Jackie",
         "email": "nurse.jackie@example.com"
       }


### PR DESCRIPTION
We agreed that we'd prefer to add them via rake task.