### PR TITLE
Remove unused fields from Consent model

### DIFF
--- a/app/avo/resources/consent.rb
+++ b/app/avo/resources/consent.rb
@@ -10,13 +10,6 @@ class Avo::Resources::Consent < Avo::BaseResource
     # Fields generated from the model
     field :patient_id, as: :number
     field :campaign_id, as: :number
-    field :childs_name, as: :textarea
-    field :common_name, as: :textarea
-    field :childs_dob, as: :date
-    field :address_line_1, as: :textarea
-    field :address_line_2, as: :textarea
-    field :address_town, as: :textarea
-    field :address_postcode, as: :textarea
     field :parent_name, as: :textarea
     field :parent_relationship,
           as: :select,
@@ -29,8 +22,6 @@ class Avo::Resources::Consent < Avo::BaseResource
     field :response, as: :select, enum: ::Consent.responses
     field :reason_for_refusal, as: :select, enum: ::Consent.reason_for_refusals
     field :reason_for_refusal_other, as: :textarea
-    field :gp_response, as: :select, enum: ::Consent.gp_responses
-    field :gp_name, as: :textarea
     field :route, as: :select, enum: ::Consent.routes
     field :health_answers, as: :code, language: "javascript", only_on: :edit
     field :health_answers, as: :code, language: "javascript" do |record|

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -3,15 +3,6 @@
 # Table name: consents
 #
 #  id                          :bigint           not null, primary key
-#  address_line_1              :text
-#  address_line_2              :text
-#  address_postcode            :text
-#  address_town                :text
-#  childs_dob                  :date
-#  childs_name                 :text
-#  common_name                 :text
-#  gp_name                     :text
-#  gp_response                 :integer
 #  health_answers              :jsonb
 #  parent_contact_method       :integer
 #  parent_contact_method_other :text
@@ -63,7 +54,6 @@ class Consent < ApplicationRecord
          other
        ],
        prefix: true
-  enum :gp_response, %w[yes no dont_know]
   enum :route, %i[website phone paper in_person self_consent], prefix: "via"
 
   serialize :health_answers, coder: HealthAnswer::ArraySerializer

--- a/db/migrate/20240108120307_remove_unused_consent_columns.rb
+++ b/db/migrate/20240108120307_remove_unused_consent_columns.rb
@@ -1,0 +1,15 @@
+class RemoveUnusedConsentColumns < ActiveRecord::Migration[7.1]
+  def change
+    change_table :consents, bulk: true do |t|
+      t.remove :childs_dob, type: :text
+      t.remove :childs_name, type: :text
+      t.remove :common_name, type: :text
+      t.remove :address_line_1, type: :text
+      t.remove :address_line_2, type: :text
+      t.remove :address_postcode, type: :text
+      t.remove :address_town, type: :text
+      t.remove :gp_name, type: :text
+      t.remove :gp_response, type: :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_08_112551) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_08_120307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -95,13 +95,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_112551) do
   create_table "consents", force: :cascade do |t|
     t.bigint "patient_id", null: false
     t.bigint "campaign_id", null: false
-    t.text "childs_name"
-    t.text "common_name"
-    t.date "childs_dob"
-    t.text "address_line_1"
-    t.text "address_line_2"
-    t.text "address_town"
-    t.text "address_postcode"
     t.text "parent_name"
     t.integer "parent_relationship"
     t.text "parent_relationship_other"
@@ -112,8 +105,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_08_112551) do
     t.integer "response"
     t.integer "reason_for_refusal"
     t.text "reason_for_refusal_other"
-    t.integer "gp_response"
-    t.text "gp_name"
     t.integer "route", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/lib/example_campaign_data.rb
+++ b/lib/example_campaign_data.rb
@@ -110,15 +110,6 @@ class ExampleCampaignData
             "reasonForRefusalOtherReason"
           ]
 
-          consent[:childs_name] = consent_example["childsName"]
-          consent[:childs_dob] = consent_example["childsDob"]
-          consent[:common_name] = consent_example["childsCommonName"]
-
-          consent[:address_line_1] = consent_example["addressLine1"]
-          consent[:address_line_2] = consent_example["addressLine2"]
-          consent[:address_postcode] = consent_example["addressPostcode"]
-          consent[:address_town] = consent_example["addressTown"]
-
           consent[:parent_name] = consent_example["parentName"]
           consent[:parent_relationship] = consent_example["parentRelationship"]
           consent[:parent_relationship_other] = consent_example[
@@ -132,9 +123,6 @@ class ExampleCampaignData
           consent[:parent_contact_method_other] = consent_example[
             "parentContactMethodOther"
           ]
-
-          consent[:gp_response] = consent_example["gpResponse"]
-          consent[:gp_name] = consent_example["gpName"]
 
           consent[:route] = consent_example["route"]
 

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -3,15 +3,6 @@
 # Table name: consents
 #
 #  id                          :bigint           not null, primary key
-#  address_line_1              :text
-#  address_line_2              :text
-#  address_postcode            :text
-#  address_town                :text
-#  childs_dob                  :date
-#  childs_name                 :text
-#  common_name                 :text
-#  gp_name                     :text
-#  gp_response                 :integer
 #  health_answers              :jsonb
 #  parent_contact_method       :integer
 #  parent_contact_method_other :text

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -3,15 +3,6 @@
 # Table name: consents
 #
 #  id                          :bigint           not null, primary key
-#  address_line_1              :text
-#  address_line_2              :text
-#  address_postcode            :text
-#  address_town                :text
-#  childs_dob                  :date
-#  childs_name                 :text
-#  common_name                 :text
-#  gp_name                     :text
-#  gp_response                 :integer
 #  health_answers              :jsonb
 #  parent_contact_method       :integer
 #  parent_contact_method_other :text


### PR DESCRIPTION
These were originally added before we understood the data model the way we currently do.