### PR TITLE
Enable DB encryption at rest

### DIFF
--- a/copilot/environments/addons/db.yml
+++ b/copilot/environments/addons/db.yml
@@ -129,6 +129,7 @@ Resources:
           !FindInMap [dbEnvScalingConfigurationMap, All, DBMinCapacity]
         MaxCapacity:
           !FindInMap [dbEnvScalingConfigurationMap, All, DBMaxCapacity]
+      StorageEncrypted: true
 
   dbDBWriterInstance:
     Metadata:


### PR DESCRIPTION
This parameter is documented here:

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbcluster.html#cfn-rds-dbcluster-storageencrypted

A feature request for AWS Copilot to include it by default is here:

https://github.com/aws/copilot-cli/issues/4949

And further discussion of encrypting Amazon Aurora DBs is here:

https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Overview.Encryption.html

It's not clear whether this will trigger a rebuild of the DB on the next deploy, or whether we'll manually need to recreate the environment. The official suggestion is to:

- create a snapshot
- copy it with encryption enabled to create an encrypted snapshot
- create a new db with the encrypted snapshot
- point the app to the new dbcluster

We'll probably just want to reload the example data from scratch.

Regarding key management, without the KmsKeyId parameter set, the encryption will use the default KMS key. I'm not sure if this is Good Enough, whether we need to specify a non-default AWS-managed key, or create a customer managed key. TBD.