### PR TITLE
Deny default access in copilot

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -30,6 +30,7 @@ network:
   connect: true # Enable Service Connect for intra-environment traffic between services.
   vpc:
     flow_logs: on
+    deny_default: true
     security_groups:
       - from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-dbSecurityGroup
 


### PR DESCRIPTION
Copilot includes a security group that allows our containers to talk to each other by default. That's being picked up in a pen test and we probably don't need that.

https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#network-vpc-security-groups-deny-default

Issue also discussed here:

https://github.com/aws/copilot-cli/issues/2848