### PR TITLE
Make bin/lint quieter

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 bin/bundle exec rubocop --autocorrect-all
-yarn prettier --write --ignore-unknown '**/*'
-bin/bundle exec brakeman
+yarn prettier --write --list-different --ignore-unknown '**/*'
+bin/bundle exec brakeman --quiet --no-summary --no-pager


### PR DESCRIPTION
This removes the default progress reports so that we can better focus on any warning or errors emitted from the linters.