### PR TITLE
Add phase banners

### DIFF
--- a/app/assets/stylesheets/_phase-banner.scss
+++ b/app/assets/stylesheets/_phase-banner.scss
@@ -1,0 +1,16 @@
+.nhsuk-phase-banner {
+  @extend .govuk-phase-banner;
+
+  &__content {
+    @extend .govuk-phase-banner__content;
+  }
+
+  &__content__tag {
+    @extend .govuk-phase-banner__content__tag;
+    background-color: $color_nhsuk-blue;
+  }
+
+  &__text {
+    @extend .govuk-phase-banner__text;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,6 +4,7 @@
     Arial,
     sans-serif,
   ),
+  $govuk-border-colour: #d8dde0,
   $govuk-brand-colour: #005eb8,
   $govuk-error-colour: #d5281b,
   $govuk-success-colour: #007f3b,
@@ -29,6 +30,7 @@ $color_app-pale-blue: #ccdff1;
 @import "notification-banner";
 @import "offline";
 @import "panel";
+@import "phase-banner";
 @import "table";
 @import "tag";
 @import "status";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :set_disable_cache_headers
   before_action :set_header_path
   before_action :set_service_name
+  before_action :set_phase_banner_text
 
   class UnprocessableEntity < StandardError
   end
@@ -31,6 +32,11 @@ class ApplicationController < ActionController::Base
 
   def set_service_name
     @service_name = "Manage vaccinations in schools"
+  end
+
+  def set_phase_banner_text
+    @phase_banner_text =
+      "This is a pilot service. Do not use it to make clinical decisions."
   end
 
   def set_disable_cache_headers

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -28,5 +28,9 @@ module ParentInterface
     def set_service_name
       @service_name = "Give or refuse consent for vaccinations"
     end
+
+    def set_phase_banner_text
+      @phase_banner_text = "This is a pilot service."
+    end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,6 +69,12 @@
       </nav>
     </header>
 
+    <%= govuk_phase_banner(
+      classes: ["nhsuk-width-container"],
+      tag: { text: "Pilot" },
+      text: @phase_banner_text
+    ) %>
+
     <%= yield :before_main %>
 
     <div class="nhsuk-width-container">


### PR DESCRIPTION
Add phase banner to application layout, and because the text we show varies between what parents see and what SAIS teams see, set @phase_banner_text using `set_phase_banner_text`, like we do for service name, etc.

<img width="600" alt="Screenshot of phase banner for manage service." src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/4b53dad2-58fd-447f-903a-f0c0bea60807">
<img width="600" alt="Screenshot of phase banner for consent service." src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/c9a54fcd-5bbe-4915-b776-af9ce41ff2b4">
