### PR TITLE
Add initial cohort upload controller and pages

### DIFF
--- a/app/controllers/pilot_controller.rb
+++ b/app/controllers/pilot_controller.rb
@@ -1,0 +1,7 @@
+class PilotController < ApplicationController
+  def manage
+  end
+
+  def cohort
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -21,6 +21,13 @@
 <hr>
 
 <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
+  <%= link_to "Manage pilot", manage_pilot_path %>
+</h2>
+<p>
+  Download a list of parents interested in the pilot, and upload a cohort list
+</p>
+
+<h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
   <%= link_to "Manage team", "#" %>
 </h2>
 <p>Add or remove team members and set permissions</p>

--- a/app/views/pilot/cohort.html.erb
+++ b/app/views/pilot/cohort.html.erb
@@ -1,0 +1,11 @@
+<% page_title = "Upload the cohort list" %>
+
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+    { text: 'Home', href: dashboard_path },
+    { text: 'Manage pilot', href: manage_pilot_path },
+    { text: page_title }
+  ]) %>
+<% end %>
+
+<%= h1 page_title, class: 'nhsuk-heading-l' %>

--- a/app/views/pilot/manage.html.erb
+++ b/app/views/pilot/manage.html.erb
@@ -1,0 +1,7 @@
+<%= h1 "Manage pilot" %>
+
+<h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
+  <%= link_to "Upload the cohort list", cohort_pilot_path %>
+</h2>
+
+<p>Upload a list of children to vaccinate in the pilot</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,11 @@ Rails.application.routes.draw do
 
   get "/csrf", to: "csrf#new"
 
+  resource :pilot do
+    get "/", to: "pilot#manage", as: :manage
+    get "/cohort", to: "pilot#cohort", as: :cohort
+  end
+
   resources :sessions, only: %i[index show] do
     get "consents", to: "consents#index", on: :member
     get "triage", to: "triage#index", on: :member

--- a/tests/pilot_cohort.spec.ts
+++ b/tests/pilot_cohort.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, Page } from "@playwright/test";
+import { signInTestUser } from "./shared";
+
+let p: Page;
+
+test("Pilot - manage cohort", async ({ page }) => {
+  p = page;
+
+  await given_the_app_is_setup();
+  await and_i_am_signed_in();
+
+  await when_i_visit_the_dashboard();
+  await then_i_should_see_the_manage_pilot_link();
+
+  await when_i_click_the_manage_pilot_link();
+  await then_i_should_see_the_manage_pilot_page();
+
+  await when_i_click_the_upload_cohort_link();
+  await then_i_should_see_the_upload_cohort_page();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function and_i_am_signed_in() {
+  await signInTestUser(p);
+}
+
+async function when_i_visit_the_dashboard() {
+  await p.goto("/dashboard");
+}
+
+async function then_i_should_see_the_manage_pilot_link() {
+  await expect(p.getByRole("link", { name: "Manage pilot" })).toBeVisible();
+}
+
+async function when_i_click_the_manage_pilot_link() {
+  await p.getByRole("link", { name: "Manage pilot" }).click();
+}
+
+async function then_i_should_see_the_manage_pilot_page() {
+  await expect(
+    p.getByRole("heading", { level: 1, name: "Manage pilot" }),
+  ).toBeVisible();
+}
+
+async function when_i_click_the_upload_cohort_link() {
+  await p.getByRole("link", { name: "Upload the cohort list" }).click();
+}
+
+async function then_i_should_see_the_upload_cohort_page() {
+  await expect(
+    p.getByRole("heading", { name: "Upload the cohort list" }),
+  ).toBeVisible();
+}


### PR DESCRIPTION
Form and upload-handling functionality coming in a follow-up.

## Manage pilot link

![Screenshot 2024-01-11 at 15 46 47](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/01287ae1-fb75-4536-9867-e7c21fa6a6cc)

## Manage pilot page

![Screenshot 2024-01-11 at 15 47 13](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/8fafed3c-4f91-4e1b-89b8-91990373942c)

## Upload cohort list page

![Screenshot 2024-01-11 at 15 49 18](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/1b237c9b-d832-4d7c-a804-27e3dd6cf5e1)