### PR TITLE
Add registration closed page

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,7 +5,12 @@ class RegistrationsController < ApplicationController
   layout "registration"
 
   def new
-    @registration_form = Registration.new
+    if Flipper.enabled?(:registration_open)
+      @registration_form = Registration.new
+      render "new"
+    else
+      render "closed"
+    end
   end
 
   def create

--- a/app/views/registrations/closed.html.erb
+++ b/app/views/registrations/closed.html.erb
@@ -10,5 +10,5 @@
 
 <p>
   If you’re interested in taking part in future research with the NHS, please
-  email <a href="mailto:england.mavis@nhs.net">anthony.green11@nhs.net</a>.
+  email <%= govuk_mail_to t("service.nhs_ur_email") %>.
 </p>

--- a/app/views/registrations/closed.html.erb
+++ b/app/views/registrations/closed.html.erb
@@ -1,0 +1,14 @@
+<% page_title = "The deadline for registering your interest in the NHS school vaccinations pilot has passed" %>
+
+<%= h1 page_title, class: "nhsuk-heading-xl" %>
+
+<p>
+  If you have not already responded to messages from your child’s school about
+  the HPV vaccination, please do so. The routine vaccination campaign is running
+  in parallel with the pilot.
+</p>
+
+<p>
+  If you’re interested in taking part in future research with the NHS, please
+  email <a href="mailto:england.mavis@nhs.net">anthony.green11@nhs.net</a>.
+</p>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -125,7 +125,7 @@
 
     <p>
       Taking part in the pilot is voluntary. You can withdraw at any time by
-      emailing <a href="mailto:england.manage-childrens-vaccinations@nhs.net">england.manage-childrens-vaccinations@nhs.net</a>.
+      emailing <%= govuk_mail_to t("service.email") %>.
     </p>
 
     <p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,7 +4,8 @@ en:
     success: Success
     warning: Warning
   service:
-    email: england.manage-childrens-vaccinations@nhs.net
+    email: england.mavis@nhs.net
+    nhs_ur_email: anthony.green11@nhs.net
     temporary_cumbria_phone: "01900 705 045"
   wicked:
     # ConsentForm

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe ConsentFormMailer, type: :mailer do
-  let(:team_email) { "england.manage-childrens-vaccinations@nhs.net" }
+  let(:team_email) { "england.mavis@nhs.net" }
   let(:team_phone) { "01900 705 045" }
 
   def consent_form(overrides = {})

--- a/tests/pilot_registration.spec.ts
+++ b/tests/pilot_registration.spec.ts
@@ -7,6 +7,7 @@ test("Pilot registration", async ({ page }) => {
   p = page;
 
   await given_the_app_is_setup();
+  await and_registration_is_open();
 
   await when_i_go_to_the_registration_page_for_a_school();
   await then_i_see_the_page_with_the_school_name();
@@ -23,6 +24,16 @@ test("Pilot registration", async ({ page }) => {
 
 async function given_the_app_is_setup() {
   await p.goto("/reset");
+}
+
+async function and_registration_is_open() {
+  await signInTestUser(p);
+  await p.goto("/flipper/features/registration_open");
+  await expect(p.getByText("Home Features registration_open")).toBeVisible();
+  if (await p.getByText("Disabled").isVisible()) {
+    await p.getByRole("button", { name: "Fully Enable" }).click();
+    await expect(p.getByText("Fully enabled")).toBeVisible();
+  }
 }
 
 async function when_i_go_to_the_registration_page_for_a_school() {


### PR DESCRIPTION
This gets shown when registration is not open, as controlled by a feature flag.

Still need to hear back if this is the right email address to use, though. Will wait for that before merging.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/4a399ec5-f744-4585-9ce3-74a3a7c1bcef)
