### PR TITLE
Add /pilot/registrations page

### DIFF
--- a/app/controllers/pilot_controller.rb
+++ b/app/controllers/pilot_controller.rb
@@ -1,9 +1,16 @@
 class PilotController < ApplicationController
-  layout "two_thirds"
+  layout "two_thirds", except: %i[registrations]
 
   def manage
   end
 
   def manual
+  end
+
+  def registrations
+    @registrations =
+      Registration
+        .where(location_id: current_user.team.locations.map(&:id))
+        .group_by { |r| r.location.name }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,4 +39,9 @@ class User < ApplicationRecord
 
   encrypts :email, deterministic: true
   encrypts :full_name
+
+  def team
+    # TODO: Update the app to properly support multiple teams per user
+    teams.first
+  end
 end

--- a/app/views/pilot/manage.html.erb
+++ b/app/views/pilot/manage.html.erb
@@ -1,13 +1,16 @@
 <%= h1 "Manage pilot" %>
 
 <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
+  <%= link_to "See who’s interested in the pilot", pilot_registrations_path %>
+</h2>
+<p>View and download a list of parents interested in the pilot</p>
+
+<h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
   <%= link_to "Find out how to create a pilot cohort", manual_pilot_path %>
 </h2>
-
 <p>Get instructions on how to create a pilot cohort</p>
 
 <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
   <%= link_to "Upload the cohort list", new_pilot_cohort_path %>
 </h2>
-
 <p>Upload a list of children to vaccinate in the pilot</p>

--- a/app/views/pilot/manual.html.erb
+++ b/app/views/pilot/manual.html.erb
@@ -58,9 +58,7 @@
 <p class="nhsuk-body">
   You can see how many people have expressed their interest in joining the pilot
   from each school in
-  <a class="nhsuk-link" href="/pilot/participants"
-    >Parents interested in the pilot</a
-  >.
+  <%= link_to "Parents interested in the pilot", pilot_registrations_path %>.
 </p>
 <p class="nhsuk-body">
   When you have more than 110 responses overall, and a suitable number from each
@@ -107,9 +105,7 @@
 <p class="nhsuk-body">
   Once you reach the desired number of eligible children for a particular
   school, go to
-  <a class="nhsuk-link" href="/pilot/participants"
-    >Parents interested in the pilot</a
-  >
+  <%= link_to "Parents interested in the pilot", pilot_registrations_path %>
   and click on the link labelled ‘Close pilot to new participants at this
   school’.
 </p>

--- a/app/views/pilot/registrations.html.erb
+++ b/app/views/pilot/registrations.html.erb
@@ -1,0 +1,42 @@
+<% page_title = "Parents interested in the pilot" %>
+
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+    { text: 'Home', href: dashboard_path },
+    { text: 'Manage pilot', href: manage_pilot_path },
+    { text: page_title }
+  ]) %>
+<% end %>
+
+<%= h1 page_title, class: 'nhsuk-heading-l' %>
+
+<% if @registrations.empty? %>
+  <p>No parents have registered their interest in the pilot yet.</p>
+<% end %>
+
+<% @registrations.each do |school, responses| %>
+  <%= render AppCardComponent.new(heading: school) do %>
+    <%= govuk_table do |table|
+      table.with_caption(text: pluralize(responses.count, "response"),
+                         classes: 'nhsuk-u-font-size-19')
+
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: 'Name')
+          row.with_cell(text: 'Email Address')
+          row.with_cell(text: 'Phone number')
+        end
+      end
+
+      table.with_body do |body|
+        responses.each do |response|
+          body.with_row do |row|
+            row.with_cell(text: response.parent_name)
+            row.with_cell(text: response.parent_email)
+            row.with_cell(text: response.parent_phone)
+          end
+        end
+      end
+    end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,10 @@ Rails.application.routes.draw do
     get "/", to: "pilot#manage", as: :manage
     get "/manual", to: "pilot#manual", as: :manual
 
+    resources :registrations, only: %i[] do
+      get "/", to: "pilot#registrations", on: :collection
+    end
+
     resource :cohort_list, as: :cohort, only: %i[new create] do
       get "success", on: :collection
     end

--- a/tests/pilot_download_cohort.spec.ts
+++ b/tests/pilot_download_cohort.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect, Page } from "@playwright/test";
+import { signInTestUser } from "./shared";
+
+let p: Page;
+
+test("Pilot - upload cohort", async ({ page }) => {
+  p = page;
+
+  await given_the_app_is_setup();
+  await and_i_am_signed_in();
+
+  await when_i_visit_the_dashboard();
+  await then_i_should_see_the_manage_pilot_link();
+
+  await when_i_click_the_manage_pilot_link();
+  await then_i_should_see_the_manage_pilot_page();
+
+  await when_i_click_the_registrations_link();
+  await then_i_should_see_the_registrations_page();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function and_i_am_signed_in() {
+  await signInTestUser(p);
+}
+
+async function when_i_visit_the_dashboard() {
+  await p.goto("/dashboard");
+}
+
+async function then_i_should_see_the_manage_pilot_link() {
+  await expect(p.getByRole("link", { name: "Manage pilot" })).toBeVisible();
+}
+
+async function when_i_click_the_manage_pilot_link() {
+  await p.getByRole("link", { name: "Manage pilot" }).click();
+}
+
+async function then_i_should_see_the_manage_pilot_page() {
+  await expect(
+    p.getByRole("heading", { level: 1, name: "Manage pilot" }),
+  ).toBeVisible();
+}
+
+async function when_i_click_the_registrations_link() {
+  await p
+    .getByRole("link", { name: "See who’s interested in the pilot" })
+    .click();
+}
+
+async function then_i_should_see_the_registrations_page() {
+  await expect(
+    p.getByRole("heading", {
+      level: 1,
+      name: "Parents interested in the pilot",
+    }),
+  ).toBeVisible();
+}

--- a/tests/pilot_upload_cohort.spec.ts
+++ b/tests/pilot_upload_cohort.spec.ts
@@ -3,7 +3,7 @@ import { signInTestUser } from "./shared";
 
 let p: Page;
 
-test("Pilot - manage cohort", async ({ page }) => {
+test("Pilot - upload cohort", async ({ page }) => {
   p = page;
 
   await given_the_app_is_setup();


### PR DESCRIPTION
Prerequisites:

- https://github.com/nhsuk/manage-childrens-vaccinations/pull/849
- https://github.com/nhsuk/manage-childrens-vaccinations/pull/850
- https://github.com/nhsuk/manage-childrens-vaccinations/pull/856

This displays all the registrations that have been submitted by parents to participate in the pilot.

TODO:

- [x] https://github.com/nhsuk/manage-childrens-vaccinations/pull/856
- [x] Add end to end test

### Manage pilot page

![Screenshot 2024-01-18 at 16 40 59](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/e99a7e7b-6851-4ced-895c-a7bc0dd44b60)

### Empty state

![Screenshot 2024-01-18 at 16 40 41](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/752bc41e-ca88-4917-a307-ffd7be77f40a)

### State with registrations

Coming soon