### PR TITLE
Add filtering to patient tables

### DIFF
--- a/app/assets/stylesheets/_action-table.scss
+++ b/app/assets/stylesheets/_action-table.scss
@@ -1,3 +1,14 @@
+action-table-filters,
+action-table-no-results {
+  display: none;
+
+  @include mq($from: tablet) {
+    &:defined {
+      display: block;
+    }
+  }
+}
+
 action-table {
   display: block;
 
@@ -35,22 +46,5 @@ action-table {
   & th[aria-sort="descending"] button::after {
     opacity: 1;
     transform: rotate(180deg);
-  }
-
-  .no-results p {
-    text-transform: lowercase;
-
-    &::first-letter {
-      text-transform: uppercase;
-    }
-
-    &:first-of-type {
-      @extend .nhsuk-heading-m;
-    }
-  }
-
-  .no-results button {
-    @include nhsuk-link-style-default;
-    font-weight: normal;
   }
 }

--- a/app/assets/stylesheets/_button.scss
+++ b/app/assets/stylesheets/_button.scss
@@ -1,0 +1,4 @@
+.app-button--small {
+  @include nhsuk-typography-responsive(16);
+  padding: nhsuk-spacing(1) nhsuk-spacing(2);
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,6 +25,7 @@ $nhsuk-fonts-path: "/";
 $color_app-pale-blue: #ccdff1;
 
 @import "action-table";
+@import "button";
 @import "card";
 @import "dev-tools";
 @import "file-upload";
@@ -39,3 +40,10 @@ $color_app-pale-blue: #ccdff1;
 @import "status";
 @import "summary-list";
 @import "utilities";
+
+// NHS.UK Frontend overrides
+.nhsuk-label--s,
+.nhsuk-fieldset__legend--s {
+  padding-top: nhsuk-spacing(2);
+  margin-bottom: nhsuk-spacing(2);
+}

--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -1,0 +1,32 @@
+<action-table class="nhsuk-grid-row" sort="name">
+  <div class="nhsuk-grid-column-one-quarter">
+    <%= render AppPatientTableFilterComponent.new(tab_id: @tab_id) %>
+  </div>
+  <div class="nhsuk-grid-column-three-quarters">
+    <%= govuk_table(classes: "app-table--patients nhsuk-u-margin-0") do |table| %>
+      <%= table.with_head do |head| %>
+        <%= head.with_row do |row| %>
+          <%= @columns.each do |column| %>
+            <%= row.with_cell(
+              text: column_name(column),
+              html_attributes: { "data-col": column }
+            ) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= table.with_body do |body| %>
+        <%= @patient_sessions.each do |patient_session| %>
+          <%= body.with_row do |row| %>
+            <%= @columns.each do |column| %>
+              <%= row.with_cell(**column_value(patient_session, column)) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+    <action-table-no-results>
+      <%= render AppEmptyListComponent.new() %>
+    </action-table-no-results>
+  </div>
+</action-table>

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -1,41 +1,13 @@
 class AppPatientTableComponent < ViewComponent::Base
   include ApplicationHelper
 
-  def call
-    tag.action_table(sort: "name") do
-      govuk_table(classes: "app-table--patients nhsuk-u-margin-0") do |table|
-        table.with_head do |head|
-          head.with_row do |row|
-            @columns.each do |column|
-              row.with_cell(
-                text: column_name(column),
-                html_attributes: {
-                  "data-col": column
-                }
-              )
-            end
-          end
-        end
-
-        table.with_body do |body|
-          @patient_sessions.each do |patient_session|
-            body.with_row do |row|
-              @columns.each do |column|
-                row.with_cell(**column_value(patient_session, column))
-              end
-            end
-          end
-        end
-      end
-    end
-  end
-
-  def initialize(patient_sessions:, columns: %i[name dob], route: nil)
+  def initialize(patient_sessions:, tab_id:, columns: %i[name dob], route: nil)
     super
 
     @patient_sessions = patient_sessions
     @columns = columns
     @route = route
+    @tab_id = tab_id
   end
 
   private
@@ -53,6 +25,8 @@ class AppPatientTableComponent < ViewComponent::Base
         text:
           patient_session.patient.date_of_birth.to_fs(:nhsuk_date_short_month),
         html_attributes: {
+          "data-filter":
+            patient_session.patient.date_of_birth.strftime("%d/%m/%Y"),
           "data-sort": patient_session.patient.date_of_birth
         }
       }

--- a/app/components/app_patient_table_filter_component.html.erb
+++ b/app/components/app_patient_table_filter_component.html.erb
@@ -1,0 +1,60 @@
+<action-table-filters>
+  <fieldset class="govuk-fieldset nhsuk-u-margin-top-3">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+      Filter results
+    </legend>
+    <div class="nhsuk-form-group">
+      <label class="nhsuk-label nhsuk-label--s" for="filter-<%= @tab_id %>-name">
+        By name
+      </label>
+      <input class="nhsuk-input" id="filter-<%= @tab_id %>-name" name="name" type="search" autocomplete="off">
+    </div>
+    <div class="nhsuk-form-group">
+      <label class="nhsuk-label nhsuk-label--s nhsuk-u-margin-bottom-0" for="filter-<%= @tab_id %>-dob">
+        By date of birth
+      </label>
+      <div class="nhsuk-hint nhsuk-u-font-size-16" id="filter-<%= @tab_id %>-dob-hint">
+        e.g. 2005 or 01/03/2014
+      </div>
+      <input class="nhsuk-input" id="filter-<%= @tab_id %>-dob" name="dob" type="search" aria-describedby="filter-<%= @tab_id %>-dob-hint" autocomplete="off">
+    </div>
+    <% if @filter_actions %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+            By action needed
+          </legend>
+          <div class="govuk-checkboxes govuk-checkboxes--small">
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="filter-<%= @tab_id %>-action" name="action" type="checkbox" value="Get consent">
+              <label class="govuk-label govuk-checkboxes__label" for="filter-<%= @tab_id %>-action">
+                Get consent
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="filter-<%= @tab_id %>-action-2" name="action" type="checkbox" value="Check refusal">
+              <label class="govuk-label govuk-checkboxes__label" for="filter-<%= @tab_id %>-action-2">
+                Check refusal
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="filter-<%= @tab_id %>-action-3" name="action" type="checkbox" value="Triage">
+              <label class="govuk-label govuk-checkboxes__label" for="filter-<%= @tab_id %>-action-3">
+                Triage
+              </label>
+            </div>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input" id="filter-<%= @tab_id %>-action-4" name="action" type="checkbox" value="Vaccinate">
+              <label class="govuk-label govuk-checkboxes__label" for="filter-<%= @tab_id %>-action-4">
+                Vaccinate
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+    <% end %>
+  </fieldset>
+  <button class="nhsuk-button nhsuk-button--secondary app-button--small" type="reset">
+    Reset filters
+  </button>
+</action-table-filters>

--- a/app/components/app_patient_table_filter_component.rb
+++ b/app/components/app_patient_table_filter_component.rb
@@ -1,0 +1,8 @@
+class AppPatientTableFilterComponent < ViewComponent::Base
+  def initialize(tab_id:, filter_actions: false)
+    super
+
+    @tab_id = tab_id
+    @filter_actions = filter_actions
+  end
+end

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -20,6 +20,7 @@
     if data.size > 0
       render AppPatientTableComponent.new(
         patient_sessions: data,
+        tab_id: label.parameterize,
         columns:,
         route: :consent,
       )

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -20,6 +20,7 @@
     if data.size > 0
       render AppPatientTableComponent.new(
         patient_sessions: data,
+        tab_id: label.parameterize,
         columns:,
         route: :triage,
       )

--- a/app/views/vaccinations/_patient_row.html.erb
+++ b/app/views/vaccinations/_patient_row.html.erb
@@ -4,7 +4,7 @@
                 session_patient_vaccinations_path(patient_session.session, patient_session.patient),
       "data-testid": "child-link" %>
   </td>
-  <td class="nhsuk-table__cell" style="width: 150px" data-sort="<%= patient_session.patient.date_of_birth %>">
+  <td class="nhsuk-table__cell" style="width: 150px" data-filter="<%= patient_session.patient.date_of_birth.strftime("%d/%m/%Y") %>" data-sort="<%= patient_session.patient.date_of_birth %>">
     <%= patient_session.patient.date_of_birth.to_fs(:nhsuk_date_short_month) %>
   </td>
   <td class="nhsuk-table__cell" data-testid="child-action">

--- a/app/views/vaccinations/_patients_with_actions.html.erb
+++ b/app/views/vaccinations/_patients_with_actions.html.erb
@@ -1,50 +1,26 @@
-<div class="nhsuk-grid-row">
+<action-table class="nhsuk-grid-row" sort="name">
   <div class="nhsuk-grid-column-one-quarter">
-    <div class="nhsuk-form-group nhsuk-u-margin-top-3">
-      <label class="nhsuk-label" for="search-<%= id %>">
-        By name
-      </label>
-      <input class="nhsuk-input" id="search-<%= id %>" name="search" type="text" aria-describedby="search-hint">
-    </div>
-    <script>
-      function filterTable() {
-        var inputValue = document.getElementById("search-<%= id %>").value.toLowerCase();
-        var rows = document.getElementById("patients-<%= id %>").querySelectorAll("tbody tr");
-
-        for (var i = 0; i < rows.length; i++) {
-          var nameCell = rows[i].getElementsByTagName("td")[0];
-          var name = nameCell.textContent || nameCell.innerText;
-          if (name.toLowerCase().indexOf(inputValue) > -1) {
-            rows[i].style.display = "";
-          } else {
-            rows[i].style.display = "none";
-          }
-        }
-      }
-      document.getElementById("search-<%= id %>").addEventListener("input", filterTable);
-    </script>
+    <%= render AppPatientTableFilterComponent.new(tab_id: id, filter_actions: true) %>
   </div>
   <div class="nhsuk-grid-column-three-quarters" id="patients-<%= id %>">
     <% if patient_sessions.any? %>
-      <action-table sort="name">
-        <table class="nhsuk-table app-table--patients">
-          <caption class="nhsuk-table__caption nhsuk-visually-hidden">Patients</caption>
-          <thead class="nhsuk-table__head">
-            <tr class="nhsuk-table__row">
-              <th class="nhsuk-table__header" data-col="name">Name</th>
-              <th class="nhsuk-table__header app-u-nowrap" data-col="dob">Date of birth</th>
-              <th class="nhsuk-table__header" data-col="action" style="width: 200px">Action needed</th>
-            </tr>
-          </thead>
-          <tbody class="nhsuk-table__body">
-            <% patient_sessions.each do |patient_session| %>
-              <%= render "patient_row", patient_session: %>
-            <% end %>
-          </tbody>
-        </table>
-      </action-table>
+      <table class="nhsuk-table app-table--patients">
+        <caption class="nhsuk-table__caption nhsuk-visually-hidden">Patients</caption>
+        <thead class="nhsuk-table__head">
+          <tr class="nhsuk-table__row">
+            <th class="nhsuk-table__header" data-col="name">Name</th>
+            <th class="nhsuk-table__header app-u-nowrap" data-col="dob">Date of birth</th>
+            <th class="nhsuk-table__header" data-col="action" style="width: 200px">Action needed</th>
+          </tr>
+        </thead>
+        <tbody class="nhsuk-table__body">
+          <% patient_sessions.each do |patient_session| %>
+            <%= render "patient_row", patient_session: %>
+          <% end %>
+        </tbody>
+      </table>
     <% else %>
       <%= render AppEmptyListComponent.new %>
     <% end %>
   </div>
-</div>
+</action-table>

--- a/app/views/vaccinations/_patients_with_outcomes.html.erb
+++ b/app/views/vaccinations/_patients_with_outcomes.html.erb
@@ -1,50 +1,26 @@
-<div class="nhsuk-grid-row">
+<action-table class="nhsuk-grid-row" sort="name">
   <div class="nhsuk-grid-column-one-quarter">
-    <div class="nhsuk-form-group nhsuk-u-margin-top-3">
-      <label class="nhsuk-label" for="search">
-        By name
-      </label>
-      <input class="nhsuk-input" id="search-<%= id %>" name="search" type="text" aria-describedby="search-hint">
-    </div>
-    <script>
-      function filterTable() {
-        var inputValue = document.getElementById("search-<%= id %>").value.toLowerCase();
-        var rows = document.getElementById("patients-<%= id %>").querySelectorAll("tbody tr");
-
-        for (var i = 0; i < rows.length; i++) {
-          var nameCell = rows[i].getElementsByTagName("td")[0];
-          var name = nameCell.textContent || nameCell.innerText;
-          if (name.toLowerCase().indexOf(inputValue) > -1) {
-            rows[i].style.display = "";
-          } else {
-            rows[i].style.display = "none";
-          }
-        }
-      }
-      document.getElementById("search-<%= id %>").addEventListener("input", filterTable);
-    </script>
+    <%= render AppPatientTableFilterComponent.new(tab_id: id) %>
   </div>
   <div class="nhsuk-grid-column-three-quarters" id="patients-<%= id %>">
     <% if patient_sessions.any? %>
-      <action-table sort="name">
-        <table class="nhsuk-table app-table--patients">
-          <caption class="nhsuk-table__caption nhsuk-visually-hidden">Patients</caption>
-          <thead class="nhsuk-table__head">
-            <tr class="nhsuk-table__row">
-              <th class="nhsuk-table__header" data-col="name">Name</th>
-              <th class="nhsuk-table__header app-u-nowrap" data-col="dob">Date of birth</th>
-              <th class="nhsuk-table__header" data-col="outcome" style="width: 200px">Outcome</th>
-            </tr>
-          </thead>
-          <tbody class="nhsuk-table__body">
-            <% patient_sessions.each do |patient_session| %>
-              <%= render "patient_row", patient_session: %>
-            <% end %>
-          </tbody>
-        </table>
-      </action-table>
+      <table class="nhsuk-table app-table--patients">
+        <caption class="nhsuk-table__caption nhsuk-visually-hidden">Patients</caption>
+        <thead class="nhsuk-table__head">
+          <tr class="nhsuk-table__row">
+            <th class="nhsuk-table__header" data-col="name">Name</th>
+            <th class="nhsuk-table__header app-u-nowrap" data-col="dob">Date of birth</th>
+            <th class="nhsuk-table__header" data-col="outcome" style="width: 200px">Outcome</th>
+          </tr>
+        </thead>
+        <tbody class="nhsuk-table__body">
+          <% patient_sessions.each do |patient_session| %>
+            <%= render "patient_row", patient_session: %>
+          <% end %>
+        </tbody>
+      </table>
     <% else %>
       <%= render AppEmptyListComponent.new %>
     <% end %>
   </div>
-</div>
+</action-table>

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe AppPatientTableComponent, type: :component do
 
   let(:route) { :consent }
   let(:patient_sessions) { create_list(:patient_session, 2) }
-  let(:component) { described_class.new(patient_sessions:, route:) }
+  let(:component) do
+    described_class.new(patient_sessions:, tab_id: "foo", route:)
+  end
 
   it { should have_css(".nhsuk-table") }
   it { should have_css(".nhsuk-table__head") }


### PR DESCRIPTION
This PR uses the `<action-table-filters>` web component to filter rows in patient tables.

<img width="990" alt="Screenshot of patient table with filters." src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/04a891eb-755a-4d32-9fe7-1c110995653d">

I’ve created a ViewComponent for the filters, which takes a `tab_id` (used in `id` and `for` attributes on the filter fields) and `filter_actions`, a boolean to determine if the filters for actions is shown).

A test for this new component is failing currently, not sure how/what I need to change to clear this.