### PR TITLE
Add playwright-reports to ci artifacts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,3 +126,10 @@ jobs:
 
       - name: Run Playwright tests
         run: yarn test:e2e
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright?report
+          retention-days: 10


### PR DESCRIPTION
This makes the videos created by Playwright on test failure available for download. These will show up at the bottom of the action run page as the `playwright-report`artifact.

I've added the globbing character `?` to the path specifier because that causes the `upload-artifact` action to preserve that path in the zipfile. Without it, unzipping the zip file splats the contents of the `playwright-report/` directory into the current dir which is messy and time consuming to clean up if you do it in the wrong place. Not sure why `upload-artifact` doesn't have a better way to do this.

10 days is the maximum retention, presumably set by our open-source status.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/a4b2646f-bdf3-4570-8351-f6c8a8d27e17)
