### PR TITLE
Patient table captions

### DIFF
--- a/app/assets/stylesheets/_tabs.scss
+++ b/app/assets/stylesheets/_tabs.scss
@@ -1,0 +1,5 @@
+.nhsuk-tabs__list-item {
+  @include mq($from: tablet, $until: desktop) {
+    @include nhsuk-font(16);
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,6 +36,7 @@ $color_app-pale-blue: #ccdff1;
 @import "panel";
 @import "phase-banner";
 @import "table";
+@import "tabs";
 @import "tag";
 @import "status";
 @import "summary-list";

--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -4,6 +4,7 @@
   </div>
   <div class="nhsuk-grid-column-three-quarters">
     <%= govuk_table(classes: "app-table--patients nhsuk-u-margin-0") do |table| %>
+      <%= table.with_caption(text: @caption) %>
       <%= table.with_head do |head| %>
         <%= head.with_row do |row| %>
           <%= @columns.each do |column| %>

--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -1,13 +1,20 @@
 class AppPatientTableComponent < ViewComponent::Base
   include ApplicationHelper
 
-  def initialize(patient_sessions:, tab_id:, columns: %i[name dob], route: nil)
+  def initialize(
+    patient_sessions:,
+    tab_id:,
+    caption:,
+    columns: %i[name dob],
+    route: nil
+  )
     super
 
     @patient_sessions = patient_sessions
     @columns = columns
     @route = route
     @tab_id = tab_id
+    @caption = caption
   end
 
   private

--- a/app/components/app_patient_table_filter_component.html.erb
+++ b/app/components/app_patient_table_filter_component.html.erb
@@ -1,6 +1,6 @@
 <action-table-filters>
-  <fieldset class="govuk-fieldset nhsuk-u-margin-top-3">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+  <fieldset class="nhsuk-fieldset">
+    <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m nhsuk-u-padding-top-0 nhsuk-u-font-size-22">
       Filter results
     </legend>
     <div class="nhsuk-form-group">
@@ -19,9 +19,9 @@
       <input class="nhsuk-input" id="filter-<%= @tab_id %>-dob" name="dob" type="search" aria-describedby="filter-<%= @tab_id %>-dob-hint" autocomplete="off">
     </div>
     <% if @filter_actions %>
-      <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+      <div class="nhsuk-form-group">
+        <fieldset class="nhsuk-fieldset">
+          <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--s">
             By action needed
           </legend>
           <div class="govuk-checkboxes govuk-checkboxes--small">

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -13,7 +13,9 @@
 
 <%= h1 page_title, page_title:, class: "govuk-heading-l" %>
 
-<% def consent_tab(slot, label, data, columns: %i[name dob])
+<% def consent_tab(slot, state, columns: %i[name dob])
+  label = t("states.#{state}.label")
+  data = @tabs[state]
   slot.with_tab(id: label.parameterize,
                 label: "#{label} (#{data.size})",
                 classes: 'nhsuk-tabs__panel') do
@@ -21,6 +23,7 @@
       render AppPatientTableComponent.new(
         patient_sessions: data,
         tab_id: label.parameterize,
+        caption: t("states.#{state}.title"),
         columns:,
         route: :consent,
       )
@@ -31,9 +34,8 @@
 end %>
 
 <%= render AppTabComponent.new title: "Consents", classes: 'nhsuk-tabs' do |slot|
-  consent_tab(slot, "Consent given", @tabs[:consent_given?])
-  consent_tab(slot, "Consent refused", @tabs[:consent_refused?],
-              columns: %i[name dob reason])
-  consent_tab(slot, "Consent conflicts", @tabs[:consent_conflicts?])
-  consent_tab(slot, "No response", @tabs[:no_consent?])
+  consent_tab(slot, :consent_given?)
+  consent_tab(slot, :consent_refused?, columns: %i[name dob reason])
+  consent_tab(slot, :consent_conflicts?)
+  consent_tab(slot, :no_consent?)
 end %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -13,7 +13,9 @@
 
 <%= h1 page_title, page_title:, class: "govuk-heading-l" %>
 
-<% def consent_tab(slot, label, data, columns: %i[name dob])
+<% def consent_tab(slot, state, columns: %i[name dob])
+  label = t("states.#{state}.label")
+  data = @tabs[state]
   slot.with_tab(id: label.parameterize,
                 label: "#{label} (#{data.size})",
                 classes: 'nhsuk-tabs__panel') do
@@ -21,6 +23,7 @@
       render AppPatientTableComponent.new(
         patient_sessions: data,
         tab_id: label.parameterize,
+        caption: t("states.#{state}.title"),
         columns:,
         route: :triage,
       )
@@ -31,7 +34,7 @@
 end %>
 
 <%= render AppTabComponent.new title: "Consents", classes: 'nhsuk-tabs' do |slot|
-  consent_tab(slot, "Triage needed", @tabs[:needs_triage])
-  consent_tab(slot, "Triage completed", @tabs[:triage_complete])
-  consent_tab(slot, "No triage needed", @tabs[:no_triage_needed])
+  consent_tab(slot, :needs_triage)
+  consent_tab(slot, :triage_complete)
+  consent_tab(slot, :no_triage_needed)
 end %>

--- a/app/views/vaccinations/_patients_with_actions.html.erb
+++ b/app/views/vaccinations/_patients_with_actions.html.erb
@@ -5,7 +5,7 @@
   <div class="nhsuk-grid-column-three-quarters" id="patients-<%= id %>">
     <% if patient_sessions.any? %>
       <table class="nhsuk-table app-table--patients">
-        <caption class="nhsuk-table__caption nhsuk-visually-hidden">Patients</caption>
+        <caption class="nhsuk-table__caption"><%= t("states.action_needed.title") %></caption>
         <thead class="nhsuk-table__head">
           <tr class="nhsuk-table__row">
             <th class="nhsuk-table__header" data-col="name">Name</th>

--- a/app/views/vaccinations/_patients_with_outcomes.html.erb
+++ b/app/views/vaccinations/_patients_with_outcomes.html.erb
@@ -5,7 +5,7 @@
   <div class="nhsuk-grid-column-three-quarters" id="patients-<%= id %>">
     <% if patient_sessions.any? %>
       <table class="nhsuk-table app-table--patients">
-        <caption class="nhsuk-table__caption nhsuk-visually-hidden">Patients</caption>
+        <caption class="nhsuk-table__caption"><%= caption %></caption>
         <thead class="nhsuk-table__head">
           <tr class="nhsuk-table__row">
             <th class="nhsuk-table__header" data-col="name">Name</th>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -15,17 +15,22 @@
 
 <%=
 render AppTabComponent.new(title: "Vaccinations", classes: 'nhsuk-tabs') do |c|
-  c.with_tab(id: "action-needed", label: "Action needed (#{ @partitioned_patient_sessions[:action_needed].size })", classes: 'nhsuk-tabs__panel') do
+  c.with_tab(id: "action-needed", label: t("states.action_needed.label") + " (#{ @partitioned_patient_sessions[:action_needed].size })", classes: 'nhsuk-tabs__panel') do
     render "patients_with_actions",
            id: "action-needed",
+           caption: t("states.action_needed.title"),
            patient_sessions: @partitioned_patient_sessions[:action_needed]
   end
-  c.with_tab(id: "vaccinated", label: "Vaccinated (#{ @partitioned_patient_sessions[:vaccinated].size })", classes: 'nhsuk-tabs__panel') do
-    render "patients_with_outcomes", id: "vaccinated", patient_sessions: @partitioned_patient_sessions[:vaccinated]
+  c.with_tab(id: "vaccinated", label: t("states.vaccinated.label") + " (#{ @partitioned_patient_sessions[:vaccinated].size })", classes: 'nhsuk-tabs__panel') do
+    render "patients_with_outcomes",
+           id: "vaccinated",
+           caption: t("states.vaccinated.title"),
+           patient_sessions: @partitioned_patient_sessions[:vaccinated]
   end
-  c.with_tab(id: "could-not-vaccinate", label: "Could not vaccinate (#{ @partitioned_patient_sessions[:not_vaccinated].size })", classes: 'nhsuk-tabs__panel') do
+  c.with_tab(id: "could-not-vaccinate", label: t("states.not_vaccinated.label") + " (#{ @partitioned_patient_sessions[:not_vaccinated].size })", classes: 'nhsuk-tabs__panel') do
     render "patients_with_outcomes",
            id: "could-not-vaccinate",
+           caption: t("states.not_vaccinated.title"),
            patient_sessions: @partitioned_patient_sessions[:not_vaccinated]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,37 @@ en:
   page_titles:
     privacy_policy: "Your privacy"
     privacy_policy_summary: "Your privacy"
+  states:
+    consent_given?:
+      label: Given
+      title: Children with consent given
+    consent_refused?:
+      label: Refused
+      title: Children with consent refused
+    consent_conflicts?:
+      label: Conflicts
+      title: Children with conflicting consent responses
+    no_consent?:
+      label: No response
+      title: Children with no consent response
+    needs_triage:
+      label: Triage needed
+      title: Children needing triage
+    triage_complete:
+      label: Triage completed
+      title: Children with triage completed
+    no_triage_needed:
+      label: No triage needed
+      title: Children with no triage needed
+    action_needed:
+      label: Action needed
+      title: Children with action needed
+    vaccinated:
+      label: Vaccinated
+      title: Vaccinated children
+    not_vaccinated:
+      label: Could not vaccinate
+      title: Children who could not be vaccinated
   service:
     email: england.mavis@nhs.net
     nhs_ur_email: anthony.green11@nhs.net

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -10,7 +10,12 @@ RSpec.describe AppPatientTableComponent, type: :component do
   let(:route) { :consent }
   let(:patient_sessions) { create_list(:patient_session, 2) }
   let(:component) do
-    described_class.new(patient_sessions:, tab_id: "foo", route:)
+    described_class.new(
+      patient_sessions:,
+      tab_id: "foo",
+      caption: "Foo",
+      route:
+    )
   end
 
   it { should have_css(".nhsuk-table") }

--- a/tests/nurse_consent_conflicting_consent.spec.ts
+++ b/tests/nurse_consent_conflicting_consent.spec.ts
@@ -35,7 +35,7 @@ async function given_i_am_checking_consent() {
 }
 
 async function when_i_select_a_child_with_conflicting_consent() {
-  await p.getByRole("tab", { name: "Consent conflicts" }).click();
+  await p.getByRole("tab", { name: "Conflicts" }).click();
   await p
     .getByRole("link", { name: fixtures.patientWithConflictingConsent })
     .click();


### PR DESCRIPTION
- Adds (or makes visible) captions for patient tables. This is so that tables are properly labelled, and that in mobile views, they have a clear heading.
- Localises tab labels and table captions for patient views
- Adjust the font sizing of tabs so that the font is 16px between `tablet` and `desktop` breakpoints
- Fix spacing on filter fieldset legend so that it aligns with table caption
- Some light refactoring of `consent_tab` to make it a little DRYer

<img width="730" alt="Screenshot of action needed table in action needed tab." src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/237da189-1221-44a6-bf48-e1106dd9d441">
