### PR TITLE
Add size option to `h1` application helper method

### DIFF
--- a/app/components/app_patient_page_component.html.erb
+++ b/app/components/app_patient_page_component.html.erb
@@ -1,4 +1,4 @@
-<%= h1 patient.full_name, id: dom_id(patient), class: "nhsuk-heading-l" %>
+<%= h1 patient.full_name, id: dom_id(patient) %>
 
 <%= render AppStatusBannerComponent.new(patient_session:, current_user:) %>
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,11 @@
 module ApplicationHelper
   def h1(text = nil, **options, &block)
-    title_text = options[:page_title] || text
+    title_text = options.fetch(:page_title, text)
+    size = options.fetch(:size, "l")
+
+    options[:class] = "nhsuk-heading-#{size}"
     options.delete(:page_title)
+    options.delete(:size)
 
     content_for(:page_title, title_text) unless content_for?(:page_title)
 

--- a/app/views/cohort_lists/errors.html.erb
+++ b/app/views/cohort_lists/errors.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "The cohort list could not be added", class: 'nhsuk-heading-l' %>
+<%= h1 "The cohort list could not be added" %>
 
 <p>
   It wasn’t possible to add a cohort list due to the following errors in the

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "Consent response for #{@consent_form.parent_name}", class: "nhsuk-heading-l" %>
+<%= h1 "Consent response for #{@consent_form.parent_name}" %>
 
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -11,7 +11,7 @@
   ]) %>
 <% end %>
 
-<%= h1 page_title, page_title:, class: "govuk-heading-l" %>
+<%= h1 page_title, page_title: %>
 
 <% def consent_tab(slot, state, columns: %i[name dob])
   label = t("states.#{state}.label")

--- a/app/views/content/rendered_markdown_template.html.erb
+++ b/app/views/content/rendered_markdown_template.html.erb
@@ -1,7 +1,7 @@
 <% content_for :content do %>
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <%= h1 @page_title, class: "govuk-heading-xl" %>
+      <%= h1 @page_title, size: "xl" %>
 
       <%= @nhsuk_markdown %>
     </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "#{@service_name} (MAVIS)" %>
+<%= h1 "#{@service_name} (MAVIS)", size: "xl" %>
 
 <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
   <%= link_to "School sessions", sessions_path, data: { testid: "sessions" } %>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "Sorry, there’s a problem with the service" %>
+<%= h1 "Sorry, there’s a problem with the service", size: "xl" %>
 
 <p class="nhsuk-body">Try again later.</p>
 

--- a/app/views/manage_consents/assessing_gillick.html.erb
+++ b/app/views/manage_consents/assessing_gillick.html.erb
@@ -14,7 +14,7 @@
 
 <% page_title = "Assessing Gillick competence" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @patient.full_name %>
   </span>

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -7,7 +7,7 @@
 
 <% page_title = "Check and confirm answers" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @patient.full_name %>
   </span>

--- a/app/views/manage_consents/questions.html.erb
+++ b/app/views/manage_consents/questions.html.erb
@@ -7,7 +7,7 @@
 
 <% page_title = "Health questions" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @patient.full_name %>
   </span>

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -14,7 +14,7 @@
 
 <% page_title = "Who are you trying to get consent from?" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @patient.full_name %>
   </span>

--- a/app/views/offline_passwords/new.html.erb
+++ b/app/views/offline_passwords/new.html.erb
@@ -3,8 +3,7 @@
     <%= form_with(model: @password, url: setup_offline_session_path) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= h1 "Create a password to protect your offline changes",
-        class: "nhsuk-heading-l" %>
+      <%= h1 "Create a password to protect your offline changes" %>
 
       <p>
         Before you can work offline, you need to create a password. We'll use

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -2,7 +2,7 @@
   <div class="nhsuk-grid-column-two-thirds">
     <%= render(AppFlashMessageComponent.new(flash: flash)) %>
 
-    <%= h1 "#{@service_name} (MAVIS)" %>
+    <%= h1 "#{@service_name} (MAVIS)", size: "xl" %>
 
     <p>Use this service to:</p>
 

--- a/app/views/parent_interface/consent_forms/_confirmation_injection.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_injection.html.erb
@@ -1,4 +1,3 @@
-<%= h1 t("consent_forms.confirmation_injection.title.#{ @session.type.downcase }"),
-  class: 'nhsuk-heading-l' %>
+<%= h1 t("consent_forms.confirmation_injection.title.#{ @session.type.downcase }") %>
 
 <p>A nurse will be in touch to discuss them having an injection instead.</p>

--- a/app/views/parent_interface/consent_forms/_confirmation_needs_triage.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_needs_triage.html.erb
@@ -1,5 +1,4 @@
-<%= h1 t("consent_forms.confirmation_needs_triage.title.#{ @session.type.downcase }"),
-  class: 'nhsuk-heading-l' %>
+<%= h1 t("consent_forms.confirmation_needs_triage.title.#{ @session.type.downcase }") %>
 
 <p>
   As you answered ‘yes’ to some of the health questions, we need to check the

--- a/app/views/parent_interface/consent_forms/_confirmation_refused.html.erb
+++ b/app/views/parent_interface/consent_forms/_confirmation_refused.html.erb
@@ -1,2 +1,1 @@
-<%= h1 t("consent_forms.confirmation_refused.title.#{ @session.type.downcase }"),
-  class: 'nhsuk-heading-l' %>
+<%= h1 t("consent_forms.confirmation_refused.title.#{ @session.type.downcase }") %>

--- a/app/views/parent_interface/consent_forms/cannot_consent.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent.html.erb
@@ -5,8 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "You cannot give or refuse consent through this service",
-  class: 'nhsuk-heading-l' %>
+<%= h1 "You cannot give or refuse consent through this service" %>
 
 <p>This service is being piloted with a small number of schools. It’s only for
 parents whose children attend participating schools.</p>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -15,7 +15,7 @@
   )
 end %>
 
-<%= h1 "Check your answers and confirm", class: "nhsuk-heading-l" %>
+<%= h1 "Check your answers and confirm" %>
 
 <h2 class="nhsuk-heading-m">Consent</h2>
 

--- a/app/views/parent_interface/consent_forms/edit/address.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/address.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "Home address", class: "nhsuk-heading-l" %>
+<%= h1 "Home address" %>
 
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>

--- a/app/views/parent_interface/consent_forms/edit/injection.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/injection.html.erb
@@ -5,8 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "Your child may be able to have an injection instead",
-  class: 'nhsuk-heading-l' %>
+<%= h1 "Your child may be able to have an injection instead" %>
 
 <p>
   If the nasal spray is not suitable, they may be able to have an injection

--- a/app/views/parent_interface/consent_forms/edit/name.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/name.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "What is your child’s name?", class: "nhsuk-heading-l" %>
+<%= h1 "What is your child’s name?" %>
 
 <p>
   Give the official name that’s on their passport or birth certificate. If

--- a/app/views/parent_interface/consent_forms/edit/parent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/parent.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "About you", class: "nhsuk-heading-l" %>
+<%= h1 "About you" %>
 
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
   <% content_for(:before_content) { f.govuk_error_summary } %>

--- a/app/views/parent_interface/consent_forms/edit/school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/school.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<%= h1 "Confirm your child’s school", class: 'nhsuk-heading-l' %>
+<%= h1 "Confirm your child’s school" %>
 
 <%= govuk_inset_text(classes: 'nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4') do %>
   <span class="nhsuk-u-visually-hidden">Information:</span>

--- a/app/views/pilot/manual.html.erb
+++ b/app/views/pilot/manual.html.erb
@@ -8,7 +8,7 @@
       { text: page_title } ]) %>
 <% end %>
 
-<%= h1 page_title, class: "nhsuk-heading-xl" %>
+<%= h1 page_title, size: "xl" %>
 
 <p class="nhsuk-body">Creating the pilot cohort involves five steps:</p>
 

--- a/app/views/pilot/registrations.html.erb
+++ b/app/views/pilot/registrations.html.erb
@@ -8,7 +8,7 @@
   ]) %>
 <% end %>
 
-<%= h1 page_title, class: 'nhsuk-heading-l' %>
+<%= h1 page_title %>
 
 <%= govuk_button_link_to "Download data for registered parents (CSV)",
   download_pilot_registrations_path, download: "registered_parents.csv" %>

--- a/app/views/registrations/closed.html.erb
+++ b/app/views/registrations/closed.html.erb
@@ -1,6 +1,6 @@
 <% page_title = "The deadline for registering your interest in the NHS school vaccinations pilot has passed" %>
 
-<%= h1 page_title, class: "nhsuk-heading-xl" %>
+<%= h1 page_title, size: "xl" %>
 
 <p>
   If you have not already responded to messages from your child’s school about

--- a/app/views/registrations/confirmation.html.erb
+++ b/app/views/registrations/confirmation.html.erb
@@ -1,6 +1,6 @@
 <% page_title = "Thank you for registering your interest in the NHS school vaccinations pilot" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-xl" do %>
+<%= h1 page_title:, size: "xl" do %>
   <span class="nhsuk-caption-xl"><%= @school.name %></span>
   <%= page_title %>
 <% end %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -3,7 +3,7 @@
 <%= form_for(@registration_form, url: registration_path) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= h1 page_title:, class: "nhsuk-heading-xl" do %>
+  <%= h1 page_title:, size: "xl" do %>
     <span class="nhsuk-caption-xl"><%= @school.name %></span>
     <%= page_title %>
   <% end %>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -9,7 +9,7 @@
   ]) %>
 <% end %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <%= page_title %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @school.address %>,

--- a/app/views/sessions/confirm.html.erb
+++ b/app/views/sessions/confirm.html.erb
@@ -7,7 +7,7 @@
 
 <% page_title = "Check and confirm details" %>
 
-<%= h1 page_title, class: "nhsuk-heading-l" %>
+<%= h1 page_title %>
 
 <%= render AppCardComponent.new(heading: "Session") do %>
   <%= govuk_summary_list classes: 'app-summary-list--no-bottom-border' do |summary_list|

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -9,7 +9,7 @@
   ]) %>
 <% end %>
 
-<%= h1 page_title, page_title: %>
+<%= h1 page_title, page_title:, size: "xl" %>
 
 <%= govuk_button_to("Add a new session", sessions_path) %>
 

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -10,7 +10,7 @@
   ]) %>
 <% end %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <%= page_title %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @session.date.to_fs(:long_ordinal_uk) %> ·

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -11,7 +11,7 @@
   ]) %>
 <% end %>
 
-<%= h1 page_title, page_title:, class: "govuk-heading-l" %>
+<%= h1 page_title, page_title: %>
 
 <% def consent_tab(slot, state, columns: %i[name dob])
   label = t("states.#{state}.label")

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "Change your password", class: 'nhsuk-heading-xl' %>
+<%= h1 "Change your password", size: "xl" %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= f.hidden_field :reset_password_token %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "Reset your password", class: "nhsuk-heading-xl" %>
+<%= h1 "Reset your password", size: "xl" %>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/users/unlocks/new.html.erb
+++ b/app/views/users/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<%= h1 "Resend unlock instructions", class: "nhsuk-heading-xl" %>
+<%= h1 "Resend unlock instructions", size: "xl" %>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -14,7 +14,7 @@
 
 <% page_title = "Check and confirm" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <%= page_title %>
 <% end %>
 

--- a/app/views/vaccinations/delivery_site/edit.html.erb
+++ b/app/views/vaccinations/delivery_site/edit.html.erb
@@ -7,7 +7,7 @@
 
 <% page_title = "Tell us how the vaccination was given" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @patient.full_name %>
   </span>

--- a/app/views/vaccinations/history.html.erb
+++ b/app/views/vaccinations/history.html.erb
@@ -2,7 +2,7 @@
 
 <% page_title = "Vaccination record" %>
 
-<%= h1 page_title:, class: "nhsuk-heading-l" do %>
+<%= h1 page_title: do %>
   <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
     <%= @patient.full_name %>
   </span>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -11,7 +11,7 @@
   ]) %>
 <% end %>
 
-<%= h1 page_title, page_title:, class: "govuk-heading-l" %>
+<%= h1 page_title, page_title: %>
 
 <%=
 render AppTabComponent.new(title: "Vaccinations", classes: 'nhsuk-tabs') do |c|

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -4,7 +4,9 @@ describe ApplicationHelper do
   describe "#h1" do
     context "when called with only text" do
       it "returns an h1 tag with the text" do
-        expect(helper.h1("Title")).to eq("<h1>Title</h1>")
+        expect(helper.h1("Title")).to eq(
+          '<h1 class="nhsuk-heading-l">Title</h1>'
+        )
       end
 
       it "sets the page title" do
@@ -15,12 +17,22 @@ describe ApplicationHelper do
 
     context "when called with text and page_title option" do
       it "returns an h1 tag with the text" do
-        expect(helper.h1("Title", page_title: "Custom")).to eq("<h1>Title</h1>")
+        expect(helper.h1("Title", page_title: "Custom")).to eq(
+          '<h1 class="nhsuk-heading-l">Title</h1>'
+        )
       end
 
       it "sets the page title from the option" do
         helper.h1("Title", page_title: "Custom")
         expect(helper.content_for(:page_title)).to eq("Custom")
+      end
+    end
+
+    context "when called with size option" do
+      it "returns an h1 tag with the correct heading class" do
+        expect(helper.h1("Title", size: "xl")).to eq(
+          '<h1 class="nhsuk-heading-xl">Title</h1>'
+        )
       end
     end
 
@@ -31,7 +43,7 @@ describe ApplicationHelper do
 
       it "returns an h1 tag with the block content" do
         output = helper.h1(page_title: "Custom Title") { "Block Content" }
-        expect(output).to eq("<h1>Block Content</h1>")
+        expect(output).to eq('<h1 class="nhsuk-heading-l">Block Content</h1>')
       end
 
       it "sets the page title from the title option" do


### PR DESCRIPTION
The `h1` helper is widely used but:

- often requires adding the `nhsuk-heading-l` class
- sometimes that class is a `govuk-` prefixed one
- sometimes no class is added at all

This PR refactors this helper method so that it always supplies a typography heading class, and defaults that size to being `l`.