### PR TITLE
Do not show registration page when school registration is closed

### DIFF
--- a/app/avo/resources/patient.rb
+++ b/app/avo/resources/patient.rb
@@ -18,9 +18,7 @@ class Avo::Resources::Patient < Avo::BaseResource
     field :location, as: :belongs_to
     # add fields here
     field :parent_name, as: :string
-    field :parent_relationship,
-          as: :select,
-          enum: ::Patient.parent_relationships
+    field :parent_relationship
     field :parent_relationship_other, as: :string
     field :parent_email, as: :string
     field :parent_phone, as: :string

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,7 +5,7 @@ class RegistrationsController < ApplicationController
   layout "registration"
 
   def new
-    if Flipper.enabled?(:registration_open)
+    if Flipper.enabled?(:registration_open) && @school.registration_open?
       @registration_form = Registration.new
       render "new"
     else

--- a/lib/example_campaign_data.rb
+++ b/lib/example_campaign_data.rb
@@ -54,7 +54,8 @@ class ExampleCampaignData
       town: school_data["town"],
       county: school_data["county"],
       postcode: school_data["postcode"],
-      url: school_data["url"]
+      url: school_data["url"],
+      registration_open: true
     }
   end
 

--- a/tests/pilot_registration_close.spec.ts
+++ b/tests/pilot_registration_close.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect, Page } from "@playwright/test";
+import { signInTestUser } from "./shared";
+
+let p: Page;
+
+test("Pilot registration - close", async ({ page }) => {
+  p = page;
+
+  await given_the_app_is_setup();
+  await and_registration_is_open();
+  await when_i_visit_the_parents_registration_page();
+  await then_i_see_the_registration_form();
+
+  await when_i_to_to_the_who_has_registered();
+  await then_i_see_the_parents_who_have_registered_page();
+
+  await when_click_the_link_to_close_registration();
+  await then_i_see_the_confirm_close_registration_page();
+
+  await when_i_return_to_the_list_of_participants();
+  await then_i_see_the_parents_who_have_registered_page();
+
+  await when_click_the_link_to_close_registration();
+  await and_i_click_the_back_link();
+  await then_i_see_the_parents_who_have_registered_page();
+
+  await when_click_the_link_to_close_registration();
+  await and_i_confirm_closing_registration();
+  await then_i_can_see_that_registration_is_closed();
+  await and_the_link_to_close_registration_is_gone();
+
+  await when_i_visit_the_parents_registration_page();
+  await then_i_see_the_registration_is_closed_page();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function and_registration_is_open() {
+  await signInTestUser(p);
+  await p.goto("/flipper/features/registration_open");
+  await expect(p.getByText("Home Features registration_open")).toBeVisible();
+  if (await p.getByText("Disabled").isVisible()) {
+    await p.getByRole("button", { name: "Fully Enable" }).click();
+    await expect(p.getByText("Fully enabled")).toBeVisible();
+  }
+}
+
+async function when_i_visit_the_parents_registration_page() {
+  await p.goto("/schools/1/registration/new");
+}
+
+async function then_i_see_the_registration_form() {
+  await expect(
+    p.getByRole("heading", {
+      name: "Register your interest in the NHS school vaccinations pilot",
+    }),
+  ).toBeVisible();
+}
+
+async function when_i_to_to_the_who_has_registered() {
+  await p.goto("/dashboard");
+  await p.click("text=Manage pilot");
+  await p.click("text=See who’s interested in the pilot");
+}
+
+async function when_click_the_link_to_close_registration() {
+  await p
+    .getByRole("link", {
+      name: "Close pilot to new participants at this school",
+    })
+    .click();
+}
+
+async function then_i_see_the_confirm_close_registration_page() {
+  await expect(
+    p.getByRole("heading", {
+      name: "Are you sure you want to close the pilot to new participants at this school?",
+    }),
+  ).toBeVisible();
+}
+
+async function when_i_return_to_the_list_of_participants() {
+  await p
+    .getByRole("link", { name: "No, return to list of participants" })
+    .click();
+}
+
+async function and_i_click_the_back_link() {
+  await p.getByRole("link", { name: "Back" }).click();
+}
+
+async function then_i_see_the_parents_who_have_registered_page() {
+  await expect(
+    p.getByRole("heading", { name: "Parents interested in the pilot" }),
+  ).toBeVisible();
+}
+
+async function and_i_confirm_closing_registration() {
+  await p
+    .getByRole("button", { name: "Yes, close the pilot to new participants" })
+    .click();
+}
+
+async function then_i_can_see_that_registration_is_closed() {
+  await expect(
+    p.getByText("Pilot is now closed to new participants"),
+  ).toBeVisible();
+}
+
+async function and_the_link_to_close_registration_is_gone() {
+  await expect(
+    p.getByRole("link", {
+      name: "Close pilot to new participants at this school",
+    }),
+  ).not.toBeVisible();
+}
+
+async function then_i_see_the_registration_is_closed_page() {
+  await expect(
+    p.getByRole("heading", {
+      name: "The deadline for registering your interest in the NHS school vaccinations pilot has passed",
+    }),
+  ).toBeVisible();
+}


### PR DESCRIPTION
Finishes the work of the previous PR to add a "close pilot for school" journey by ensuring that the registration page does not show when the school's registration is closed.

Also adds a test for the close pilot registration journey.