### PR TITLE
Always show schools when managing pilot registrations

### DIFF
--- a/app/controllers/pilot_controller.rb
+++ b/app/controllers/pilot_controller.rb
@@ -8,7 +8,7 @@ class PilotController < ApplicationController
   end
 
   def registrations
-    @schools = current_user.team.locations
+    @schools = current_user.team.locations.includes(:registrations)
   end
 
   def download

--- a/app/controllers/pilot_controller.rb
+++ b/app/controllers/pilot_controller.rb
@@ -8,10 +8,7 @@ class PilotController < ApplicationController
   end
 
   def registrations
-    @registrations =
-      Registration.where(
-        location_id: current_user.team.locations.map(&:id)
-      ).group_by(&:location)
+    @schools = current_user.team.locations
   end
 
   def download

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -1,0 +1,5 @@
+module RegistrationHelper
+  def school_registrations(school)
+    Registration.where(location_id: school.id)
+  end
+end

--- a/app/helpers/registration_helper.rb
+++ b/app/helpers/registration_helper.rb
@@ -1,5 +1,0 @@
-module RegistrationHelper
-  def school_registrations(school)
-    Registration.where(location_id: school.id)
-  end
-end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -25,6 +25,7 @@ class Location < ApplicationRecord
   has_many :sessions
   has_many :patients
   has_many :consent_forms, through: :sessions
+  has_many :registrations
   belongs_to :team
 
   validates :name, presence: true

--- a/app/views/pilot/registrations.html.erb
+++ b/app/views/pilot/registrations.html.erb
@@ -26,12 +26,12 @@
       </p>
     <% end %>
 
-    <% if school_registrations(school).empty? %>
+    <% if school.registrations.empty? %>
       <p>No parents have registered their interest in the pilot yet.</p>
     <% else %>
       <%= govuk_table do |table|
         table.with_caption(
-          text: pluralize(school_registrations(school).count, "response"),
+          text: pluralize(school.registrations.size, "response"),
           classes: 'nhsuk-u-font-size-19')
 
         table.with_head do |head|
@@ -43,7 +43,7 @@
         end
 
         table.with_body do |body|
-          school_registrations(school).each do |response|
+          school.registrations.each do |response|
             body.with_row do |row|
               row.with_cell(text: response.parent_name)
               row.with_cell(text: response.parent_email)

--- a/app/views/pilot/registrations.html.erb
+++ b/app/views/pilot/registrations.html.erb
@@ -15,11 +15,7 @@
 <%= govuk_button_link_to "Download data for registered parents (CSV)",
   download_pilot_registrations_path, download: "registered_parents.csv" %>
 
-<% if @registrations.empty? %>
-  <p>No parents have registered their interest in the pilot yet.</p>
-<% end %>
-
-<% @registrations.each do |school, responses| %>
+<% @schools.each do |school| %>
   <%= render AppCardComponent.new(heading: school.name) do %>
     <% if Flipper.enabled?(:registration_open) && school.registration_open %>
       <p>
@@ -30,27 +26,32 @@
       </p>
     <% end %>
 
-    <%= govuk_table do |table|
-      table.with_caption(text: pluralize(responses.count, "response"),
-                         classes: 'nhsuk-u-font-size-19')
+    <% if school_registrations(school).empty? %>
+      <p>No parents have registered their interest in the pilot yet.</p>
+    <% else %>
+      <%= govuk_table do |table|
+        table.with_caption(
+          text: pluralize(school_registrations(school).count, "response"),
+          classes: 'nhsuk-u-font-size-19')
 
-      table.with_head do |head|
-        head.with_row do |row|
-          row.with_cell(text: 'Name')
-          row.with_cell(text: 'Email Address')
-          row.with_cell(text: 'Phone number')
-        end
-      end
-
-      table.with_body do |body|
-        responses.each do |response|
-          body.with_row do |row|
-            row.with_cell(text: response.parent_name)
-            row.with_cell(text: response.parent_email)
-            row.with_cell(text: response.parent_phone)
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(text: 'Name')
+            row.with_cell(text: 'Email Address')
+            row.with_cell(text: 'Phone number')
           end
         end
-      end
-    end %>
+
+        table.with_body do |body|
+          school_registrations(school).each do |response|
+            body.with_row do |row|
+              row.with_cell(text: response.parent_name)
+              row.with_cell(text: response.parent_email)
+              row.with_cell(text: response.parent_phone)
+            end
+          end
+        end
+      end %>
+    <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
This change ensures the option to close registrations is always available, even if a school has not received any registration responses.

@misaka; feel free to fix the code to prevent the unoptimised database call.