### PR TITLE
Update terms and conditions on registration form

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -133,25 +133,6 @@
       personally identified when we share the results of our research.
     </p>
 
-    <h3>What happens to data in our service</h3>
-
-    <p>
-      We’ll save the responses you give in our digital service, as well as data
-      recorded during vaccination sessions.
-    </p>
-
-    <p>
-      This data will only be shared within the project team. We’ll store it
-      securely with password protection.
-    </p>
-
-    <h3>How long we’ll keep your data</h3>
-
-    <p>
-      We’ll keep data in our digital service for 2 months after the project
-      finishes.
-    </p>
-
     <h3>What you’ll get for taking part in the pilot</h3>
 
     <p>We’ll send you a £20 high street shopping voucher once you’ve:</p>
@@ -175,6 +156,13 @@
       Once you’ve completed the survey, you might be asked to take part in some
       follow-up research. There are separate incentives for this, and there’s no
       obligation to take part.
+    </p>
+
+    <h3>What happens to data in our service</h3>
+
+    <p>
+      Your privacy is important to us. We explain how we protect your personal
+      information in our <%= govuk_link_to "privacy policy", :privacy_policy %>.
     </p>
   <% end %>
 


### PR DESCRIPTION
Updates terms and conditions on registration form to point participants to the full privacy policy.

The email address to use if participants want to withdraw need to be that for the SAIS team, but we don’t have that in the application yet. I’ll create a follow up PR to add that, and then use that data on this page.