### PR TITLE
Update fieldset and label spacing

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,8 +44,7 @@ $color_app-pale-blue: #ccdff1;
 @import "utilities";
 
 // NHS.UK Frontend overrides
-.nhsuk-label--s,
-.nhsuk-fieldset__legend--s {
-  padding-top: nhsuk-spacing(2);
+.nhsuk-label,
+.nhsuk-fieldset__legend {
   margin-bottom: nhsuk-spacing(2);
 }

--- a/app/components/app_patient_table_filter_component.html.erb
+++ b/app/components/app_patient_table_filter_component.html.erb
@@ -3,7 +3,7 @@
     <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--m nhsuk-u-padding-top-0 nhsuk-u-font-size-22">
       Filter results
     </legend>
-    <div class="nhsuk-form-group">
+    <div class="nhsuk-form-group nhsuk-u-margin-top-2">
       <label class="nhsuk-label nhsuk-label--s" for="filter-<%= @tab_id %>-name">
         By name
       </label>

--- a/app/views/edit_sessions/timeline.html.erb
+++ b/app/views/edit_sessions/timeline.html.erb
@@ -23,7 +23,7 @@
     <%= f.govuk_radio_button :consent_days_before, :custom,
       label: { text: 'Choose your own schedule' } do %>
       <%= f.govuk_text_field :consent_days_before_custom,
-        label: { text: 'Days before the session' },
+        label: { text: 'Days before the session', size: 's' },
         width: 2,
         suffix_text: "days" %>
     <% end %>
@@ -38,7 +38,7 @@
     <%= f.govuk_radio_button :reminder_days_after, :custom,
       label: { text: 'Choose your own schedule' } do %>
       <%= f.govuk_text_field :reminder_days_after_custom,
-        label: { text: 'Days after the first consent request' },
+        label: { text: 'Days after the first consent request', size: 's' },
         width: 2,
         suffix_text: "days" %>
     <% end %>
@@ -52,7 +52,7 @@
     <%= f.govuk_radio_button :close_consent_on, :custom,
       label: { text: 'Choose your own deadline' } do %>
       <%= f.govuk_date_field :close_consent_at,
-        legend: { text: 'Deadline for consent responses' },
+        legend: { text: 'Deadline for consent responses', size: 's' },
         hint: { text: 'For example, 27 3 2023' } %>
     <% end %>
   <% end %>


### PR DESCRIPTION
- Update CSS fix for `nhsuk-label` and `nhsuk-fieldset` that normalises the spacing
- Fix the alignment of first label on patient table filter
- Consistent conditional label/fieldset size on session timeline page