### PR TITLE
Add all unassigned patients to new session

### DIFF
--- a/app/controllers/edit_sessions_controller.rb
+++ b/app/controllers/edit_sessions_controller.rb
@@ -22,6 +22,7 @@ class EditSessionsController < ApplicationController
   def update
     case current_step
     when :confirm
+      copy_entire_cohort_to_session
       @session.draft = false
     when :location, :vaccine
       @session.team = current_user.team
@@ -34,6 +35,15 @@ class EditSessionsController < ApplicationController
   end
 
   private
+
+  def copy_entire_cohort_to_session
+    @session
+      .location
+      .patients
+      .filter { |patient| patient.sessions.active.empty? }
+      .each { |patient| @session.patients << patient }
+    @session.save!
+  end
 
   def current_step
     wizard_value(step)&.to_sym

--- a/app/views/edit_sessions/confirm.html.erb
+++ b/app/views/edit_sessions/confirm.html.erb
@@ -32,6 +32,18 @@
     end
 
     summary_list.with_row do |row|
+      row.with_key { "Cohort" }
+      row.with_value do
+        patients_count = @session
+        .location
+        .patients
+        .filter { |patient| patient.sessions.active.empty? }
+        .count
+        pluralize(patients_count, "children")
+      end
+    end
+
+    summary_list.with_row do |row|
       row.with_key { "Consent requests" }
       row.with_value {
         "Send #{pluralize(@session.days_between_consent_and_session, "day")} before the session"


### PR DESCRIPTION
Horrible temporary hack to just automatically add all patients to a new session, if they haven't been added to a session yet.