### PR TITLE
When counting unmatched forms, avoid counting draft consent forms

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,7 +24,8 @@ class SessionsController < ApplicationController
       without_a_response: 0,
       needing_triage: 0,
       ready_to_vaccinate: 0,
-      unmatched_responses: @session.location.consent_forms.unmatched.count
+      unmatched_responses:
+        @session.location.consent_forms.unmatched.recorded.count
     }
 
     @patient_sessions.each do |s|


### PR DESCRIPTION
This makes the count consistent with `SchoolsController#set_unmatched_consent_responses`.

Without this fix, you see an inconsistency:

<img width="723" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/4f36f3e9-55e1-4e25-bdbd-f9cdf66cb5ea">

<img width="1046" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/44e1e197-9113-4120-97f9-8edd61480527">
