### PR TITLE
Session stats: bugfixes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,7 +22,7 @@ class SessionsController < ApplicationController
       SessionStats.new(
         patient_sessions: @patient_sessions,
         location: @session.location
-      ).call
+      )
   end
 
   def make_in_progress

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,28 +18,11 @@ class SessionsController < ApplicationController
     @patient_sessions =
       @session.patient_sessions.strict_loading.includes(:campaign, :consents)
 
-    @counts = {
-      with_consent_given: 0,
-      with_consent_refused: 0,
-      without_a_response: 0,
-      needing_triage: 0,
-      ready_to_vaccinate: 0,
-      unmatched_responses: @session.location.consent_forms.unmatched.count
-    }
-
-    @patient_sessions.each do |s|
-      @counts[:with_consent_given] += 1 if s.consent_given?
-      @counts[:with_consent_refused] += 1 if s.consent_refused?
-      @counts[:without_a_response] += 1 if s.no_consent?
-
-      if s.consent_given_triage_needed? || s.triaged_kept_in_triage?
-        @counts[:needing_triage] += 1
-        @counts[:ready_to_vaccinate] += 1
-      end
-
-      @counts[:ready_to_vaccinate] += 1 if s.triaged_ready_to_vaccinate? ||
-        s.added_to_session? || s.consent_given_triage_not_needed?
-    end
+    @counts =
+      SessionStats.new(
+        patient_sessions: @patient_sessions,
+        location: @session.location
+      ).call
   end
 
   def make_in_progress

--- a/app/models/session_stats.rb
+++ b/app/models/session_stats.rb
@@ -2,9 +2,21 @@ class SessionStats
   def initialize(patient_sessions:, location:)
     @patient_sessions = patient_sessions
     @location = location
+
+    @stats = calculate_stats
   end
 
-  def call
+  def [](key)
+    @stats[key]
+  end
+
+  def to_h
+    @stats
+  end
+
+  private
+
+  def calculate_stats
     counts = {
       with_consent_given: 0,
       with_consent_refused: 0,

--- a/app/models/session_stats.rb
+++ b/app/models/session_stats.rb
@@ -1,0 +1,33 @@
+class SessionStats
+  def initialize(patient_sessions:, location:)
+    @patient_sessions = patient_sessions
+    @location = location
+  end
+
+  def call
+    counts = {
+      with_consent_given: 0,
+      with_consent_refused: 0,
+      without_a_response: 0,
+      needing_triage: 0,
+      ready_to_vaccinate: 0,
+      unmatched_responses: @location.consent_forms.unmatched.count
+    }
+
+    @patient_sessions.each do |s|
+      counts[:with_consent_given] += 1 if s.consent_given?
+      counts[:with_consent_refused] += 1 if s.consent_refused?
+      counts[:without_a_response] += 1 if s.no_consent?
+
+      if s.consent_given_triage_needed? || s.triaged_kept_in_triage?
+        counts[:needing_triage] += 1
+        counts[:ready_to_vaccinate] += 1
+      end
+
+      counts[:ready_to_vaccinate] += 1 if s.triaged_ready_to_vaccinate? ||
+        s.added_to_session? || s.consent_given_triage_not_needed?
+    end
+
+    counts
+  end
+end

--- a/app/models/session_stats.rb
+++ b/app/models/session_stats.rb
@@ -21,11 +21,10 @@ class SessionStats
 
       if s.consent_given_triage_needed? || s.triaged_kept_in_triage?
         counts[:needing_triage] += 1
-        counts[:ready_to_vaccinate] += 1
       end
 
       counts[:ready_to_vaccinate] += 1 if s.triaged_ready_to_vaccinate? ||
-        s.added_to_session? || s.consent_given_triage_not_needed?
+        s.consent_given_triage_not_needed?
     end
 
     counts

--- a/app/models/session_stats.rb
+++ b/app/models/session_stats.rb
@@ -11,7 +11,7 @@ class SessionStats
       without_a_response: 0,
       needing_triage: 0,
       ready_to_vaccinate: 0,
-      unmatched_responses: @location.consent_forms.unmatched.count
+      unmatched_responses: @location.consent_forms.unmatched.recorded.count
     }
 
     @patient_sessions.each do |s|

--- a/spec/models/session_stats_spec.rb
+++ b/spec/models/session_stats_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe SessionStats do
         create(:patient_session, :consent_given_triage_not_needed, session:) # ready to vaccinate, consent given
 
         create(:consent_form, :recorded, session:, consent_id: nil) # => unmatched response
+        create(:consent_form, session:, consent_id: nil, recorded_at: nil) # => still draft, should not be counted
       end
 
       it "returns a hash of session stats" do

--- a/spec/models/session_stats_spec.rb
+++ b/spec/models/session_stats_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe SessionStats do
       described_class.new(
         patient_sessions: session.patient_sessions,
         location: session.location
-      ).call
+      )
     end
 
     it "returns a hash of session stats" do
-      expect(subject).to eq(
+      expect(subject.to_h).to eq(
         with_consent_given: 0,
         with_consent_refused: 0,
         without_a_response: 0,
@@ -36,7 +36,7 @@ RSpec.describe SessionStats do
       end
 
       it "returns a hash of session stats" do
-        expect(subject).to eq(
+        expect(subject.to_h).to eq(
           with_consent_given: 4,
           with_consent_refused: 1,
           without_a_response: 1,

--- a/spec/models/session_stats_spec.rb
+++ b/spec/models/session_stats_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe SessionStats do
+  describe "#call" do
+    let(:session) { create :session }
+
+    subject do
+      described_class.new(
+        patient_sessions: session.patient_sessions,
+        location: session.location
+      ).call
+    end
+
+    it "returns a hash of session stats" do
+      expect(subject).to eq(
+        with_consent_given: 0,
+        with_consent_refused: 0,
+        without_a_response: 0,
+        needing_triage: 0,
+        ready_to_vaccinate: 0,
+        unmatched_responses: 0
+      )
+    end
+
+    context "with patient sessions" do
+      before do
+        create(:patient_session, :consent_refused, session:) # consent refused
+        create(:patient_session, :added_to_session, session:) # without a response
+        create(:patient_session, :consent_given_triage_needed, session:) # needing triage, consent given
+        create(:patient_session, :triaged_kept_in_triage, session:) # needing triage, consent given
+        create(:patient_session, :triaged_ready_to_vaccinate, session:) # ready to vaccinate, consent given
+        create(:patient_session, :consent_given_triage_not_needed, session:) # ready to vaccinate, consent given
+
+        create(:consent_form, :recorded, session:, consent_id: nil) # => unmatched response
+      end
+
+      it "returns a hash of session stats" do
+        expect(subject).to eq(
+          with_consent_given: 4,
+          with_consent_refused: 1,
+          without_a_response: 1,
+          needing_triage: 2,
+          ready_to_vaccinate: 2,
+          unmatched_responses: 1
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Avoid counting draft consent forms when counting unmatched forms

Without this fix, you see an inconsistency:

<img width="723" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/4f36f3e9-55e1-4e25-bdbd-f9cdf66cb5ea">

<img width="1046" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/44e1e197-9113-4120-97f9-8edd61480527">

* Don't count patients in triage or without consent as 'ready to vaccinate'
* Extract a `SessionStats` model to make it easier to test the logic

Best reviewed commit by commit.