### PR TITLE
Add session: display dates of birth and session date as human-readable dates

### DIFF
--- a/app/views/edit_sessions/cohort.html.erb
+++ b/app/views/edit_sessions/cohort.html.erb
@@ -34,7 +34,7 @@
             end
           end
           row.with_cell(text: patient.full_name)
-          row.with_cell(text: patient.date_of_birth)
+          row.with_cell(text: patient.date_of_birth.to_fs(:nhsuk_date_short_month))
           row.with_cell(
             text:
             t("activerecord.attributes.patient.year_group.#{patient.year_group}")

--- a/app/views/edit_sessions/timeline.html.erb
+++ b/app/views/edit_sessions/timeline.html.erb
@@ -11,7 +11,7 @@
 
   <%= govuk_inset_text do %>
     <span class="nhsuk-visually-hidden">Information:</span>
-    Session scheduled for <%= @session.date.to_fs(:app_date_time_long) %>
+    Session scheduled for <%= @session.date.to_fs(:nhsuk_date_day_of_week) %> (<%= @session.human_enum_name(:time_of_day) %>)
   <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :consent_days_before,


### PR DESCRIPTION
## Dates of birth

Before

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/a821aae3-5921-44eb-8755-f4339d587664)

After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/9e7dfa9f-0c32-4916-93a4-22d276d4243a)

## Session dates

Before

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/6458ca7d-dad5-4f88-af4d-41f6a0fb92ae)

After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/a4d92cc2-cf7b-40df-b87e-99c06302213c)
