### PR TITLE
Force quotes when generating cohort CSV

### DIFF
--- a/app/models/cohort_list.rb
+++ b/app/models/cohort_list.rb
@@ -87,7 +87,7 @@ class CohortList
   end
 
   def to_csv
-    CSV.generate(headers: true) do |csv|
+    CSV.generate(headers: true, force_quotes: true) do |csv|
       csv << EXPECTED_HEADERS
 
       data.each { csv << _1 }


### PR DESCRIPTION
Graphical spreadsheet editors like Excel, Google Sheets, and Numbers tend to mangle data such as phone numbers (which have a leading 0) when importing CSV data. Using quotes around all fields should help to prevent this.