### PR TITLE
Add print styles to registration form

### DIFF
--- a/app/assets/stylesheets/registration.scss
+++ b/app/assets/stylesheets/registration.scss
@@ -1,5 +1,106 @@
 $nhsuk-font: system-ui;
 
+$nhsuk-typography-scale: (
+  48: (
+    null: (
+      font-size: 32px,
+      line-height: 40px,
+    ),
+    tablet: (
+      font-size: 48px,
+      line-height: 56px,
+    ),
+    print: (
+      font-size: 19pt,
+      line-height: 1.15,
+    ),
+  ),
+  32: (
+    null: (
+      font-size: 24px,
+      line-height: 32px,
+    ),
+    tablet: (
+      font-size: 32px,
+      line-height: 40px,
+    ),
+    print: (
+      font-size: 16pt,
+      line-height: 1.05,
+    ),
+  ),
+  24: (
+    null: (
+      font-size: 20px,
+      line-height: 28px,
+    ),
+    tablet: (
+      font-size: 24px,
+      line-height: 32px,
+    ),
+    print: (
+      font-size: 14pt,
+      line-height: 1.15,
+    ),
+  ),
+  22: (
+    null: (
+      font-size: 18px,
+      line-height: 28px,
+    ),
+    tablet: (
+      font-size: 22px,
+      line-height: 32px,
+    ),
+    print: (
+      font-size: 14pt,
+      line-height: 1.15,
+    ),
+  ),
+  19: (
+    null: (
+      font-size: 16px,
+      line-height: 24px,
+    ),
+    tablet: (
+      font-size: 19px,
+      line-height: 28px,
+    ),
+    print: (
+      font-size: 12pt,
+      line-height: 1.15,
+    ),
+  ),
+  16: (
+    null: (
+      font-size: 14px,
+      line-height: 24px,
+    ),
+    tablet: (
+      font-size: 16px,
+      line-height: 24px,
+    ),
+    print: (
+      font-size: 10pt,
+      line-height: 1.2,
+    ),
+  ),
+  14: (
+    null: (
+      font-size: 12px,
+      line-height: 20px,
+    ),
+    tablet: (
+      font-size: 14px,
+      line-height: 24px,
+    ),
+    print: (
+      font-size: 9pt,
+      line-height: 1.2,
+    ),
+  ),
+);
+
 @import "nhsuk-frontend/packages/nhsuk";
 
 // NHS.UK frontend overrides
@@ -8,16 +109,73 @@ html {
   background-color: $color_nhsuk-white;
 }
 
+.nhsuk-width-container {
+  max-width: 720px;
+}
+
+.nhsuk-fieldset {
+  margin-top: nhsuk-spacing(3);
+}
+
 .nhsuk-label--s,
 .nhsuk-fieldset__legend--s {
   padding-top: nhsuk-spacing(2);
   margin-bottom: nhsuk-spacing(2);
 }
 
-.nhsuk-width-container {
-  max-width: 720px;
+.nhsuk-fieldset__legend--l,
+.nhsuk-heading-l {
+  border-top: 1px solid $nhsuk-border-color;
+  padding-top: nhsuk-spacing(3);
+  width: 100%;
+}
+
+.nhsuk-inset-text {
+  // margin-top: nhsuk-spacing(3);
+  max-width: 100%;
+  padding-bottom: 0;
+  padding-top: 0;
 }
 
 .nhsuk-visually-hidden {
   @extend .nhsuk-u-visually-hidden;
+}
+
+@media print {
+  body {
+    margin: 0;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+
+    &::after {
+      content: "";
+    }
+  }
+
+  .nhsuk-main-wrapper {
+    padding: 0;
+  }
+
+  .nhsuk-width-container {
+    max-width: 100%;
+  }
+
+  .nhsuk-button {
+    display: none;
+  }
+
+  .nhsuk-radios__conditional--hidden {
+    display: block !important;
+  }
+
+  .nhsuk-heading-xl,
+  .nhsuk-heading-l,
+  .nhsuk-heading-m,
+  .nhsuk-body-m,
+  .nhsuk-list {
+    margin-bottom: nhsuk-spacing(2);
+  }
 }

--- a/app/views/registrations/closed.html.erb
+++ b/app/views/registrations/closed.html.erb
@@ -2,7 +2,7 @@
 
 <%= h1 page_title, size: "xl" %>
 
-<p>
+<p class="nhsuk-body-m">
   If you have not already responded to messages from your child’s school about
   the HPV vaccination, please do so. The routine vaccination campaign is running
   in parallel with the pilot.

--- a/app/views/registrations/confirmation.html.erb
+++ b/app/views/registrations/confirmation.html.erb
@@ -5,7 +5,7 @@
   <%= page_title %>
 <% end %>
 
-<p>
+<p class="nhsuk-body-m">
   We’ll review your details to check you’re eligible for the pilot. We’ll be in
   touch again soon to let you know if you can take part.
 </p>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -8,20 +8,20 @@
     <%= page_title %>
   <% end %>
 
-  <p>
+  <p class="nhsuk-body-m">
     This pilot is for parents of children who are due to get their HPV
     vaccination this year.
   </p>
 
-  <p>
+  <p class="nhsuk-body-m">
     Taking part involves responding to a request for consent through a digital
     service, and then completing a follow-up survey. It should take 15 to 30
     minutes of your time.
   </p>
 
-  <p>To register your interest, complete the fields below.</p>
-
-  <%= govuk_section_break visible: true, size: "l" %>
+  <p class="nhsuk-body-m">
+    To register your interest, complete the fields below.
+  </p>
 
   <%= f.govuk_fieldset legend: { text: "About you", size: "l" } do %>
 
@@ -60,11 +60,12 @@
 
   <% end %>
 
-  <%= govuk_section_break visible: true, size: "l" %>
-
   <%= f.govuk_fieldset legend: { text: "About your child", size: "l" } do %>
 
-    <p>We need your child’s details to check your eligibility to take part in the pilot.</p>
+    <p class="nhsuk-body-m">
+      We need your child’s details to check your eligibility to take part in 
+      the pilot.
+    </p>
 
     <%= f.govuk_text_field :first_name,
                            label: { text: "First name", size: "s" },
@@ -118,31 +119,37 @@
                            class: "nhsuk-input--width-10" %>
   <% end %>
 
-  <%= govuk_section_break visible: true, size: "l" %>
-
   <%= govuk_inset_text do %>
     <span class="nhsuk-visually-hidden">Information: </span>
 
-    <h3>What you’ll get for taking part in the pilot</h3>
+    <h3 class="nhsuk-heading-m">
+      What you’ll get for taking part in the pilot
+    </h3>
 
-    <p>We’ll send you a £20 high street shopping voucher once you’ve:</p>
+    <p class="nhsuk-body-m">
+      We’ll send you a £20 high street shopping voucher once you’ve:
+    </p>
 
-    <ul>
+    <ul class="nhsuk-list nhsuk-list--bullet">
       <li>submitted a response through our digital service</li>
       <li>completed a survey about your experience</li>
     </ul>
 
-    <p>You need to do both these things to qualify for a voucher.</p>
+    <p class="nhsuk-body-m">
+      You need to do both these things to qualify for a voucher.
+    </p>
 
-    <p>
+    <p class="nhsuk-body-m">
       Vouchers are limited to one per household. If you have more than one child
       eligible for the HPV vaccination, you should only submit a consent
       response for one of your children.
     </p>
 
-    <h3>Follow-up research</h3>
+    <h3 class="nhsuk-heading-m">
+      Follow-up research
+    </h3>
 
-    <p>
+    <p class="nhsuk-body-m">
       Once you’ve completed the survey, you might be asked to take part in some
       follow-up research. There are separate incentives for this, and there’s no
       obligation to take part.
@@ -150,16 +157,18 @@
 
     <h3>Your personal information </h3>
 
-    <p>
+    <p class="nhsuk-body-m">
       Your contact details will be shared with NHS England so they can contact 
       you and send you a high street shopping voucher. You can find out more 
       about how NHS England will protect your personal information in their 
       <%= govuk_link_to "privacy notice", :privacy_policy %>.
     </p>
 
-    <h3>If you’re not chosen to take part in the pilot</h3>
+    <h3 class="nhsuk-heading-m">
+      If you’re not chosen to take part in the pilot
+    </h3>
 
-    <p>
+    <p class="nhsuk-body-m">
       NHS England will delete your contact details within two months of the last pilot vaccination session taking place.
     </p>
   <% end %>
@@ -193,8 +202,6 @@
                           },
                           link_errors: true %>
   <% end %>
-
-  <%= govuk_section_break visible: true, size: "l" %>
 
   <%= f.govuk_submit "Register your interest", secondary: true %>
 <% end %>


### PR DESCRIPTION
Adds print styles to registration form. Ensures that: 

- conditional fields are shown when form is being printed
- reduces sizing so that form appears across 3 pages of A4 instead of 4.
- hides button and privacy link destination

Preview:

- [before.pdf](https://github.com/nhsuk/manage-childrens-vaccinations/files/14185659/before.pdf)
- [after.pdf](https://github.com/nhsuk/manage-childrens-vaccinations/files/14185658/after.pdf)

