### PR TITLE
Remove unimplemented dashboard links

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -13,11 +13,6 @@
   <li>record vaccinations</li>
 </ul>
 
-<h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
-  <%= link_to "Manage vaccines", "#" %>
-</h2>
-<p>Add or remove batches</p>
-
 <hr>
 
 <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
@@ -26,13 +21,3 @@
 <p>
   Download a list of parents interested in the pilot, and upload a cohort list
 </p>
-
-<h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
-  <%= link_to "Manage team", "#" %>
-</h2>
-<p>Add or remove team members and set permissions</p>
-
-<h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
-  <%= link_to "Your account", "#" %>
-</h2>
-<p>Change your email address or password</p>


### PR DESCRIPTION
This functionality isn't available in the pilot.

### After

<img width="1504" alt="Screenshot 2024-02-07 at 10 21 15" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/7afb20aa-9627-4a4b-904a-28486a5a5a78">
