### PR TITLE
Validate school ids in cohort list belong to team

### DIFF
--- a/app/models/cohort_list.rb
+++ b/app/models/cohort_list.rb
@@ -70,7 +70,7 @@ class CohortList
     self.rows =
       data
         .map { |raw_row| raw_row.to_h.transform_keys { _1.downcase.to_sym } }
-        .map { CohortListRow.new(_1) }
+        .map { CohortListRow.new(_1.merge(team:)) }
   end
 
   def generate_patients!

--- a/app/models/cohort_list_row.rb
+++ b/app/models/cohort_list_row.rb
@@ -17,7 +17,8 @@ class CohortListRow
                 :child_address_line_2,
                 :child_address_town,
                 :child_address_postcode,
-                :child_nhs_number
+                :child_nhs_number,
+                :team
 
   validates :submitted_at, presence: true
   validate :submitted_at_is_valid, if: -> { submitted_at.present? }
@@ -132,7 +133,7 @@ class CohortListRow
   end
 
   def school_id_is_valid
-    Location.find(school_id)
+    team.locations.find(school_id)
   rescue ActiveRecord::RecordNotFound
     errors.add(:school_id, :invalid)
   end

--- a/spec/models/cohort_list_row_spec.rb
+++ b/spec/models/cohort_list_row_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe CohortListRow, type: :model do
+  describe "school_id validations" do
+    let(:user) { create(:user, team:) }
+    let(:location) { create(:location) }
+    let(:location2) { create(:location) }
+    let(:team) { create(:team, locations: [location]) }
+
+    subject(:cohort_list_row) { described_class.new(team:) }
+
+    it { should_not allow_value(location2.id).for(:school_id) }
+  end
+end

--- a/spec/models/cohort_list_spec.rb
+++ b/spec/models/cohort_list_spec.rb
@@ -3,11 +3,12 @@ require "rails_helper"
 RSpec.describe CohortList, type: :model do
   subject(:cohort_list) { described_class.new(csv:, team:) }
 
-  let(:team) { create(:team) }
+  let(:team) { create(:team, locations: [location]) }
+  # Ensure we have a location with id=1 since our fixture file uses it
+  let!(:location) { Location.find_by(id: 1) || create(:location, id: 1) }
   let(:csv) { fixture_file_upload("spec/fixtures/cohort_list/#{file}") }
 
   before do
-    create(:location, id: 1, team:) if Location.count.zero?
     if Registration.count.zero?
       create(:registration, id: 1, location_id: 1)
       create(:registration, id: 2, location_id: 1)


### PR DESCRIPTION
Otherwise someone could add a child to a school that belongs to another school, which would make that child visible to the team that owns that school.