### PR TITLE
Add pilot_phase_1 feature flag

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
   end
 
   FLIPPER_INITIALIZERS[:basic_auth].call unless Flipper.exist? :basic_auth
+  FLIPPER_INITIALIZERS[:pilot_phase_1].call unless Flipper.exist? :pilot_phase_1
 
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 

--- a/app/views/sessions/_session_row.html.erb
+++ b/app/views/sessions/_session_row.html.erb
@@ -17,7 +17,11 @@
           colour: "blue"
         ) %><br>
       <% end %>
-      <%= link_to session.location.name, session_path(session), "data-testid": "session-link" %><br>
+      <% if Flipper.enabled? :pilot_phase_1 %>
+        <%= link_to session.location.name, edit_session_path(session), "data-testid": "session-link" %><br>
+      <% else %>
+        <%= link_to session.location.name, session_path(session), "data-testid": "session-link" %><br>
+      <% end %>
       <%= session.location.town %>, <%= session.location.postcode %>
     </p>
   </td>

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -5,10 +5,13 @@
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
     { text: 'Home', href: dashboard_path },
-    { text: 'School sessions', href: sessions_path },
+    { text: 'School sessions', href: sessions_path }
+  ] + (Flipper.enabled?(:pilot_phase_1) ? [
+    { text: @session.name, active: true }
+  ] : [
     { text: @session.name, href: session_path(@session) },
     { text: page_title, active: true }
-  ]) %>
+  ])) %>
 <% end %>
 
 <%= h1 page_title %>

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -18,5 +18,12 @@ FLIPPER_INITIALIZERS = {
     else
       Flipper.disable(:basic_auth)
     end
+  end,
+  pilot_phase_1: -> do
+    if Rails.env.staging? || Rails.env.production?
+      Flipper.enable(:pilot_phase_1)
+    else
+      Flipper.disable(:pilot_phase_1)
+    end
   end
 }.freeze

--- a/tests/pilot_phase_1.spec.ts
+++ b/tests/pilot_phase_1.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, Page } from "@playwright/test";
+import { signInTestUser, fixtures, formatDate } from "./shared";
+
+let p: Page;
+
+test("Pilot journey", async ({ page }) => {
+  p = page;
+  await given_the_app_is_setup();
+  await and_phase_1_is_enabled();
+
+  await given_i_am_signed_in();
+
+  await when_i_go_to_the_sessions_page();
+  await then_i_should_see_a_session_link();
+
+  await when_i_click_on_the_session_link();
+  await then_i_should_see_the_session_details_page();
+});
+
+async function given_the_app_is_setup() {
+  await p.goto("/reset");
+}
+
+async function and_phase_1_is_enabled() {
+  await p.goto("/flipper/features/pilot_phase_1");
+  await expect(p.getByText("Home Features pilot_phase_1")).toBeVisible();
+
+  if (await p.getByText("Disabled").isVisible()) {
+    await p.getByRole("button", { name: "Fully Enable" }).click();
+    await expect(p.getByText("Fully enabled")).toBeVisible();
+  }
+}
+
+async function given_i_am_signed_in() {
+  await signInTestUser(p);
+}
+
+async function when_i_go_to_the_sessions_page() {
+  await p.goto("/sessions");
+}
+
+async function then_i_should_see_a_session_link() {
+  await expect(
+    p.getByRole("link", { name: fixtures.schoolName }),
+  ).toBeVisible();
+}
+
+async function when_i_click_on_the_session_link() {
+  await p.getByRole("link", { name: fixtures.schoolName }).click();
+}
+
+async function then_i_should_see_the_session_details_page() {
+  await expect(
+    p.getByRole("heading", { name: "Session details" }),
+  ).toBeVisible();
+}


### PR DESCRIPTION
When enabled, this flag restricts the interface and hides links to consent/triage/vaccination pages. It does not restrict the actual routes. It's enabled by default in prod-like environments.