### PR TITLE
Add on-demand deployment option

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   # Permissions to request and use OIDC tokens and access repository contents
   copilot:
+    name: AWS Copilot
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,15 @@ name: Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        options:
+          - staging
+          - training
 
 jobs:
   # Permissions to request and use OIDC tokens and access repository contents
@@ -32,4 +41,9 @@ jobs:
 
       - name: Deploy the application using AWS Copilot
         run: |
-          copilot svc deploy --env test
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ENVIRONMENT=${{ github.event.inputs.environment }}
+          else
+            ENVIRONMENT=test
+          fi
+          copilot svc deploy --env $ENVIRONMENT


### PR DESCRIPTION
This adds the possibility to deploy the application using the GitHub actions UI to the training and staging environments.

`test` is the default which is used for automatic deploys from `main`.