### PR TITLE
Remove double flash message banner

### DIFF
--- a/app/components/app_flash_message_component.html.erb
+++ b/app/components/app_flash_message_component.html.erb
@@ -1,11 +1,15 @@
-<%= govuk_notification_banner(
-  classes: classes,
-  html_attributes: { role: role },
-  title_text: title,
-  success: success?,
-) do |notification_banner| %>
-  <% notification_banner.with_heading(text: heading) if heading.present? %>
-  <% if body.present? %>
-    <p><%= body.html_safe %></p>
-  <% end %>
-<% end %>
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+    <%= govuk_notification_banner(
+      classes: classes,
+      html_attributes: { role: role },
+      title_text: title,
+      success: success?,
+    ) do |notification_banner| %>
+      <% notification_banner.with_heading(text: heading) if heading.present? %>
+      <% if body.present? %>
+        <p><%= body.html_safe %></p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -1,5 +1,3 @@
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
 <% page_title = "Check consent responses" %>
 
 <% content_for :before_main do %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -79,6 +79,8 @@
 
     <div class="nhsuk-width-container">
       <main class="nhsuk-main-wrapper" id="main-content" role="main">
+        <%= render(AppFlashMessageComponent.new(flash: flash)) %>
+
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
     </div>

--- a/app/views/layouts/two_thirds.html.erb
+++ b/app/views/layouts/two_thirds.html.erb
@@ -1,8 +1,6 @@
 <% content_for :content do %>
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
       <%= yield :before_content %>
 
       <%= yield %>

--- a/app/views/pages/start.html.erb
+++ b/app/views/pages/start.html.erb
@@ -1,7 +1,5 @@
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">
-    <%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
     <%= h1 "#{@service_name} (MAVIS)", size: "xl" %>
 
     <p>Use this service to:</p>

--- a/app/views/pilot/registrations.html.erb
+++ b/app/views/pilot/registrations.html.erb
@@ -1,5 +1,3 @@
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
 <% page_title = "Parents interested in the pilot" %>
 
 <% content_for :before_main do %>

--- a/app/views/sessions/edit.html.erb
+++ b/app/views/sessions/edit.html.erb
@@ -1,5 +1,3 @@
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
 <% page_title = "Session details" %>
 
 <% content_for :before_main do %>

--- a/app/views/sessions/index.html.erb
+++ b/app/views/sessions/index.html.erb
@@ -1,7 +1,5 @@
 <% page_title = "School sessions" %>
 
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
     { text: 'Home', href: dashboard_path },

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -1,5 +1,3 @@
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
 <% page_title = @session.name %>
 
 <% content_for :before_main do %>

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -1,5 +1,3 @@
-<%= render(AppFlashMessageComponent.new(flash: flash)) %>
-
 <% page_title = "Triage health questions" %>
 
 <% content_for :before_main do %>

--- a/app/views/vaccinations/index.html.erb
+++ b/app/views/vaccinations/index.html.erb
@@ -1,7 +1,5 @@
 <% page_title = "Record vaccinations" %>
 
-<%= render(AppFlashMessageComponent.new(flash:)) %>
-
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
     { text: 'Home', href: dashboard_path },


### PR DESCRIPTION
Before this, the two_thirds layout included a banner, and some pages would also include their own banner.

This changes so that the layout always includes a banner and makes it always span two thirds, which was another previous inconsistency.