### PR TITLE
Add spec/factories folder to production docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,6 +40,7 @@
 /docs
 /coverage
 /spec
+!/spec/factories
 /tests
 /terraform
 


### PR DESCRIPTION
The spec/factories are necessary if we want to run FactoryBot create's in the prod-like envs.