### PR TITLE
Use date fields for send_consent_at

### DIFF
--- a/app/controllers/edit_sessions_controller.rb
+++ b/app/controllers/edit_sessions_controller.rb
@@ -66,8 +66,9 @@ class EditSessionsController < ApplicationController
         patient_ids: []
       },
       timeline: %i[
-        consent_days_before
-        consent_days_before_custom
+        send_consent_at(3i)
+        send_consent_at(2i)
+        send_consent_at(1i)
         reminder_days_after
         reminder_days_after_custom
         close_consent_on
@@ -125,6 +126,18 @@ class EditSessionsController < ApplicationController
       unless validator.date_params_valid?
         @session.date = validator.date_params_as_struct
         @session.time_of_day = update_params[:time_of_day]
+        render_wizard nil, status: :unprocessable_entity
+      end
+    when :timeline
+      validator =
+        DateParamsValidator.new(
+          field_name: :send_consent_at,
+          object: @session,
+          params: update_params
+        )
+
+      unless validator.date_params_valid?
+        @session.send_consent_at = validator.date_params_as_struct
         render_wizard nil, status: :unprocessable_entity
       end
     end

--- a/app/views/edit_sessions/timeline.html.erb
+++ b/app/views/edit_sessions/timeline.html.erb
@@ -14,20 +14,9 @@
     Session scheduled for <%= @session.date.to_fs(:nhsuk_date_day_of_week) %> (<%= @session.human_enum_name(:time_of_day) %>)
   <% end %>
 
-  <%= f.govuk_radio_buttons_fieldset :consent_days_before,
+  <%= f.govuk_date_field :send_consent_at,
     legend: { size: 'm', text: 'Consent requests' },
-    hint: { text: 'When should parents get a request for consent?' } do %>
-    <%= f.govuk_radio_button :consent_days_before, :default,
-      label: { text: "#{pluralize(Session::DEFAULT_DAYS_FOR_CONSENT, 'day')} before the session" },
-      link_errors: true %>
-    <%= f.govuk_radio_button :consent_days_before, :custom,
-      label: { text: 'Choose your own schedule' } do %>
-      <%= f.govuk_text_field :consent_days_before_custom,
-        label: { text: 'Days before the session', size: 's' },
-        width: 2,
-        suffix_text: "days" %>
-    <% end %>
-  <% end %>
+    hint: { text: 'When should parents get a request for consent?' } %>
 
   <%= f.govuk_radio_buttons_fieldset :reminder_days_after,
     legend: { size: 'm', text: 'Reminders' },
@@ -36,7 +25,7 @@
       label: { text: "#{pluralize(Session::DEFAULT_DAYS_FOR_REMINDER, 'day')} after the first consent request" },
       link_errors: true %>
     <%= f.govuk_radio_button :reminder_days_after, :custom,
-      label: { text: 'Choose your own schedule' } do %>
+      label: { text: 'Choose your own date' } do %>
       <%= f.govuk_text_field :reminder_days_after_custom,
         label: { text: 'Days after the first consent request', size: 's' },
         width: 2,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -496,13 +496,13 @@ en:
               too_long: Enter triage notes that are less than 1000 characters long
         session:
           attributes:
-            consent_days_before:
-              blank: Choose when to send consent requests
-              inclusion: Choose when to send consent requests
-            consent_days_before_custom:
-              blank: Choose the number of days before the session to send consent requests
-              greater_than_or_equal_to: Choose a number between 10 and 30
-              less_than_or_equal_to: Choose a number between 10 and 30
+            send_consent_at:
+              blank: Choose a date to send consent requests
+              greater_than_or_equal_to: Enter a date in the future
+              less_than_or_equal_to: Enter a date before the session
+              missing_year: Enter a year
+              missing_month: Enter a month
+              missing_day: Enter a day
             reminder_days_after:
               blank: Choose when to send reminders
               inclusion: Choose when to send reminders

--- a/tests/pilot_journey.spec.ts
+++ b/tests/pilot_journey.spec.ts
@@ -168,9 +168,7 @@ async function when_i_create_a_new_session() {
 
   // Choosing a date 30 days from today
   sessionDate = new Date();
-  formatDate(sessionDate);
   sessionDate.setDate(sessionDate.getDate() + 30);
-  formatDate(sessionDate);
 
   await p
     .getByLabel("Day", { exact: true })
@@ -223,9 +221,21 @@ async function and_select_the_children_for_the_cohort() {
 }
 
 async function and_enter_and_confirm_the_session_details() {
-  await p.getByRole("radio", { name: "14 days before the session" }).click();
+  // Ask for consents 16 days from today, 2 weeks before the session
+  const consentDate = new Date();
+  consentDate.setDate(sessionDate.getDate() + 16);
   await p
-    .getByRole("radio", { name: "7 days after the first consent request" })
+    .getByRole("textbox", { name: "Day" })
+    .fill(consentDate.getDate().toString());
+  await p
+    .getByRole("textbox", { name: "Month" })
+    .fill((consentDate.getMonth() + 1).toString());
+  await p
+    .getByRole("textbox", { name: "Year" })
+    .fill(consentDate.getFullYear().toString());
+
+  await p
+    .getByRole("radio", { name: "2 days after the first consent request" })
     .click();
   await p
     .getByRole("radio", {

--- a/tests/session_create.spec.ts
+++ b/tests/session_create.spec.ts
@@ -178,9 +178,20 @@ async function then_i_see_the_timeline_page() {
 }
 
 async function when_i_choose_my_timeline() {
-  await p.getByRole("radio", { name: "14 days before the session" }).click();
+  const consentDate = new Date();
+  consentDate.setDate(consentDate.getDate());
   await p
-    .getByRole("radio", { name: "7 days after the first consent request" })
+    .getByRole("textbox", { name: "Day" })
+    .fill(consentDate.getDate().toString());
+  await p
+    .getByRole("textbox", { name: "Month" })
+    .fill((consentDate.getMonth() + 1).toString());
+  await p
+    .getByRole("textbox", { name: "Year" })
+    .fill(consentDate.getFullYear().toString());
+
+  await p
+    .getByRole("radio", { name: "2 days after the first consent request" })
     .click();
   await p
     .getByRole("radio", {


### PR DESCRIPTION
This replaces the field that asks for a day before the session to one that simply asks for a specific day/month/year.

One bug with this approach is that the `DateParamsValidator` comes before the validations on the model, so if there are errors there, the errors on the model don't get surfaced and re-appear once the date is entered correctly. I'd like to revisit the `DateParamsValidator` implementation at some point and hopefully get it working more similarly to other validators.

Also changes `DEFAULT_DAYS_FOR_REMINDER` to `2`.

### Screenshots

<img width="901" alt="Screenshot 2024-02-15 at 16 36 55" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/10c07da0-af26-40d0-98d5-4a570bb3dd32">
<img width="944" alt="Screenshot 2024-02-15 at 16 37 02" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/2a577349-fda5-43c0-8002-284f402a613a">
<img width="918" alt="Screenshot 2024-02-15 at 16 37 10" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/6f97e390-f45d-4452-9e83-7a11077ab201">
<img width="910" alt="Screenshot 2024-02-15 at 16 40 18" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/9d7859da-b28a-4f4c-b93b-25b810ce0fd9">
<img width="887" alt="Screenshot 2024-02-15 at 16 40 41" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/1d1c5474-d446-44fe-8b57-b00b90cb4934">
