### PR TITLE
Add script to extract testing fixtures

### DIFF
--- a/bin/generate-example-campaigns
+++ b/bin/generate-example-campaigns
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Use this to generate example campaigns for testing.
+
 rails generate_example_campaign[db/sample_data/example-hpv-campaign.json] seed=42 presets=default type=hpv username="Nurse Joy"
 rails generate_example_campaign[db/sample_data/example-flu-campaign.json] seed=43 presets=default type=flu username="Nurse Jackie"
 rails generate_example_campaign[db/sample_data/example-pilot-campaign.json] seed=44 presets=empty_pilot username="Nurse Flo"
@@ -7,5 +9,6 @@ rails generate_example_campaign[db/sample_data/example-pilot-campaign.json] seed
 read year month day <<< $(date +"%Y %m %d")
 echo "Set the dates in spec/lib/example_campaign_generator_spec.rb"
 echo ""
-printf "  let(:test_timestamp) { [%d, %d, %d, 12, 0, 0] }" $year $month $day
+printf "  let(:test_timestamp) { [%d, %d, %d, 12, 0, 0] }\n" $year $month $day
 echo ""
+

--- a/bin/show-testing-fixtures
+++ b/bin/show-testing-fixtures
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Use this to generate example campaigns for testing.
+
+set -e
+
+function patient_that_needs_consent {
+    jq -r '[.sessions[].patients[]
+ | select(.consents == null)
+ | {firstName, lastName}]
+ | sort_by(.firstName)
+ | .[0]
+ | "\(.firstName) \(.lastName)"' db/sample_data/example-hpv-campaign.json
+}
+
+function patient_that_needs_triage {
+    jq -r '[.sessions[].patients[]
+      | select(.consents | type == "array" and any(.response == "given"))
+      | select(.consents | type == "array" and any(.healthQuestionResponses | type == "array"
+                                                   and any(.response == "Yes")))
+      | select(.triage | .status == "ready_to_vaccinate" | not)
+      | {firstName, lastName}
+      ] | sort_by(.firstName) | .[0] | "\(.firstName) \(.lastName)"' db/sample_data/example-hpv-campaign.json
+}
+
+function second_patient_that_needs_consent {
+    jq -r '[.sessions[].patients[]
+      | select(.consents == null) | {firstName, lastName}]
+      | sort_by(.firstName)
+      | .[1] | "\(.firstName) \(.lastName)"' db/sample_data/example-hpv-campaign.json
+}
+
+function patient_with_conflicting_consent {
+    jq -r '[.sessions[].patients[]
+    | select(
+        .consents | type == "array" and any(.[]; .response == "refused") and any(.[]; .response == "given")
+      )
+    | {firstName, lastName}]
+    | sort_by(.firstName)
+    | .[0]
+    | "\(.firstName) \(.lastName)"' db/sample_data/example-hpv-campaign.json
+}
+
+function second_patient_that_needs_triage {
+    jq -r '[.sessions[].patients[]
+      | select(.consents | type == "array" and any(.response == "given"))
+      | select(.consents | type == "array" and any(.healthQuestionResponses | type == "array"
+                                                   and any(.response == "Yes")))
+      | select(.triage | .status == "ready_to_vaccinate" | not)
+      | {firstName, lastName}
+      ] | sort_by(.firstName) | .[1] | "\(.firstName) \(.lastName)"'  db/sample_data/example-hpv-campaign.json
+}
+
+function patient_that_needs_vaccination {
+    jq -r '[.sessions[].patients[]
+ | select(.triage | .status == "ready_to_vaccinate")
+ | {firstName, lastName}
+] | sort_by(.firstName) | .[0] | "\(.firstName) \(.lastName)"' db/sample_data/example-hpv-campaign.json
+}
+
+function second_patient_that_needs_vaccination {
+    jq -r '[.sessions[].patients[]
+ | select(.triage | .status == "ready_to_vaccinate")
+ | {firstName, lastName}
+] | sort_by(.firstName) | .[1] | "\(.firstName) \(.lastName)"' db/sample_data/example-hpv-campaign.json
+}
+
+function vaccine_batch {
+    jq -r '.vaccines[].batches[0].name' db/sample_data/example-hpv-campaign.json
+}
+
+function school_name {
+    jq -r '.sessions[].school.name' db/sample_data/example-hpv-campaign.json
+}
+
+function second_school_name {
+    jq -r '.sessions[].school.name' db/sample_data/example-flu-campaign.json
+}
+
+function unmatched_consent_form_parent_name {
+    jq -r '.sessions[].consent_forms[0].parent_name' db/sample_data/example-hpv-campaign.json
+}
+
+function unmatched_consent_form_child_name {
+    jq -r '.sessions[].consent_forms[0] | { first_name, last_name } | "\(.first_name) \(.last_name)"' db/sample_data/example-hpv-campaign.json
+}
+
+function pilot_school_name {
+    jq -r '.schoolsWithNoSession[].name' db/sample_data/example-pilot-campaign.json
+}
+
+function children_to_be_vaccinated_in_flu_session {
+    jq '[.sessions[].patients[] | select(.triage | .status == "do_not_vaccinate" | not)] | length' db/sample_data/example-flu-campaign.json
+}
+
+# Do we have any args?
+if [ $# -gt 0 ]; then
+    fun=$1
+    eval "$fun"
+    exit 0
+fi
+
+echo "Copy the following into tests/shared/intex.ts replacing the fixtures"
+echo "structure there:"
+echo ""
+
+cat <<EOF
+export const fixtures = {
+  parentName: "Lauren Pacocha", // Made up / arbitrary
+  parentRole: "Mum",
+
+  // Get from /sessions/1/consents, "No response" tab
+  patientThatNeedsConsent: "$(patient_that_needs_consent)",
+  secondPatientThatNeedsConsent: "$(second_patient_that_needs_consent)",
+
+  // Get from /sessions/1/consents, "Consent conflicts" tab
+  patientWithConflictingConsent: "$(patient_with_conflicting_consent)",
+
+  // Get from /sessions/1/triage, "Triage needed" tab; check that they don't
+  // have existing triage
+  patientThatNeedsTriage: "$(patient_that_needs_triage)",
+  secondPatientThatNeedsTriage: "$(second_patient_that_needs_triage)",
+
+  // Get from /sessions/1/vaccinations, "Action needed" tab
+  patientThatNeedsVaccination: "$(patient_that_needs_vaccination)",
+  secondPatientThatNeedsVaccination: "$(second_patient_that_needs_vaccination)",
+
+  // Get from /sessions/1/patients/Y/vaccinations/batch/edit
+  vaccineBatch: "$(vaccine_batch)",
+
+  // Get from /sessions, signed in as Nurse Joy
+  schoolName: "$(school_name)",
+
+  // Get from /sessions, signed in as Nurse Jackie
+  secondSchoolName: /$(second_school_name)/,
+
+  // Any consent response from /schools/1, signed in as Nurse Joy
+  unmatchedConsentFormParentName: "$(unmatched_consent_form_parent_name)",
+  unmatchedConsentFormChildName: "$(unmatched_consent_form_child_name)",
+
+  // School from /pilot/registrations
+  pilotSchoolName: "$(pilot_school_name)",
+
+  // Children whose parents have expressed interest in the pilot These should
+  // all exist in the downloaded list of registered parents from
+  // /pilot/registrations or from the "registrations" section of the example
+  // campaign CSV. We only the first 3.
+  registeredChildren: [
+$(jq -r '[.registrations[] | {firstName, lastName}] | .[0:3][] | "\(.firstName) \(.lastName)"' db/sample_data/example-pilot-campaign.json | while read firstName lastName ; do
+  echo "    { firstName: \"$firstName\", lastName: \"$lastName\", fullName: \"$firstName $lastName\" },"
+done)
+  ],
+
+  // Number of children who are ready to be vaccinated in the flu session
+  childrenToBeVaccinatedInFluSession: $(children_to_be_vaccinated_in_flu_session),
+};
+EOF


### PR DESCRIPTION
First take at automating generating the fixtures used by tests from the example campaign JSON. As discussed this could be improved with a JS (or even Ruby) implementation, but this is the first stab.