### PR TITLE
Add inset text to session create confirmation page

### DIFF
--- a/app/views/edit_sessions/confirm.html.erb
+++ b/app/views/edit_sessions/confirm.html.erb
@@ -11,4 +11,11 @@
 
 <%= render AppSessionDetailsComponent.new(session: @session) %>
 
+<% if @session.send_consent_at.today? %>
+  <%= govuk_inset_text do %>
+    After clicking confirm, consent request emails will be sent today at
+    <%= Time.zone.now.strftime("%H:%M") %>.
+  <% end %>
+<% end %>
+
 <%= govuk_button_to "Confirm", wizard_path, method: :put %>

--- a/tests/session_create.spec.ts
+++ b/tests/session_create.spec.ts
@@ -156,6 +156,10 @@ async function then_i_see_the_confirm_details_page() {
   await expect(p.locator(".nhsuk-card")).toHaveText(
     new RegExp("Cohort" + "5 children"),
   );
+
+  await expect(p.locator(".nhsuk-inset-text")).toHaveText(
+    /After clicking confirm/,
+  );
 }
 
 async function when_i_click_on_the_confirm_button() {


### PR DESCRIPTION
If the date to send consent requests is today, we should display a small warning text above the confirm button.

<img width="903" alt="Screenshot 2024-02-16 at 16 02 49" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/1f281c0a-e288-42d7-82df-9be987386e63">
