### PR TITLE
Add more testing around the agree to observe checkbox

### DIFF
--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -1,0 +1,61 @@
+require "faker"
+
+class TestingController < ApplicationController
+  skip_before_action :authenticate_user!
+  before_action :ensure_dev_or_test_env
+
+  layout "two_thirds"
+
+  skip_before_action :verify_authenticity_token
+
+  def show_campaign
+    @campaign = Campaign.find(params[:id])
+
+    respond_to do |format|
+      format.json do
+        render json: {
+                 registrationPage:
+                   new_school_registration_path(
+                     @campaign.sessions.first.location
+                   ),
+                 locationName: @campaign.sessions.first.location.name
+               }
+      end
+    end
+  end
+
+  def generate_campaign
+    Faker::Config.locale = "en-GB"
+
+    session = FactoryBot.create(:session)
+    location =
+      FactoryBot.create(
+        :location,
+        name: "Testing Location",
+        sessions: [session],
+        **location_params
+      )
+    campaign = location.sessions.first.campaign
+    redirect_to testing_show_campaign_path(id: campaign.id)
+  end
+
+  private
+
+  def location_params
+    params.require(:location).permit(
+      :name,
+      :address,
+      :postcode,
+      :latitude,
+      :longitude,
+      :permission_to_observe_required,
+      :registration_open
+    )
+  end
+
+  def ensure_dev_or_test_env
+    unless Rails.env.development? || Rails.env.test?
+      raise "Not in test environment"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,11 @@ Rails.application.routes.draw do
   if Rails.env.development? || Rails.env.test?
     get "/reset", to: "dev#reset"
     get "/random_consent_form", to: "dev#random_consent_form"
+
+    namespace :testing do
+      get "/campaigns/:id", action: :show_campaign, as: "show_campaign"
+      post "generate-campaign"
+    end
   end
 
   get "/csrf", to: "csrf#new"

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -17,10 +17,15 @@
 #
 FactoryBot.define do
   factory :team do
-    sequence(:name) { |n| "Team #{n}" }
-    sequence(:email) { |n| "team-#{n}@example.com" }
-    ods_code { "U#{rand(10_000..99_999)}" }
+    transient do
+      random { Random.new }
+      identifier { random.rand(1..10_000) }
+    end
+
+    name { "Team #{identifier}" }
+    email { "team-#{identifier}@example.com" }
+    ods_code { "U#{identifier}" }
     privacy_policy_url { "https://example.com/privacy" }
-    sequence(:reply_to_id) { |n| "reply-to-id-team-#{n}" }
+    reply_to_id { "reply-to-id-team-#{identifier}" }
   end
 end

--- a/tests/pilot_registration_checkboxes.spec.ts
+++ b/tests/pilot_registration_checkboxes.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, Page, APIRequestContext } from "@playwright/test";
+import { signInTestUser, fixtures } from "./shared";
+
+let p: Page;
+let r: APIRequestContext;
+let registrationPage: string;
+let locationName: string;
+
+test("Pilot registration - check-boxes", async ({ page, request }) => {
+  p = page;
+  r = request;
+
+  await given_a_location_requiring_permission_to_observe();
+  await and_registration_is_open();
+
+  await when_i_go_to_the_registration_page_for_a_school();
+  await and_i_enter_all_the_details();
+  await and_i_check_all_the_boxes_except_the_one_to_agree_to_take_part();
+  await and_i_click_submit();
+  await then_i_see_a_message_saying_i_must_agree_to_all_conditions();
+
+  await when_i_check_all_the_boxes_except_the_one_to_share_contact_details();
+  await and_i_click_submit();
+  await then_i_see_a_message_saying_i_must_agree_to_all_conditions();
+
+  await when_i_check_all_the_boxes_except_the_one_about_regular_consent();
+  await and_i_click_submit();
+  await then_i_see_a_message_saying_i_must_agree_to_all_conditions();
+
+  await when_i_check_all_the_boxes_except_the_one_about_observation();
+  await and_i_click_submit();
+  await then_i_see_a_message_saying_i_must_agree_to_all_conditions();
+
+  await when_i_check_all_the_boxes();
+  await and_i_click_submit();
+  await then_i_see_the_confirmation_message();
+});
+
+async function given_a_location_requiring_permission_to_observe() {
+  let response = await r.post("/testing/generate-campaign", {
+    data: {
+      location: {
+        permission_to_observe_required: true,
+        registration_open: true,
+      },
+    },
+    timeout: 10000,
+    headers: {
+      Accept: "application/json",
+    },
+  });
+  let json = await response.json();
+
+  registrationPage = json.registrationPage;
+  locationName = json.locationName;
+}
+
+async function and_registration_is_open() {
+  await signInTestUser(p);
+  await p.goto("/flipper/features/registration_open");
+  await expect(p.getByText("Home Features registration_open")).toBeVisible();
+  if (await p.getByText("Disabled").isVisible()) {
+    await p.getByRole("button", { name: "Fully Enable" }).click();
+    await expect(p.getByText("Fully enabled")).toBeVisible();
+  }
+}
+
+async function when_i_go_to_the_registration_page_for_a_school() {
+  await p.goto(registrationPage);
+}
+
+async function and_i_click_submit() {
+  await p.click("button[type='submit']");
+}
+
+async function and_i_enter_all_the_details() {
+  // Parent details
+  await p.getByLabel("Your name").fill("Big Daddy Tests");
+  await p.getByLabel("Dad").check();
+  await p.getByLabel("Email address").fill("daddy.tests@example.com");
+  await p.getByLabel("Phone number").fill("07123456789");
+
+  // Child details
+  await p.getByLabel("First name").fill("Bobby");
+  await p.getByLabel("Last name").fill("Tests");
+  await p.getByLabel("Yes").check();
+  await p.getByLabel("Preferred name").fill("Drop Table");
+  await p.getByLabel("Day").fill("01");
+  await p.getByLabel("Month").fill("01");
+  await p.getByLabel("Year").fill("2020");
+  await p.getByLabel("Address line 1").fill("1 Test Street");
+  await p.getByLabel("Address line 1").fill("2nd Floor");
+  await p.getByLabel("Town or city").fill("Testville");
+  await p.getByLabel("Postcode").fill("TE1 1ST");
+  await p.getByLabel("NHS number").fill("999 888 7777");
+}
+
+async function and_i_check_all_the_boxes_except_the_one_to_agree_to_take_part() {
+  await p.getByLabel("I agree to take part in the pilot").uncheck();
+  await p.getByLabel("I agree to share my contact details").check();
+  await p.getByLabel("I confirm I’ve responded to the school").check();
+  await p
+    .getByLabel("I agree to my child’s vaccination session being observed")
+    .check();
+}
+
+async function then_i_see_a_message_saying_i_must_agree_to_all_conditions() {
+  const alert = p.getByRole("alert");
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText(
+    "You must agree to all of the conditions for taking part in the pilot",
+  );
+}
+
+async function when_i_check_all_the_boxes_except_the_one_to_share_contact_details() {
+  await p.getByLabel("I agree to take part in the pilot").check();
+  await p.getByLabel("I agree to share my contact details").uncheck();
+  await p.getByLabel("I confirm I’ve responded to the school").check();
+  await p
+    .getByLabel("I agree to my child’s vaccination session being observed")
+    .check();
+}
+
+async function when_i_check_all_the_boxes_except_the_one_about_regular_consent() {
+  await p.getByLabel("I agree to take part in the pilot").check();
+  await p.getByLabel("I agree to share my contact details").check();
+  await p.getByLabel("I confirm I’ve responded to the school").uncheck();
+  await p
+    .getByLabel("I agree to my child’s vaccination session being observed")
+    .check();
+}
+
+async function when_i_check_all_the_boxes_except_the_one_about_observation() {
+  await p.getByLabel("I agree to take part in the pilot").check();
+  await p.getByLabel("I agree to share my contact details").check();
+  await p.getByLabel("I confirm I’ve responded to the school").check();
+  await p
+    .getByLabel("I agree to my child’s vaccination session being observed")
+    .uncheck();
+}
+
+async function when_i_check_all_the_boxes() {
+  await p.getByLabel("I agree to take part in the pilot").check();
+  await p.getByLabel("I agree to share my contact details").check();
+  await p.getByLabel("I confirm I’ve responded to the school").check();
+  await p
+    .getByLabel("I agree to my child’s vaccination session being observed")
+    .check();
+}
+
+async function then_i_see_the_confirmation_message() {
+  await expect(
+    p.getByRole("heading", {
+      name: "Thank you for registering your interest in the NHS school vaccinations pilot",
+    }),
+  ).toBeVisible();
+}

--- a/tests/pilot_registration_no_observation.spec.ts
+++ b/tests/pilot_registration_no_observation.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect, Page, APIRequestContext } from "@playwright/test";
+// import { signInTestUser, fixtures } from "./shared";
+
+let p: Page;
+let r: APIRequestContext;
+let registrationPage: string;
+let locationName: string;
+
+test("Pilot registration - no observation", async ({ page, request }) => {
+  p = page;
+  r = request;
+
+  await given_a_location_not_requiring_permission_to_observe();
+  await and_registration_is_open();
+
+  await when_i_go_to_the_registration_page_for_a_school();
+  await then_i_see_the_page_with_the_school_name();
+  await and_there_is_no_checkbox_to_give_permission_to_observe();
+
+  await when_i_enter_all_the_details();
+  await and_i_click_submit();
+  await then_i_see_a_message_saying_i_must_agree_to_all_conditions();
+
+  await when_i_check_the_conditions_for_taking_part();
+  await and_i_click_submit();
+  await then_i_see_the_confirmation_message();
+});
+
+async function given_a_location_not_requiring_permission_to_observe() {
+  let response = await r.post("/testing/generate-campaign", {
+    data: {
+      location: {
+        permission_to_observe_required: false,
+        registration_open: true,
+      },
+    },
+    timeout: 10000,
+    headers: {
+      Accept: "application/json",
+    },
+  });
+  let json = await response.json();
+
+  registrationPage = json.registrationPage;
+  locationName = json.locationName;
+}
+
+async function and_registration_is_open() {
+  await p.goto("/flipper/features/registration_open");
+  await expect(p.getByText("Home Features registration_open")).toBeVisible();
+  if (await p.getByText("Disabled").isVisible()) {
+    await p.getByRole("button", { name: "Fully Enable" }).click();
+    await expect(p.getByText("Fully enabled")).toBeVisible();
+  }
+}
+
+async function when_i_go_to_the_registration_page_for_a_school() {
+  await p.goto(registrationPage);
+}
+
+async function then_i_see_the_page_with_the_school_name() {
+  await expect(p.getByRole("heading", { name: locationName })).toBeVisible();
+}
+
+async function and_there_is_no_checkbox_to_give_permission_to_observe() {
+  await expect(
+    p.getByLabel("I agree to my child’s vaccination session being observed"),
+  ).not.toBeVisible();
+}
+
+async function and_i_click_submit() {
+  await p.click("button[type='submit']");
+}
+
+async function when_i_enter_all_the_details() {
+  // Parent details
+  await p.getByLabel("Your name").fill("Big Daddy Tests");
+  await p.getByLabel("Dad").check();
+  await p.getByLabel("Email address").fill("daddy.tests@example.com");
+  await p.getByLabel("Phone number").fill("07123456789");
+
+  // Child details
+  await p.getByLabel("First name").fill("Bobby");
+  await p.getByLabel("Last name").fill("Tests");
+  await p.getByLabel("Yes").check();
+  await p.getByLabel("Preferred name").fill("Drop Table");
+  await p.getByLabel("Day").fill("01");
+  await p.getByLabel("Month").fill("01");
+  await p.getByLabel("Year").fill("2020");
+  await p.getByLabel("Address line 1").fill("1 Test Street");
+  await p.getByLabel("Address line 1").fill("2nd Floor");
+  await p.getByLabel("Town or city").fill("Testville");
+  await p.getByLabel("Postcode").fill("TE1 1ST");
+  await p.getByLabel("NHS number").fill("999 888 7777");
+}
+
+async function then_i_see_a_message_saying_i_must_agree_to_all_conditions() {
+  const alert = p.getByRole("alert");
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText(
+    "You must agree to all of the conditions for taking part in the pilot",
+  );
+}
+
+async function when_i_check_the_conditions_for_taking_part() {
+  await p.getByLabel("I agree to take part in the pilot").check();
+  await p
+    .getByLabel(
+      "I agree to share my contact details with NHS England for the purpose of administering payments and electronic communications",
+    )
+    .check();
+  await p
+    .getByLabel(
+      "I confirm I’ve responded to the school’s regular request for consent for my child’s HPV vaccination",
+    )
+    .check();
+}
+
+async function then_i_see_the_confirmation_message() {
+  await expect(
+    p.getByRole("heading", {
+      name: "Thank you for registering your interest in the NHS school vaccinations pilot",
+    }),
+  ).toBeVisible();
+}


### PR DESCRIPTION
It's important that the behaviour of the checkboxes the parents use to agree to having their child observed work reliably. This adds extra testing to ensure:

- if the parent does not check the observation checkbox (or any of the other agreement/confirmation checkboxes) they cannot join the pilot
- if the school does not require agreement to observation the checkbox does not appear

This also adds a new approach to generating fixtures by using a `TestingController` to try to simplify the process.

Questions about test coverage:
- We don't have a test to ensure that if a parent fills in the registration form but does _not_ check any of the required agreements / confirmations, their child is not added to the system. Worth adding?