### PR TITLE
Test out ECS resource changes in staging

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -31,15 +31,13 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # the concurrency of the application would be max `threads` * `workers`.
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY", 0)
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
-#
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -50,6 +50,9 @@ secrets:
 
 environments:
   staging:
+    cpu: 1024
+    memory: 2048
+    count: 2
     http:
       alias:
         - "staging.manage-vaccinations-in-schools.nhs.uk"

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -62,6 +62,7 @@ environments:
       MAVIS__HOST: "staging.manage-vaccinations-in-schools.nhs.uk"
       MAVIS__SUPPORT_USERNAME: manage
       MAVIS__SUPPORT_PASSWORD: vaccinations
+      WEB_CONCURRENCY: 2
   test:
     http:
       alias:


### PR DESCRIPTION
This is to test before going to production. If this test is successful we will make these changes to production, the plan would be:

1. Return staging to previous settings, except task count which should remain 2 (this means 2 containers will be run for this service in ECS, this is important to test for potential cross-server concurrency issues).
2. Update production to use the settings here.
3. PR and merge changes.
4. Deploy to staging.
5. Take manual snapshot of the production db.
6. Deploy to production.