### PR TITLE
Tweak parental consent emails

### DIFF
--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -1,8 +1,4 @@
 class ConsentFormMailer < ApplicationMailer
-  def reply_to_id(consent_form:)
-    consent_form.session.campaign.team.reply_to_id
-  end
-
   def confirmation(consent_form)
     if consent_form.common_name.present?
       short_patient_name = consent_form.common_name
@@ -32,7 +28,8 @@ class ConsentFormMailer < ApplicationMailer
         short_patient_name_apos:,
         team_email: I18n.t("service.email"),
         team_phone: I18n.t("service.temporary_cumbria_phone"),
-        observed_session:
+        observed_session:,
+        vaccination: vaccination(consent_form)
       }
     )
   end
@@ -57,7 +54,8 @@ class ConsentFormMailer < ApplicationMailer
         location_name: consent_form.session.location.name,
         long_date: consent_form.session.date.strftime("%A %-d %B"),
         full_and_preferred_patient_name:,
-        short_patient_name:
+        short_patient_name:,
+        vaccination: vaccination(consent_form)
       }
     )
   end
@@ -83,7 +81,8 @@ class ConsentFormMailer < ApplicationMailer
         reason_for_refusal:
           I18n.t(
             "consent_form_mailer.reasons_for_refusal.#{consent_form.reason}"
-          )
+          ),
+        vaccination: vaccination(consent_form)
       }
     )
   end
@@ -110,8 +109,19 @@ class ConsentFormMailer < ApplicationMailer
         full_and_preferred_patient_name:,
         short_patient_name:,
         team_email: I18n.t("service.email"),
-        team_phone: I18n.t("service.temporary_cumbria_phone")
+        team_phone: I18n.t("service.temporary_cumbria_phone"),
+        vaccination: vaccination(consent_form)
       }
     )
+  end
+
+  private
+
+  def reply_to_id(consent_form:)
+    consent_form.session.campaign.team.reply_to_id
+  end
+
+  def vaccination(consent_form)
+    "#{consent_form.session.campaign.name} vaccination"
   end
 end

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -15,6 +15,8 @@ class ConsentFormMailer < ApplicationMailer
     apos = "'"
     apos += "s" unless short_patient_name.ends_with?("s")
     short_patient_name_apos = short_patient_name + apos
+    observed_session =
+      consent_form.session.location.permission_to_observe_required?
 
     template_mail(
       "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
@@ -29,7 +31,8 @@ class ConsentFormMailer < ApplicationMailer
         short_patient_name:,
         short_patient_name_apos:,
         team_email: I18n.t("service.email"),
-        team_phone: I18n.t("service.temporary_cumbria_phone")
+        team_phone: I18n.t("service.temporary_cumbria_phone"),
+        observed_session:
       }
     )
   end

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -43,7 +43,8 @@ RSpec.describe ConsentFormMailer, type: :mailer do
           short_patient_name_apos: "Severus'",
           team_email:,
           team_phone:,
-          observed_session: false
+          observed_session: false,
+          vaccination: "HPV vaccination"
         },
         to: "harry@hogwarts.edu",
         reply_to_id:
@@ -101,7 +102,8 @@ RSpec.describe ConsentFormMailer, type: :mailer do
           long_date: consent_form.session.date.strftime("%A %-d %B"),
           short_date: consent_form.session.date.strftime("%-d %B"),
           parent_name: "Harry Potter",
-          short_patient_name: "Severus"
+          short_patient_name: "Severus",
+          vaccination: "HPV vaccination"
         },
         to: "harry@hogwarts.edu",
         reply_to_id:
@@ -114,7 +116,10 @@ RSpec.describe ConsentFormMailer, type: :mailer do
 
     it "calls template_mail with correct personalisation" do
       described_class.confirmation_injection(
-        consent_form(reason: :contains_gelatine)
+        consent_form(
+          reason: :contains_gelatine,
+          session: create(:session, campaign: create(:campaign, :flu))
+        )
       ).deliver_now
 
       expect(@template_options).to include(
@@ -124,7 +129,8 @@ RSpec.describe ConsentFormMailer, type: :mailer do
           long_date: consent_form.session.date.strftime("%A %-d %B"),
           short_date: consent_form.session.date.strftime("%-d %B"),
           parent_name: "Harry Potter",
-          reason_for_refusal: "of the gelatine in the nasal spray"
+          reason_for_refusal: "of the gelatine in the nasal spray",
+          vaccination: "Flu vaccination"
         },
         to: "harry@hogwarts.edu",
         reply_to_id:
@@ -147,7 +153,8 @@ RSpec.describe ConsentFormMailer, type: :mailer do
           parent_name: "Harry Potter",
           short_patient_name: "Severus",
           team_email:,
-          team_phone:
+          team_phone:,
+          vaccination: "HPV vaccination"
         },
         to: "harry@hogwarts.edu",
         reply_to_id:

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe ConsentFormMailer, type: :mailer do
           short_patient_name: "Severus",
           short_patient_name_apos: "Severus'",
           team_email:,
-          team_phone:
+          team_phone:,
+          observed_session: false
         },
         to: "harry@hogwarts.edu",
         reply_to_id:
@@ -67,6 +68,22 @@ RSpec.describe ConsentFormMailer, type: :mailer do
       expect(@template_options[:personalisation]).to include(
         short_patient_name: "Harry",
         short_patient_name_apos: "Harry's"
+      )
+    end
+
+    it "calls template_mail correctly when location will be observed" do
+      described_class.confirmation(
+        consent_form(
+          session:
+            create(
+              :session,
+              location: create(:location, permission_to_observe_required: true)
+            )
+        )
+      ).deliver_now
+
+      expect(@template_options[:personalisation]).to include(
+        observed_session: true
       )
     end
   end


### PR DESCRIPTION
- Add the conditional consent boolean for the UR observation content
- Add the "vaccination" personalisation to display "HPV vaccination" or "Flu vaccination" in the title/body