### PR TITLE
Bugfix: hide alternative option when confirming HPV refusal

### DIFF
--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -38,14 +38,16 @@ end %>
           visually_hidden_text: "reason for refusal")
       end
 
-      summary_list.with_row do |row|
-        row.with_key { "Alternative option" }
-        row.with_value { @consent_form.contact_injection? ?
-                          "A nurse can contact me about an injection" :
-                          "No" }
-        row.with_action(text: "Change",
-          href: change_link[:injection],
-          visually_hidden_text: "alternative option")
+      if !@consent_form.contact_injection.nil?
+        summary_list.with_row do |row|
+          row.with_key { "Alternative option" }
+          row.with_value { @consent_form.contact_injection? ?
+                            "A nurse can contact me about an injection" :
+                            "No" }
+          row.with_action(text: "Change",
+            href: change_link[:injection],
+            visually_hidden_text: "alternative option")
+        end
       end
     end
   end %>


### PR DESCRIPTION
"Alternative option" should only display when the parent has been offered an alternative as part of the flu consent process.

## Before – HPV refusal

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/648d9650-16a5-4444-bfd5-f15db9702ba1)

## After – HPV refusal

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/f4015a60-33a1-4c36-8ca4-ed4d2cfe474e)

## After – flu refusal, agree contact about alternative

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/3a75ead3-844a-4771-9551-059553fd460a)

## After – flu refusal, refuse contact alternative

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/31d5d53b-ee13-4d49-91c7-91639740b9f7)
