### PR TITLE
Refactor consent form mailer

### DIFF
--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -1,127 +1,104 @@
 class ConsentFormMailer < ApplicationMailer
   def confirmation(consent_form)
-    if consent_form.common_name.present?
-      short_patient_name = consent_form.common_name
-      full_and_preferred_patient_name =
-        consent_form.full_name + " (known as #{consent_form.common_name})"
-    else
-      short_patient_name = consent_form.first_name
-      full_and_preferred_patient_name = consent_form.full_name
-    end
-    apos = "'"
-    apos += "s" unless short_patient_name.ends_with?("s")
-    short_patient_name_apos = short_patient_name + apos
-    observed_session =
-      consent_form.session.location.permission_to_observe_required?
-
-    template_mail(
-      "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
-      to: consent_form.parent_email,
-      reply_to_id: reply_to_id(consent_form:),
-      personalisation: {
-        short_date: consent_form.session.date.strftime("%-d %B"),
-        parent_name: consent_form.parent_name,
-        location_name: consent_form.session.location.name,
-        long_date: consent_form.session.date.strftime("%A %-d %B"),
-        full_and_preferred_patient_name:,
-        short_patient_name:,
-        short_patient_name_apos:,
-        team_email: I18n.t("service.email"),
-        team_phone: I18n.t("service.temporary_cumbria_phone"),
-        observed_session:,
-        vaccination: vaccination(consent_form)
-      }
-    )
+    template_mail("7cda7ae5-99a2-4c40-9a3e-1863e23f7a73", **opts(consent_form))
   end
 
   def confirmation_needs_triage(consent_form)
-    if consent_form.common_name.present?
-      short_patient_name = consent_form.common_name
-      full_and_preferred_patient_name =
-        consent_form.full_name + " (known as #{consent_form.common_name})"
-    else
-      short_patient_name = consent_form.first_name
-      full_and_preferred_patient_name = consent_form.full_name
-    end
-
-    template_mail(
-      "604ee667-c996-471e-b986-79ab98d0767c",
-      to: consent_form.parent_email,
-      reply_to_id: reply_to_id(consent_form:),
-      personalisation: {
-        short_date: consent_form.session.date.strftime("%-d %B"),
-        parent_name: consent_form.parent_name,
-        location_name: consent_form.session.location.name,
-        long_date: consent_form.session.date.strftime("%A %-d %B"),
-        full_and_preferred_patient_name:,
-        short_patient_name:,
-        vaccination: vaccination(consent_form)
-      }
-    )
+    template_mail("604ee667-c996-471e-b986-79ab98d0767c", **opts(consent_form))
   end
 
   def confirmation_injection(consent_form)
-    full_and_preferred_patient_name =
-      if consent_form.common_name.present?
-        consent_form.full_name + " (known as #{consent_form.common_name})"
-      else
-        consent_form.full_name
-      end
-
-    template_mail(
-      "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
-      to: consent_form.parent_email,
-      reply_to_id: reply_to_id(consent_form:),
-      personalisation: {
-        short_date: consent_form.session.date.strftime("%-d %B"),
-        parent_name: consent_form.parent_name,
-        location_name: consent_form.session.location.name,
-        long_date: consent_form.session.date.strftime("%A %-d %B"),
-        full_and_preferred_patient_name:,
-        reason_for_refusal:
-          I18n.t(
-            "consent_form_mailer.reasons_for_refusal.#{consent_form.reason}"
-          ),
-        vaccination: vaccination(consent_form)
-      }
-    )
+    template_mail("4d09483a-8181-4acb-8ba3-7abd6c8644cd", **opts(consent_form))
   end
 
   def confirmation_refused(consent_form)
-    if consent_form.common_name.present?
-      short_patient_name = consent_form.common_name
-      full_and_preferred_patient_name =
-        consent_form.full_name + " (known as #{consent_form.common_name})"
-    else
-      short_patient_name = consent_form.first_name
-      full_and_preferred_patient_name = consent_form.full_name
-    end
-
-    template_mail(
-      "5a676dac-3385-49e4-98c2-fc6b45b5a851",
-      to: consent_form.parent_email,
-      reply_to_id: reply_to_id(consent_form:),
-      personalisation: {
-        short_date: consent_form.session.date.strftime("%-d %B"),
-        parent_name: consent_form.parent_name,
-        location_name: consent_form.session.location.name,
-        long_date: consent_form.session.date.strftime("%A %-d %B"),
-        full_and_preferred_patient_name:,
-        short_patient_name:,
-        team_email: I18n.t("service.email"),
-        team_phone: I18n.t("service.temporary_cumbria_phone"),
-        vaccination: vaccination(consent_form)
-      }
-    )
+    template_mail("5a676dac-3385-49e4-98c2-fc6b45b5a851", **opts(consent_form))
   end
 
   private
 
-  def reply_to_id(consent_form:)
-    consent_form.session.campaign.team.reply_to_id
+  def opts(consent_form)
+    @consent_form = consent_form
+
+    { to:, reply_to_id:, personalisation: }
   end
 
-  def vaccination(consent_form)
-    "#{consent_form.session.campaign.name} vaccination"
+  def to
+    @consent_form.parent_email
+  end
+
+  def reply_to_id
+    @consent_form.session.campaign.team.reply_to_id
+  end
+
+  def personalisation
+    {
+      full_and_preferred_patient_name:,
+      location_name:,
+      long_date:,
+      observed_session:,
+      parent_name:,
+      reason_for_refusal:,
+      short_date:,
+      short_patient_name:,
+      short_patient_name_apos:,
+      team_email:,
+      team_phone:,
+      vaccination:
+    }
+  end
+
+  def full_and_preferred_patient_name
+    if @consent_form.common_name.present?
+      @consent_form.full_name + " (known as #{@consent_form.common_name})"
+    else
+      @consent_form.full_name
+    end
+  end
+
+  def short_patient_name
+    @consent_form.common_name.presence || @consent_form.first_name
+  end
+
+  def short_patient_name_apos
+    apos = "'"
+    apos += "s" unless short_patient_name.ends_with?("s")
+    short_patient_name + apos
+  end
+
+  def observed_session
+    @consent_form.session.location.permission_to_observe_required?
+  end
+
+  def location_name
+    @consent_form.session.location.name
+  end
+
+  def short_date
+    @consent_form.session.date.strftime("%-d %B")
+  end
+
+  def long_date
+    @consent_form.session.date.strftime("%A %-d %B")
+  end
+
+  def parent_name
+    @consent_form.parent_name
+  end
+
+  def reason_for_refusal
+    I18n.t("consent_form_mailer.reasons_for_refusal.#{@consent_form.reason}")
+  end
+
+  def team_email
+    I18n.t("service.email")
+  end
+
+  def team_phone
+    I18n.t("service.temporary_cumbria_phone")
+  end
+
+  def vaccination
+    "#{@consent_form.session.campaign.name} vaccination"
   end
 end

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -33,21 +33,20 @@ RSpec.describe ConsentFormMailer, type: :mailer do
       described_class.confirmation(consent_form).deliver_now
 
       expect(@template_options).to include(
-        personalisation: {
-          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
-          location_name: consent_form.session.location.name,
-          long_date: consent_form.session.date.strftime("%A %-d %B"),
-          short_date: consent_form.session.date.strftime("%-d %B"),
-          parent_name: "Harry Potter",
-          short_patient_name: "Severus",
-          short_patient_name_apos: "Severus'",
-          team_email:,
-          team_phone:,
-          observed_session: false,
-          vaccination: "HPV vaccination"
-        },
         to: "harry@hogwarts.edu",
         reply_to_id:
+      )
+      expect(@template_options[:personalisation]).to include(
+        full_and_preferred_patient_name: "Albus Potter (known as Severus)",
+        short_patient_name: "Severus",
+        short_patient_name_apos: "Severus'",
+        location_name: consent_form.session.location.name,
+        long_date: consent_form.session.date.strftime("%A %-d %B"),
+        short_date: consent_form.session.date.strftime("%-d %B"),
+        team_email:,
+        team_phone:,
+        observed_session: false,
+        vaccination: "HPV vaccination"
       )
     end
 
@@ -96,15 +95,6 @@ RSpec.describe ConsentFormMailer, type: :mailer do
       described_class.confirmation_needs_triage(consent_form).deliver_now
 
       expect(@template_options).to include(
-        personalisation: {
-          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
-          location_name: consent_form.session.location.name,
-          long_date: consent_form.session.date.strftime("%A %-d %B"),
-          short_date: consent_form.session.date.strftime("%-d %B"),
-          parent_name: "Harry Potter",
-          short_patient_name: "Severus",
-          vaccination: "HPV vaccination"
-        },
         to: "harry@hogwarts.edu",
         reply_to_id:
       )
@@ -122,18 +112,8 @@ RSpec.describe ConsentFormMailer, type: :mailer do
         )
       ).deliver_now
 
-      expect(@template_options).to include(
-        personalisation: {
-          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
-          location_name: consent_form.session.location.name,
-          long_date: consent_form.session.date.strftime("%A %-d %B"),
-          short_date: consent_form.session.date.strftime("%-d %B"),
-          parent_name: "Harry Potter",
-          reason_for_refusal: "of the gelatine in the nasal spray",
-          vaccination: "Flu vaccination"
-        },
-        to: "harry@hogwarts.edu",
-        reply_to_id:
+      expect(@template_options[:personalisation]).to include(
+        reason_for_refusal: "of the gelatine in the nasal spray"
       )
     end
   end
@@ -145,17 +125,6 @@ RSpec.describe ConsentFormMailer, type: :mailer do
       described_class.confirmation_refused(consent_form).deliver_now
 
       expect(@template_options).to include(
-        personalisation: {
-          full_and_preferred_patient_name: "Albus Potter (known as Severus)",
-          location_name: consent_form.session.location.name,
-          long_date: consent_form.session.date.strftime("%A %-d %B"),
-          short_date: consent_form.session.date.strftime("%-d %B"),
-          parent_name: "Harry Potter",
-          short_patient_name: "Severus",
-          team_email:,
-          team_phone:,
-          vaccination: "HPV vaccination"
-        },
         to: "harry@hogwarts.edu",
         reply_to_id:
       )


### PR DESCRIPTION
Notify ignores additional values passed into the personalisation hash. As such, we can always pass in every configuration option and they will get ignored if they are not necessary.

This means we can use a single `personalisation` hash and vastly simplify our mailer code.

In a follow-up PR, we can lift/shift some of these fields (like `short_date`, `team_email` etc) to the ApplicationMailer so they are inherited and reused across all the mailers.