### PR TITLE
Lift common mailer attrs out of ConsentFormMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,2 +1,84 @@
 class ApplicationMailer < Mail::Notify::Mailer
+  private
+
+  def opts(patient_session)
+    @patient = patient_session.patient
+    @session = patient_session.session
+
+    { to:, reply_to_id:, personalisation: }
+  end
+
+  def to
+    @patient.parent_email
+  end
+
+  def reply_to_id
+    @session.campaign.team.reply_to_id
+  end
+
+  def personalisation
+    {
+      full_and_preferred_patient_name:,
+      location_name:,
+      long_date:,
+      observed_session:,
+      parent_name:,
+      short_date:,
+      short_patient_name:,
+      short_patient_name_apos:,
+      team_email:,
+      team_phone:,
+      vaccination:
+    }
+  end
+
+  def full_and_preferred_patient_name
+    if @patient.common_name.present?
+      @patient.full_name + " (known as #{@patient.common_name})"
+    else
+      @patient.full_name
+    end
+  end
+
+  def short_patient_name
+    @patient.common_name.presence || @patient.first_name
+  end
+
+  def short_patient_name_apos
+    apos = "'"
+    apos += "s" unless short_patient_name.ends_with?("s")
+    short_patient_name + apos
+  end
+
+  def parent_name
+    @patient.parent_name
+  end
+
+  def observed_session
+    @session.location.permission_to_observe_required?
+  end
+
+  def location_name
+    @session.location.name
+  end
+
+  def short_date
+    @session.date.strftime("%-d %B")
+  end
+
+  def long_date
+    @session.date.strftime("%A %-d %B")
+  end
+
+  def team_email
+    I18n.t("service.email")
+  end
+
+  def team_phone
+    I18n.t("service.temporary_cumbria_phone")
+  end
+
+  def vaccination
+    "#{@session.campaign.name} vaccination"
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -71,11 +71,11 @@ class ApplicationMailer < Mail::Notify::Mailer
   end
 
   def team_email
-    I18n.t("service.email")
+    @session.campaign.team.email
   end
 
   def team_phone
-    I18n.t("service.temporary_cumbria_phone")
+    @session.campaign.team.phone
   end
 
   def vaccination

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -19,86 +19,17 @@ class ConsentFormMailer < ApplicationMailer
 
   def opts(consent_form)
     @consent_form = consent_form
+    @patient = consent_form
+    @session = consent_form.session
 
-    { to:, reply_to_id:, personalisation: }
+    { to:, reply_to_id:, personalisation: consent_form_personalisation }
   end
 
-  def to
-    @consent_form.parent_email
-  end
-
-  def reply_to_id
-    @consent_form.session.campaign.team.reply_to_id
-  end
-
-  def personalisation
-    {
-      full_and_preferred_patient_name:,
-      location_name:,
-      long_date:,
-      observed_session:,
-      parent_name:,
-      reason_for_refusal:,
-      short_date:,
-      short_patient_name:,
-      short_patient_name_apos:,
-      team_email:,
-      team_phone:,
-      vaccination:
-    }
-  end
-
-  def full_and_preferred_patient_name
-    if @consent_form.common_name.present?
-      @consent_form.full_name + " (known as #{@consent_form.common_name})"
-    else
-      @consent_form.full_name
-    end
-  end
-
-  def short_patient_name
-    @consent_form.common_name.presence || @consent_form.first_name
-  end
-
-  def short_patient_name_apos
-    apos = "'"
-    apos += "s" unless short_patient_name.ends_with?("s")
-    short_patient_name + apos
-  end
-
-  def observed_session
-    @consent_form.session.location.permission_to_observe_required?
-  end
-
-  def location_name
-    @consent_form.session.location.name
-  end
-
-  def short_date
-    @consent_form.session.date.strftime("%-d %B")
-  end
-
-  def long_date
-    @consent_form.session.date.strftime("%A %-d %B")
-  end
-
-  def parent_name
-    @consent_form.parent_name
+  def consent_form_personalisation
+    personalisation.merge reason_for_refusal:
   end
 
   def reason_for_refusal
     I18n.t("consent_form_mailer.reasons_for_refusal.#{@consent_form.reason}")
-  end
-
-  def team_email
-    I18n.t("service.email")
-  end
-
-  def team_phone
-    I18n.t("service.temporary_cumbria_phone")
-  end
-
-  def vaccination
-    "#{@consent_form.session.campaign.name} vaccination"
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,7 +39,6 @@ en:
       title: Children who could not be vaccinated
   service:
     email: england.mavis@nhs.net
-    temporary_cumbria_phone: "01900 705 045"
   wicked:
     # ConsentForm
     name: "name"

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -3,7 +3,14 @@ require "rails_helper"
 RSpec.describe ApplicationMailer, type: :mailer do
   subject { described_class.new }
 
-  let(:team) { create(:team, reply_to_id: "notify-reply-to-id") }
+  let(:team) do
+    create(
+      :team,
+      email: "team@email.com",
+      phone: "01234567890",
+      reply_to_id: "notify-reply-to-id"
+    )
+  end
   let(:location) { create(:location, name: "Hogwarts", team:) }
   let(:campaign) { create(:campaign, :hpv, team:) }
   let(:session) do
@@ -35,8 +42,8 @@ RSpec.describe ApplicationMailer, type: :mailer do
             short_date: "1 January",
             short_patient_name: "John",
             short_patient_name_apos: "John's",
-            team_email: "england.mavis@nhs.net",
-            team_phone: "01900 705 045",
+            team_email: "team@email.com",
+            team_phone: "01234567890",
             vaccination: "HPV vaccination"
           }
         }

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailer, type: :mailer do
+  subject { described_class.new }
+
+  let(:team) { create(:team, reply_to_id: "notify-reply-to-id") }
+  let(:location) { create(:location, name: "Hogwarts", team:) }
+  let(:campaign) { create(:campaign, :hpv, team:) }
+  let(:session) do
+    create(:session, campaign:, location:, date: Date.new(2100, 1, 1))
+  end
+  let(:patient) do
+    create(
+      :patient,
+      first_name: "John",
+      last_name: "Doe",
+      parent_email: "foo@bar.com",
+      parent_name: "Parent Doe"
+    )
+  end
+  let(:patient_session) { create(:patient_session, patient:, session:) }
+
+  describe "#opts" do
+    it "returns correct options" do
+      expect(subject.send(:opts, patient_session)).to eq(
+        {
+          to: "foo@bar.com",
+          reply_to_id: "notify-reply-to-id",
+          personalisation: {
+            full_and_preferred_patient_name: "John Doe",
+            location_name: "Hogwarts",
+            long_date: "Friday 1 January",
+            observed_session: false,
+            parent_name: "Parent Doe",
+            short_date: "1 January",
+            short_patient_name: "John",
+            short_patient_name_apos: "John's",
+            team_email: "england.mavis@nhs.net",
+            team_phone: "01900 705 045",
+            vaccination: "HPV vaccination"
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -1,132 +1,19 @@
 require "rails_helper"
 
 RSpec.describe ConsentFormMailer, type: :mailer do
-  let(:team_email) { "england.mavis@nhs.net" }
-  let(:team_phone) { "01900 705 045" }
-
-  def consent_form(overrides = {})
-    @consent_form ||=
-      build(
-        :consent_form,
-        parent_email: "harry@hogwarts.edu",
-        parent_name: "Harry Potter",
-        first_name: "Albus",
-        last_name: "Potter",
-        common_name: "Severus",
-        **overrides
-      )
-  end
-
-  let(:reply_to_id) { consent_form.session.campaign.team.reply_to_id }
-
-  before do
-    allow_any_instance_of(Mail::Notify::Mailer).to receive(:template_mail).with(
-      notify_template_id,
-      ->(options) { @template_options = options }
-    )
-  end
-
-  describe "#confirmation" do
-    let(:notify_template_id) { "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73" }
-
-    it "calls template_mail with correct personalisation" do
-      described_class.confirmation(consent_form).deliver_now
-
-      expect(@template_options).to include(
-        to: "harry@hogwarts.edu",
-        reply_to_id:
-      )
-      expect(@template_options[:personalisation]).to include(
-        full_and_preferred_patient_name: "Albus Potter (known as Severus)",
-        short_patient_name: "Severus",
-        short_patient_name_apos: "Severus'",
-        location_name: consent_form.session.location.name,
-        long_date: consent_form.session.date.strftime("%A %-d %B"),
-        short_date: consent_form.session.date.strftime("%-d %B"),
-        team_email:,
-        team_phone:,
-        observed_session: false,
-        vaccination: "HPV vaccination"
-      )
-    end
-
-    it "calls template_mail correctly when common_name is nil" do
-      described_class.confirmation(consent_form(common_name: nil)).deliver_now
-
-      expect(@template_options[:personalisation]).to include(
-        full_and_preferred_patient_name: "Albus Potter",
-        short_patient_name: "Albus",
-        short_patient_name_apos: "Albus'"
-      )
-    end
-
-    it "calls template_mail correctly when first_name does not end in an s" do
-      described_class.confirmation(
-        consent_form(common_name: nil, first_name: "Harry")
-      ).deliver_now
-
-      expect(@template_options[:personalisation]).to include(
-        short_patient_name: "Harry",
-        short_patient_name_apos: "Harry's"
-      )
-    end
-
-    it "calls template_mail correctly when location will be observed" do
-      described_class.confirmation(
-        consent_form(
-          session:
-            create(
-              :session,
-              location: create(:location, permission_to_observe_required: true)
-            )
-        )
-      ).deliver_now
-
-      expect(@template_options[:personalisation]).to include(
-        observed_session: true
-      )
-    end
-  end
-
-  describe "#confirmation_needs_triage" do
-    let(:notify_template_id) { "604ee667-c996-471e-b986-79ab98d0767c" }
-
-    it "calls template_mail with correct personalisation" do
-      described_class.confirmation_needs_triage(consent_form).deliver_now
-
-      expect(@template_options).to include(
-        to: "harry@hogwarts.edu",
-        reply_to_id:
-      )
-    end
-  end
-
   describe "#confirmation_injection" do
-    let(:notify_template_id) { "4d09483a-8181-4acb-8ba3-7abd6c8644cd" }
-
     it "calls template_mail with correct personalisation" do
-      described_class.confirmation_injection(
-        consent_form(
-          reason: :contains_gelatine,
-          session: create(:session, campaign: create(:campaign, :flu))
+      mail =
+        described_class.confirmation_injection(
+          build(
+            :consent_form,
+            reason: :contains_gelatine,
+            session: create(:session, campaign: create(:campaign, :flu))
+          )
         )
-      ).deliver_now
 
-      expect(@template_options[:personalisation]).to include(
+      expect(mail.message.header["personalisation"].unparsed_value).to include(
         reason_for_refusal: "of the gelatine in the nasal spray"
-      )
-    end
-  end
-
-  describe "#confirmation_refused" do
-    let(:notify_template_id) { "5a676dac-3385-49e4-98c2-fc6b45b5a851" }
-
-    it "calls template_mail with correct personalisation" do
-      described_class.confirmation_refused(consent_form).deliver_now
-
-      expect(@template_options).to include(
-        to: "harry@hogwarts.edu",
-        reply_to_id:
       )
     end
   end


### PR DESCRIPTION
Follow-up to https://github.com/nhsuk/manage-childrens-vaccinations/pull/1011, same idea, but taken a step further.

These can sit in the ApplicationMailer to help with code reuse across different mailers.