### PR TITLE
Don't encrypt team attributes

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -25,8 +25,6 @@ class Team < ApplicationRecord
   validates :email, presence: true, email: true
   validates :phone, presence: true, phone: true
 
-  encrypts :name, :email, :phone, :privacy_policy_url
-
   MAX_COHORT_SIZE = 100
 
   def campaign


### PR DESCRIPTION
We need to migrate these in a different way, as simply adding the encrypts call breaks in test.