### PR TITLE
Add consent request mailer

### DIFF
--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -10,6 +10,14 @@ class ConsentRequestMailer < ApplicationMailer
 
   private
 
+  def host
+    if Rails.env.development? || Rails.env.test?
+      "http://localhost:4000"
+    else
+      "https://#{Settings.give_or_refuse_consent_host}"
+    end
+  end
+
   def opts(session, patient)
     @session = session
     @patient = patient
@@ -22,6 +30,6 @@ class ConsentRequestMailer < ApplicationMailer
   end
 
   def consent_link
-    start_session_parent_interface_consent_forms_url(@session)
+    host + start_session_parent_interface_consent_forms_path(@session)
   end
 end

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -1,0 +1,27 @@
+class ConsentRequestMailer < ApplicationMailer
+  include Rails.application.routes.url_helpers
+
+  def consent_request(session, patient)
+    template_mail(
+      "6aa04f0d-94c2-4a6b-af97-a7369a12f681",
+      **opts(session, patient)
+    )
+  end
+
+  private
+
+  def opts(session, patient)
+    @session = session
+    @patient = patient
+
+    { to:, reply_to_id:, personalisation: consent_request_personalisation }
+  end
+
+  def consent_request_personalisation
+    personalisation.merge consent_link:
+  end
+
+  def consent_link
+    start_session_parent_interface_consent_forms_url(@session)
+  end
+end

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -58,6 +58,7 @@ environments:
     variables:
       RAILS_ENV: staging
       MAVIS__HOST: "staging.manage-vaccinations-in-schools.nhs.uk"
+      MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "staging.give-or-refuse-consent-for-vaccinations.nhs.uk"
       MAVIS__SUPPORT_USERNAME: manage
       MAVIS__SUPPORT_PASSWORD: vaccinations
   test:
@@ -69,6 +70,7 @@ environments:
     variables:
       RAILS_ENV: staging
       MAVIS__HOST: "test.mavistesting.com"
+      MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "test.mavistesting.com"
       MAVIS__SUPPORT_USERNAME: manage
       MAVIS__SUPPORT_PASSWORD: vaccinations
   training:
@@ -78,6 +80,7 @@ environments:
     variables:
       RAILS_ENV: staging
       MAVIS__HOST: "training.mavistesting.com"
+      MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "training.mavistesting.com"
       MAVIS__SUPPORT_USERNAME: manage
       MAVIS__SUPPORT_PASSWORD: vaccinations
   production:
@@ -91,6 +94,7 @@ environments:
     variables:
       RAILS_ENV: production
       MAVIS__HOST: "www.manage-vaccinations-in-schools.nhs.uk"
+      MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "www.give-or-refuse-consent-for-vaccinations.nhs.uk"
       MAVIS__SUPPORT_USERNAME: manage
       MAVIS__SUPPORT_PASSWORD: vaccinations
       WEB_CONCURRENCY: 2

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe ConsentRequestMailer, type: :mailer do
+  describe "#consent_request" do
+    let(:patient) { create(:patient) }
+    let(:session) { create(:session, patients: [patient]) }
+    subject(:mail) { ConsentRequestMailer.consent_request(session, patient) }
+
+    it { should have_attributes(to: [patient.parent_email]) }
+
+    describe "personalisation" do
+      subject { mail.message.header["personalisation"].unparsed_value }
+
+      it { should include(short_date: session.date.strftime("%-d %B")) }
+      it { should include(long_date: session.date.strftime("%A %-d %B")) }
+      it { should include(location_name: session.location.name) }
+      it { should include(team_email: session.team.email) }
+      it { should include(team_phone: session.team.phone) }
+
+      it "uses the consent url for the session" do
+        should include(
+                 consent_link:
+                   start_session_parent_interface_consent_forms_url(session)
+               )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will be the email sent out by the scheduled job to request that parents submit consent for their children. That code is to come, this email isn't being sent yet.

The template in GOVUK Notify has been updated and set to live.
