### PR TITLE
Ask the parent for refusal reason details on a separate page

### DIFF
--- a/app/controllers/parent_interface/consent_forms/edit_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/edit_controller.rb
@@ -75,7 +75,8 @@ module ParentInterface
         ],
         contact_method: %i[contact_method contact_method_other],
         consent: %i[response],
-        reason: %i[reason reason_notes],
+        reason: %i[reason],
+        reason_notes: %i[reason_notes],
         injection: %i[contact_injection],
         gp: %i[gp_response gp_name],
         address: %i[address_line_1 address_line_2 address_town address_postcode]

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -156,6 +156,10 @@ class ConsentForm < ApplicationRecord
     validates :reason, presence: true
   end
 
+  on_wizard_step :reason_notes do
+    validates :reason_notes, presence: true
+  end
+
   on_wizard_step :injection do
     validates :contact_injection, inclusion: { in: [true, false] }
   end
@@ -192,6 +196,7 @@ class ConsentForm < ApplicationRecord
       (:contact_method if parent_phone.present?),
       :consent,
       (:reason if consent_refused?),
+      (:reason_notes if consent_refused? && reason_notes_must_be_provided?),
       (:injection if injection_offered_as_alternative?),
       (:gp if consent_given?),
       (:address if consent_given?),
@@ -253,6 +258,11 @@ class ConsentForm < ApplicationRecord
     else
       :maybe
     end
+  end
+
+  def reason_notes_must_be_provided?
+    refused_because_other? || refused_because_given_elsewhere? ||
+      refused_because_medical_reasons? || refused_because_already_received?
   end
 
   private

--- a/app/views/parent_interface/consent_forms/edit/reason.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason.html.erb
@@ -5,7 +5,7 @@
   ) %>
 <% end %>
 
-<% title = "Please tell us why you do not agree" %>
+<% title = "Why are you refusing to give consent?" %>
 <% content_for :page_title, title %>
 
 <%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
@@ -31,9 +31,6 @@
     <%= f.govuk_radio_button :reason, "other",
       label: { text: 'Other' } %>
   <% end %>
-
-  <%= f.govuk_text_area :reason_notes,
-    label: { text: 'Give details (optional)' } %>
 
   <div class="nhsuk-u-margin-top-6">
     <%= f.govuk_submit "Continue" %>

--- a/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason_notes.html.erb
@@ -1,0 +1,22 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+      href: backlink_path,
+      name: "previous page"
+  ) %>
+<% end %>
+
+<% title = t("consent_forms.reason_notes.title.#{@consent_form.reason}") %>
+<% content_for :page_title, title %>
+
+<%= h1 title %>
+
+<%= form_for @consent_form, url: wizard_path, method: :put do |f| %>
+  <% content_for(:before_content) { f.govuk_error_summary } %>
+
+  <%= f.govuk_text_area :reason_notes,
+    label: { text: 'Give details' + (@consent_form.reason_notes_must_be_provided? ? '' : ' (optional)') } %>
+
+  <div class="nhsuk-u-margin-top-6">
+    <%= f.govuk_submit "Continue" %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,6 +47,7 @@ en:
     parent: "parent"
     consent: "consent"
     reason: "reason"
+    reason_notes: "reason-notes"
     injection: "injection"
     contact_method: "contact-method"
     gp: "gp"
@@ -137,6 +138,14 @@ en:
       title:
         flu: Your child will not get a nasal flu vaccination at school
         hpv: Your child will not get an HPV vaccination at school
+    reason_notes:
+      title:
+        already_received: Where did your child get their vaccination?
+        given_elsewhere: Where will your child get their vaccination?
+        medical_reasons: What medical reasons prevent your child from being vaccinated?
+        personal_choice: Tell us why you don’t agree
+        contains_gelatine: Tell us why you don’t agree
+        other: Tell us why you don’t agree
   vaccines:
     flu: Flu
     hpv: HPV
@@ -410,6 +419,7 @@ en:
             reason:
               blank: Choose a reason
             reason_notes:
+              blank: Enter details for refusal
               too_long: Enter details for refusal that are less than 1000 characters long
             contact_injection:
               inclusion: Choose if you want to be contacted

--- a/tests/parental_consent_refused.spec.ts
+++ b/tests/parental_consent_refused.spec.ts
@@ -17,6 +17,8 @@ test("Parental consent for HPV vaccination - Consent refused", async ({
 
   await when_i_choose_medical_reasons_as_the_reason();
   await and_i_click_continue();
+  await and_i_provide_a_reason();
+  await and_i_click_continue();
   await then_i_see_the_consent_confirm_page();
 });
 
@@ -72,10 +74,14 @@ async function when_i_refuse_consent() {
 
 async function then_i_see_the_reason_page() {
   await expect(p.locator("h1")).toContainText(
-    "Please tell us why you do not agree",
+    "Why are you refusing to give consent?",
   );
 }
 
 async function when_i_choose_medical_reasons_as_the_reason() {
   await p.click("text=Medical reasons");
+}
+
+async function and_i_provide_a_reason() {
+  await p.getByLabel("Give details").fill("Previous allergic reaction");
 }


### PR DESCRIPTION
The reason is mandatory in the following cases:

* vaccine will be given elsewhere
* vaccine already administered
* medical reasons
* other

For "personal reasons" and "contains gelatine" refusals, the details are optional.

## Why are you refusing consent?

<img width="658" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/5d352ad0-20ad-446f-b90e-3c5acb138fd0">


## Refusal: vaccine already received

<img width="715" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/0ce696bf-a2e2-423a-8842-fece3b525978">

<img width="674" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/e34a0c07-8fbf-4845-b71d-8f1d74531e11">

## Refusal: vaccine will be given elsewhere

<img width="696" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/2c4dc3f4-a046-40e1-869c-ab09282a5b5f">

## Refusal: medical reasons

<img width="674" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/4a46d79e-0f63-4532-9710-54da0ffbfd96">

## Refusal: personal reasons 

<img width="700" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/d4c1f6db-ff87-4461-a59f-067083d50993">

## Refusal: other

<img width="717" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/76d6ce2b-da39-42d0-8195-f60977d99e0d">

## Refusal: other and trying to submit without providing details

<img width="736" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/511e8c1b-a9c1-4841-a1c8-7a054b2859ae">
