### PR TITLE
Move link to unmatched responses page

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -7,6 +7,14 @@ class ConsentsController < ApplicationController
   def index
     methods = %i[consent_given? consent_refused? consent_conflicts? no_consent?]
 
+    @unmatched_record_counts =
+      SessionStats.new(
+        patient_sessions: @patient_sessions,
+        location: @session.location
+      )[
+        :unmatched_responses
+      ]
+
     @tabs =
       @patient_sessions.group_by do |patient_session|
         methods.find { |m| patient_session.send(m) }

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -11,6 +11,18 @@
 
 <%= h1 page_title, page_title: %>
 
+<%= govuk_inset_text(classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4") do %>
+  <p class="nhsuk-body">
+    <%=
+      responses = pluralize(@unmatched_record_counts, 'response')
+      link_to(
+        "#{responses} need matching with records in the cohort",
+        school_path(@session.location)
+      )
+    %>
+  </p>
+<% end %>
+
 <% def consent_tab(slot, state, columns: %i[name dob])
   label = t("states.#{state}.label")
   data = @tabs[state]

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -27,16 +27,8 @@
         <p class="nhsuk-u-margin-bottom-2">
           <%= pluralize(@counts[:with_consent_given], 'child') %> with consent given<br>
           <%= pluralize(@counts[:with_consent_refused], 'child') %> with consent refused<br>
-          <%= pluralize(@counts[:without_a_response], 'child') %> without a response
-        </p>
-        <p>
-          <%=
-          responses = pluralize(@counts[:unmatched_responses], 'response')
-          link_to(
-            "#{responses} need matching with a parent record",
-            school_path(@school)
-          )
-          %>
+          <%= pluralize(@counts[:without_a_response], 'child') %> without a response<br>
+          <%= pluralize(@counts[:unmatched_responses], 'response') %> need matching with records in the cohort
         </p>
 
         <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">

--- a/tests/pilot_journey.spec.ts
+++ b/tests/pilot_journey.spec.ts
@@ -262,7 +262,7 @@ async function then_i_see_the_session_page() {
   await expect(p.getByText("0 children with consent refused")).toBeVisible();
   await expect(p.getByText("4 children without a response")).toBeVisible();
   await expect(
-    p.getByText("0 responses need matching with a parent record"),
+    p.getByText("0 responses need matching with records in the cohort"),
   ).toBeVisible();
   await expect(p.getByText("0 children needing triage")).toBeVisible();
   await expect(p.getByText("0 children ready to vaccinate")).toBeVisible();

--- a/tests/schools_match_response.spec.ts
+++ b/tests/schools_match_response.spec.ts
@@ -10,6 +10,7 @@ test("School - match response", async ({ page }) => {
   await and_i_am_signed_in();
 
   await when_i_go_to_the_session_page();
+  await and_i_click_on_the_check_consent_responses_link();
   await and_i_click_on_the_unmatched_responses_link();
   await then_i_am_on_the_unmatched_responses_page();
 
@@ -31,10 +32,14 @@ async function when_i_go_to_the_session_page() {
   await p.goto("/sessions/1");
 }
 
+async function and_i_click_on_the_check_consent_responses_link() {
+  await p.getByRole("link", { name: "Check consent responses" }).click();
+}
+
 async function and_i_click_on_the_unmatched_responses_link() {
   await p
     .getByRole("link", {
-      name: /responses? need matching with a parent record/,
+      name: /responses? need matching with records in the cohort/,
     })
     .click();
 }


### PR DESCRIPTION
It used to be on the session page, now it's on the 'check consent responses' page

## Sessions page

There is no more link here to the unmatched responses page:

<img width="624" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/571502e1-a7ca-4ae7-a736-647c63b46525">

## Check consent responses

The link is now here:

<img width="794" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/42ae6ac0-aea6-4a43-9891-d2aead4e26b6">
