### PR TITLE
Add job to send consent requests for sessions

### DIFF
--- a/app/jobs/consent_requests_job.rb
+++ b/app/jobs/consent_requests_job.rb
@@ -1,0 +1,14 @@
+# This job triggers a job to send a batch of consent requests for each sessions
+# that needs them sent today.
+
+class ConsentRequestsJob < ApplicationJob
+  queue_as :default
+
+  def perform(*_args)
+    Session.active.each do |session|
+      if session.send_consent_at&.today?
+        ConsentRequestsSessionBatchJob.perform_later(session)
+      end
+    end
+  end
+end

--- a/app/jobs/consent_requests_session_batch_job.rb
+++ b/app/jobs/consent_requests_session_batch_job.rb
@@ -1,0 +1,20 @@
+# This job is sends consent requests for a session.
+#
+# Each patient that hasn't been sent a consent request yet will be sent one.
+# Typically this should happen on the day that the session has set as the date
+# for sending consent requests.
+#
+# It is safe to re-run this job as it marks each patient as having been sent a
+# consent request, however only one of these jobs should be run at a time as
+# once started this job is not concurrency-safe.
+
+class ConsentRequestsSessionBatchJob < ApplicationJob
+  queue_as :default
+
+  def perform(session)
+    session.patients.consent_not_sent.each do |patient|
+      ConsentRequestMailer.consent_request(session, patient).deliver_now
+      patient.update!(sent_consent_at: Time.zone.now)
+    end
+  end
+end

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -17,6 +17,7 @@
 #  parent_phone              :string
 #  parent_relationship       :integer
 #  parent_relationship_other :string
+#  sent_consent_at           :datetime
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  location_id               :bigint

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -46,6 +46,8 @@ class Patient < ApplicationRecord
   has_many :triage, through: :patient_sessions
   has_many :consents
 
+  scope :consent_not_sent, -> { where(sent_consent_at: nil) }
+
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :date_of_birth, presence: true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: "localhost:4000" }
   config.action_mailer.default_options = { from: "no-reply@nhs.net" }
-  config.action_mailer.delivery_method = :file
+  config.action_mailer.delivery_method = :test
 
   # Set up Active Record Encryption in test mode
   config.active_record.encryption.primary_key = "test"

--- a/db/migrate/20240220165801_add_sent_consent_at_to_patients.rb
+++ b/db/migrate/20240220165801_add_sent_consent_at_to_patients.rb
@@ -1,0 +1,5 @@
+class AddSentConsentAtToPatients < ActiveRecord::Migration[7.1]
+  def change
+    add_column :patients, :sent_consent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -275,6 +275,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_21_130747) do
     t.string "address_town"
     t.string "address_postcode"
     t.bigint "registration_id"
+    t.datetime "sent_consent_at"
     t.index ["location_id"], name: "index_patients_on_location_id"
     t.index ["nhs_number"], name: "index_patients_on_nhs_number", unique: true
     t.index ["registration_id"], name: "index_patients_on_registration_id"

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -17,6 +17,7 @@
 #  parent_phone              :string
 #  parent_relationship       :integer
 #  parent_relationship_other :string
+#  sent_consent_at           :datetime
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  location_id               :bigint

--- a/spec/jobs/consent_requests_job_spec.rb
+++ b/spec/jobs/consent_requests_job_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe ConsentRequestsJob, type: :job do
+  before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
+
+  context "with draft and active sessions" do
+    it "enqueues ConsentRequestsSessionBatchJob for each active sessions" do
+      active_session =
+        create(:session, draft: false, send_consent_at: Time.zone.today)
+      _draft_session = create(:session, draft: true)
+
+      described_class.perform_now
+      expect(ConsentRequestsSessionBatchJob).to have_been_enqueued.once
+      expect(ConsentRequestsSessionBatchJob).to have_been_enqueued.with(
+        active_session
+      )
+    end
+  end
+
+  context "with sessions set to send consent today and in the future" do
+    it "enqueues ConsentRequestsSessionBatchJob for the session set to send consent today" do
+      active_session =
+        create(:session, draft: false, send_consent_at: Time.zone.today)
+      _later_session =
+        create(:session, draft: false, send_consent_at: 2.days.from_now)
+
+      described_class.perform_now
+      expect(ConsentRequestsSessionBatchJob).to have_been_enqueued.once
+      expect(ConsentRequestsSessionBatchJob).to have_been_enqueued.with(
+        active_session
+      )
+    end
+  end
+end

--- a/spec/jobs/consent_requests_session_batch_job_spec.rb
+++ b/spec/jobs/consent_requests_session_batch_job_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe ConsentRequestsSessionBatchJob, type: :job do
+  before { ActionMailer::Base.deliveries.clear }
+
+  it "only sends emails to patients parents to whom they have not been sent yet" do
+    patient_with_consent_sent =
+      create(:patient, sent_consent_at: Time.zone.today)
+    patient_not_sent_consent = create(:patient)
+    session =
+      create(
+        :session,
+        patients: [patient_with_consent_sent, patient_not_sent_consent]
+      )
+
+    expect { described_class.perform_now(session) }.to send_email(
+      to: patient_not_sent_consent.parent_email
+    )
+
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+  end
+
+  it "updates the sent_consent_at attribute for patients" do
+    patient = create(:patient, sent_consent_at: nil)
+    session = create(:session, patients: [patient])
+
+    described_class.perform_now(session)
+    expect(patient.reload.sent_consent_at).to be_today
+  end
+end

--- a/spec/models/patient_spec.rb
+++ b/spec/models/patient_spec.rb
@@ -17,6 +17,7 @@
 #  parent_phone              :string
 #  parent_relationship       :integer
 #  parent_relationship_other :string
+#  sent_consent_at           :datetime
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  location_id               :bigint

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,6 +21,8 @@ Capybara.register_driver(:cuprite_custom) do |app|
 end
 Capybara.javascript_driver = :cuprite_custom
 
+ActiveJob::Base.queue_adapter = :test
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec


### PR DESCRIPTION
This is email sent out by the scheduled job to request that parents submit consent for their children. This PR adds a job `ConsentRequestsJob` that can be scheduled to run daily at an appropriate time. It will trigger another job, `ConsentRequestsSessionBatchJob` which will send an email to the parent of each patient in a session that has not yet been sent a consent request.

The cron scheduler hasn't been setup yet, this will be done after we do some more testing of how Good Job's scheduled jobs work.