### PR TITLE
Add consent reminder email

### DIFF
--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -35,10 +35,10 @@ class ConsentRequestMailer < ApplicationMailer
   def consent_request_personalisation
     personalisation.merge(
       consent_link:,
-      session_date: @session.date.to_fs(:app_date),
-      session_short_date: @session.date.to_fs(:app_short_date),
-      close_consent_date: @session.close_consent_at.to_fs(:app_date),
-      close_consent_short_date: @session.close_consent_at.to_fs(:app_short_date)
+      session_date: @session.date.to_fs(:sunday_1_may),
+      session_short_date: @session.date.to_fs(:"1_may"),
+      close_consent_date: @session.close_consent_at.to_fs(:sunday_1_may),
+      close_consent_short_date: @session.close_consent_at.to_fs(:"1_may")
     )
   end
 

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -36,6 +36,7 @@ class ConsentRequestMailer < ApplicationMailer
     personalisation.merge(
       consent_link:,
       session_date: @session.date.to_fs(:app_date),
+      session_short_date: @session.date.to_fs(:app_short_date),
       close_consent_date: @session.close_consent_at.to_fs(:app_date),
       close_consent_short_date: @session.close_consent_at.to_fs(:app_short_date)
     )

--- a/app/mailers/consent_request_mailer.rb
+++ b/app/mailers/consent_request_mailer.rb
@@ -8,6 +8,13 @@ class ConsentRequestMailer < ApplicationMailer
     )
   end
 
+  def consent_reminder(session, patient)
+    template_mail(
+      "ceefd526-d44c-4561-b0d2-c9ef4ccaba4f",
+      **opts(session, patient)
+    )
+  end
+
   private
 
   def host
@@ -26,7 +33,12 @@ class ConsentRequestMailer < ApplicationMailer
   end
 
   def consent_request_personalisation
-    personalisation.merge consent_link:
+    personalisation.merge(
+      consent_link:,
+      session_date: @session.date.to_fs(:app_date),
+      close_consent_date: @session.close_consent_at.to_fs(:app_date),
+      close_consent_short_date: @session.close_consent_at.to_fs(:app_short_date)
+    )
   end
 
   def consent_link

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -2,3 +2,5 @@
 Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y"
 Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A %-d %B %Y"
 Date::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y"
+Date::DATE_FORMATS[:app_date] = "%A %-d %B"
+Date::DATE_FORMATS[:app_short_date] = "%-d %B"

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y"
-Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A %-d %B %Y"
-Date::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y"
-Date::DATE_FORMATS[:app_date] = "%A %-d %B"
-Date::DATE_FORMATS[:app_short_date] = "%-d %B"

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -2,6 +2,8 @@
 Date::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y"
 Date::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y"
 Date::DATE_FORMATS[:nhsuk_date_short_month] = "%-d %b %Y"
+Date::DATE_FORMATS[:sunday_1_may] = "%A %-d %B"
+Date::DATE_FORMATS[:"1_may"] = "%-d %B"
 
 Time::DATE_FORMATS[:nhsuk_date] = "%-d %B %Y"
 Time::DATE_FORMATS[:nhsuk_date_day_of_week] = "%A, %-d %B %Y"

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -25,4 +25,40 @@ RSpec.describe ConsentRequestMailer, type: :mailer do
       end
     end
   end
+
+  describe "#consent_reminder" do
+    let(:patient) { create(:patient) }
+    let(:session) { create(:session, patients: [patient]) }
+    subject(:mail) { ConsentRequestMailer.consent_reminder(session, patient) }
+
+    it { should have_attributes(to: [patient.parent_email]) }
+
+    describe "personalisation" do
+      subject { mail.message.header["personalisation"].unparsed_value }
+
+      it { should include(session_date: session.date.strftime("%A %-d %B")) }
+      it do
+        should include(
+                 close_consent_date:
+                   session.close_consent_at.strftime("%A %-d %B")
+               )
+      end
+      it do
+        should include(
+                 close_consent_short_date:
+                   session.close_consent_at.strftime("%-d %B")
+               )
+      end
+      it { should include(location_name: session.location.name) }
+      it { should include(team_email: session.team.email) }
+      it { should include(team_phone: session.team.phone) }
+
+      it "uses the consent url for the session" do
+        should include(
+                 consent_link:
+                   start_session_parent_interface_consent_forms_url(session)
+               )
+      end
+    end
+  end
 end

--- a/spec/mailers/consent_request_mailer_spec.rb
+++ b/spec/mailers/consent_request_mailer_spec.rb
@@ -11,8 +11,14 @@ RSpec.describe ConsentRequestMailer, type: :mailer do
     describe "personalisation" do
       subject { mail.message.header["personalisation"].unparsed_value }
 
-      it { should include(short_date: session.date.strftime("%-d %B")) }
-      it { should include(long_date: session.date.strftime("%A %-d %B")) }
+      it { should include(session_date: session.date.strftime("%A %-d %B")) }
+      it { should include(session_short_date: session.date.strftime("%-d %B")) }
+      it do
+        should include(
+                 close_consent_date:
+                   session.close_consent_at.strftime("%A %-d %B")
+               )
+      end
       it { should include(location_name: session.location.name) }
       it { should include(team_email: session.team.email) }
       it { should include(team_phone: session.team.phone) }


### PR DESCRIPTION
This will be used to send consent request reminders to patient's parents.

Also includes an update to the initial consent request email to differentiate between the session and close consent dates.

Both templates have been tested.