### PR TITLE
Bring unmatched consent responses page into line with latest designs

### DIFF
--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -1,8 +1,13 @@
 class ConsentFormsController < ApplicationController
   before_action :set_consent_form, only: [:show]
   before_action :set_school, only: [:show]
+  before_action :set_session, only: [:unmatched_responses]
 
   def show
+  end
+
+  def unmatched_responses
+    @unmatched_consent_responses = @session.consent_forms.unmatched.recorded
   end
 
   private
@@ -13,5 +18,12 @@ class ConsentFormsController < ApplicationController
 
   def set_school
     @school = @consent_form.session.location
+  end
+
+  def set_session
+    @session =
+      policy_scope(Session).find(
+        params.fetch(:session_id) { params.fetch(:id) }
+      )
   end
 end

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -7,7 +7,8 @@ class ConsentFormsController < ApplicationController
   end
 
   def unmatched_responses
-    @unmatched_consent_responses = @session.consent_forms.unmatched.recorded
+    @unmatched_consent_responses =
+      @session.consent_forms.unmatched.recorded.order(:recorded_at)
   end
 
   private

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,7 +1,6 @@
 class SchoolsController < ApplicationController
   before_action :set_school,
-                only: %i[show close_registration handle_close_registration]
-  before_action :set_unmatched_consent_responses, only: [:show]
+                only: %i[close_registration handle_close_registration]
 
   layout "two_thirds", only: %i[close_registration]
 

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: school_path(@school),
+    href: unmatched_responses_session_path(@consent_form.session.id),
     name: "school page"
   ) %>
 <% end %>

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -1,22 +1,15 @@
 
-<% page_title = @school.name %>
+<% page_title = "Unmatched consent responses" %>
 
 <% content_for :before_main do %>
   <%= render AppBreadcrumbComponent.new(items: [
-    { text: 'Home', href: dashboard_path },
-    { text: 'Manage schools' },
+    { text: "#{@session.campaign.name} session at #{@session.name}", href: session_path(@session) },
+    { text: "Check consent responses", href: consents_session_path(@session) },
     { text: page_title }
   ]) %>
 <% end %>
 
-<%= h1 page_title: do %>
-  <%= page_title %>
-  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
-    <%= @school.address %>,
-    <%= @school.town %>.
-    <%= @school.postcode %>
-  </span>
-<% end %>
+<%= h1 page_title %>
 
 <%= render AppTabComponent.new(title: "School", classes: "nhsuk-tabs") do |slot|
   unmatched_count = @unmatched_consent_responses.count

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -11,26 +11,31 @@
 
 <%= h1 page_title %>
 
-<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses", heading_size: "m", card_classes: "app-card--empty-list") do
-  govuk_table(classes: "app-table--dense") do |table|
-    table.with_head do |head|
-      head.with_row do |row|
-        row.with_cell(text: "Responded")
-        row.with_cell(text: "Child")
-        row.with_cell(text: "Parent or guardian")
-        row.with_cell(text: "Action")
-      end
-    end
-
-    table.with_body do |body|
-      @unmatched_consent_responses.each do |consent_form|
-        body.with_row do |row|
-          row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date_short_month))
-          row.with_cell(text: consent_form.full_name)
-          row.with_cell(text: consent_form.parent_name)
-          row.with_cell(text: govuk_link_to('Find match', consent_form))
+<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses", heading_size: "m", card_classes: "app-card--empty-list") do %>
+  <action-table sort="date">
+    <%= govuk_table(classes: "app-table--dense  nhsuk-u-margin-0") do |table|
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: "Responded", html_attributes: { "data-col": "date" })
+          row.with_cell(text: "Child", html_attributes: { "data-col": "child" })
+          row.with_cell(text: "Parent or guardian", html_attributes: { "data-col": "parent" })
+          row.with_cell(text: "Action")
         end
       end
-    end
-  end
-end %>
+
+      table.with_body do |body|
+        @unmatched_consent_responses.each do |consent_form|
+          body.with_row do |row|
+            row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date_short_month))
+            row.with_cell(text: consent_form.full_name)
+            row.with_cell(text: consent_form.parent_name)
+            row.with_cell(text: govuk_link_to('Find match', consent_form))
+          end
+        end
+      end
+    end %>
+    <action-table-no-results>
+      <%= render AppEmptyListComponent.new %>
+    </action-table-no-results>
+  </action-table>
+<% end %>

--- a/app/views/consent_forms/unmatched_responses.html.erb
+++ b/app/views/consent_forms/unmatched_responses.html.erb
@@ -11,35 +11,26 @@
 
 <%= h1 page_title %>
 
-<%= render AppTabComponent.new(title: "School", classes: "nhsuk-tabs") do |slot|
-  unmatched_count = @unmatched_consent_responses.count
-
-  slot.with_tab(
-    id: "unmatched-consent-responses",
-    label: "Unmatched consent responses (#{unmatched_count})",
-    classes: "nhsuk-tabs__panel",
-  ) do
-    govuk_table(classes: "app-table--dense") do |table|
-      table.with_head do |head|
-        head.with_row do |row|
-          row.with_cell(text: "Parent or guardian")
-          row.with_cell(text: "Child")
-          row.with_cell(text: "Date of birth")
-          row.with_cell(text: "Response")
-        end
+<%= render AppCardComponent.new(heading: "#{@unmatched_consent_responses.count} unmatched responses", heading_size: "m", card_classes: "app-card--empty-list") do
+  govuk_table(classes: "app-table--dense") do |table|
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Responded")
+        row.with_cell(text: "Child")
+        row.with_cell(text: "Parent or guardian")
+        row.with_cell(text: "Action")
       end
+    end
 
-      table.with_body do |body|
-        @unmatched_consent_responses.each do |consent_form|
-          body.with_row do |row|
-            row.with_cell(text: govuk_link_to(consent_form.parent_name, consent_form))
-            row.with_cell(text: consent_form.full_name)
-            row.with_cell(text: consent_form.date_of_birth&.to_fs(:nhsuk_date_short_month))
-            row.with_cell(text: consent_form.human_enum_name(:response))
-          end
+    table.with_body do |body|
+      @unmatched_consent_responses.each do |consent_form|
+        body.with_row do |row|
+          row.with_cell(text: consent_form.recorded_at&.to_fs(:nhsuk_date_short_month))
+          row.with_cell(text: consent_form.full_name)
+          row.with_cell(text: consent_form.parent_name)
+          row.with_cell(text: govuk_link_to('Find match', consent_form))
         end
       end
     end
   end
-end
-%>
+end %>

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -17,7 +17,7 @@
       responses = pluralize(@unmatched_record_counts, 'response')
       link_to(
         "#{responses} need matching with records in the cohort",
-        school_path(@session.location)
+        unmatched_responses_session_path(@session)
       )
     %>
   </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,10 @@ Rails.application.routes.draw do
 
   resources :sessions, only: %i[create edit index show update] do
     get "consents", to: "consents#index", on: :member
+    get "consents/unmatched-responses",
+        to: "consent_forms#unmatched_responses",
+        on: :member,
+        as: :unmatched_responses
     get "triage", to: "triage#index", on: :member
     get "vaccinations", to: "vaccinations#index", on: :member
 
@@ -113,7 +117,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :schools, only: [:show] do
+  resources :schools, only: [] do
     get "close_registration", on: :member
     post "close_registration",
          to: "schools#handle_close_registration",

--- a/tests/schools_match_response.spec.ts
+++ b/tests/schools_match_response.spec.ts
@@ -51,9 +51,16 @@ async function then_i_am_on_the_unmatched_responses_page() {
 }
 
 async function when_i_click_on_an_unmatched_response() {
-  await p
-    .getByRole("link", { name: fixtures.unmatchedConsentFormParentName })
-    .click();
+  const row = await p
+    .locator(
+      `//td[contains(., '${fixtures.unmatchedConsentFormParentName}')]/parent::tr`,
+    )
+    .first();
+  if (row) {
+    await row.getByRole("link", { name: "Find match" }).click();
+  } else {
+    throw new Error("Could not find unmatched consent response");
+  }
 }
 
 async function then_i_am_on_the_consent_form_page() {

--- a/tests/schools_match_response.spec.ts
+++ b/tests/schools_match_response.spec.ts
@@ -46,7 +46,7 @@ async function and_i_click_on_the_unmatched_responses_link() {
 
 async function then_i_am_on_the_unmatched_responses_page() {
   await expect(
-    p.getByRole("heading", { name: fixtures.schoolName }),
+    p.getByRole("heading", { name: "Unmatched consent responses" }),
   ).toBeVisible();
 }
 


### PR DESCRIPTION
Changes:

* moving the page's path from `/schools/XX` to `/sessions/XX/consents/unmatched-responses` to reflect that it's part of the `Check consent responses` area of the product. "Unmatched consent responses" under schools doesn't feel quite correct, as a school will have multiple sessions (i.e. unmatched responses are session-specific, not school-specific)
* updating breadcrumbs
* updated designs

## Before

<img width="992" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/dec90c79-e606-4cac-a10a-fcda4c9789b6">

## After

<img width="982" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/d95dde16-de2f-4895-9e4d-cd35a7a341ae">
