### PR TITLE
Add TriageMailer and wire up nurse triage journey

### DIFF
--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -1,0 +1,12 @@
+module TriageMailerConcern
+  extend ActiveSupport::Concern
+
+  def send_triage_mail(patient_session)
+    if patient_session.triaged_ready_to_vaccinate?
+      TriageMailer.vaccination_will_happen(patient_session).deliver_later
+    elsif patient_session.triaged_do_not_vaccinate? ||
+          patient_session.delay_vaccination?
+      TriageMailer.vaccination_wont_happen(patient_session).deliver_later
+    end
+  end
+end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -1,4 +1,6 @@
 class TriageController < ApplicationController
+  include TriageMailerConcern
+
   before_action :set_session, only: %i[index create update]
   before_action :set_patient, only: %i[create update]
   before_action :set_patient_session, only: %i[create update]
@@ -43,6 +45,7 @@ class TriageController < ApplicationController
     @triage.assign_attributes triage_params.merge(user: current_user)
     if @triage.save(context: :consent)
       @patient_session.do_triage!
+      send_triage_mail(@patient_session)
       redirect_to triage_session_path(@session),
                   flash: {
                     success: {
@@ -64,6 +67,7 @@ class TriageController < ApplicationController
     @triage.assign_attributes triage_params
     if @triage.save(context: :consent)
       @patient_session.do_triage!
+      send_triage_mail(@patient_session)
       redirect_to triage_session_path(@session),
                   flash: {
                     success: {

--- a/app/mailers/triage_mailer.rb
+++ b/app/mailers/triage_mailer.rb
@@ -1,0 +1,15 @@
+class TriageMailer < ApplicationMailer
+  def vaccination_will_happen(patient_session)
+    template_mail(
+      "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
+      **opts(patient_session)
+    )
+  end
+
+  def vaccination_wont_happen(patient_session)
+    template_mail(
+      "d1faf47e-ccc3-4481-975b-1ec34211a21f",
+      **opts(patient_session)
+    )
+  end
+end


### PR DESCRIPTION
This sends parents emails to let them know whether the vaccination will or will not happen after patients go through nurse triage.

TODO:

- [ ] Tests
- [ ] 🐛 Fix tabs in Triage section to display all triaged records correctly (currently some are being hidden after triage)