### PR TITLE
Send consent requests after creating session if sending today

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,6 +8,9 @@ class SessionsController < ApplicationController
     campaign = current_user.team.campaigns.first
 
     @session = Session.create!(draft: true, campaign:)
+    if @session.send_consent_at.today?
+      ConsentRequestsSessionBatchJob.perform_later(session)
+    end
 
     redirect_to session_edit_path(@session, :location)
   end


### PR DESCRIPTION
If the send_consent_at is set to today, we should send the consent requests immediately after the session is created.