### PR TITLE
Enable good job async processing on AWS Copilot envs

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -59,5 +59,6 @@ module ManageVaccinations
     config.time_zone = "London"
 
     config.active_job.queue_adapter = :good_job
+    config.good_job.execution_mode = :async
   end
 end


### PR DESCRIPTION
We have this set up on Heroku, but we forgot to add the environment variable to our Copilot environments.

This runs the GoodJob worker in the same process as the main Rails process.