### PR TITLE
Increase db connection pool

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -62,6 +62,7 @@ test:
 staging:
   <<: *default
   database: manage_vaccinations_staging
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5).to_i + ENV.fetch("GOOD_JOB_MAX_THREADS", 4).to_i %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -86,5 +87,6 @@ staging:
 production:
   <<: *default
   database: manage_vaccinations_production
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5).to_i + ENV.fetch("GOOD_JOB_MAX_THREADS", 4).to_i %>
   username: manage_vaccinations
   password: <%= ENV["MANAGE_VACCINATIONS_DATABASE_PASSWORD"] %>


### PR DESCRIPTION
In envs where we run GoodJob async, we need to ensure we have enough connections to the db available, as recommended by the GoodJob docs.