### PR TITLE
Bugfix to unmatched responses calculations

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -8,10 +8,7 @@ class ConsentsController < ApplicationController
     methods = %i[consent_given? consent_refused? consent_conflicts? no_consent?]
 
     @unmatched_record_counts =
-      SessionStats.new(
-        patient_sessions: @patient_sessions,
-        location: @session.location
-      )[
+      SessionStats.new(patient_sessions: @patient_sessions, session: @session)[
         :unmatched_responses
       ]
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,10 +21,7 @@ class SessionsController < ApplicationController
       @session.patient_sessions.strict_loading.includes(:campaign, :consents)
 
     @counts =
-      SessionStats.new(
-        patient_sessions: @patient_sessions,
-        location: @session.location
-      )
+      SessionStats.new(patient_sessions: @patient_sessions, session: @session)
   end
 
   def edit

--- a/app/models/session_stats.rb
+++ b/app/models/session_stats.rb
@@ -1,7 +1,7 @@
 class SessionStats
-  def initialize(patient_sessions:, location:)
+  def initialize(patient_sessions:, session:)
     @patient_sessions = patient_sessions
-    @location = location
+    @session = session
 
     @stats = calculate_stats
   end
@@ -23,7 +23,7 @@ class SessionStats
       without_a_response: 0,
       needing_triage: 0,
       ready_to_vaccinate: 0,
-      unmatched_responses: @location.consent_forms.unmatched.recorded.count
+      unmatched_responses: @session.consent_forms.unmatched.recorded.count
     }
 
     @patient_sessions.each do |s|

--- a/spec/models/session_stats_spec.rb
+++ b/spec/models/session_stats_spec.rb
@@ -5,10 +5,7 @@ RSpec.describe SessionStats do
     let(:session) { create :session }
 
     subject do
-      described_class.new(
-        patient_sessions: session.patient_sessions,
-        location: session.location
-      )
+      described_class.new(patient_sessions: session.patient_sessions, session:)
     end
 
     it "returns a hash of session stats" do


### PR DESCRIPTION
Before the fix, the stats were being calculated off the *location*, which may have multiple sessions.

Afeter this fix, the stats calculate only the unmatched responses for the specific *session*.