### PR TITLE
Default all envs to 2GB RAM

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -23,7 +23,7 @@ image:
 
 platform: linux/x86_64
 cpu: 256 # Number of CPU units for the task.
-memory: 1024 # Amount of memory in MiB used by the task.
+memory: 2048 # Amount of memory in MiB used by the task.
 count: 1 # Number of tasks that should be running in your service.
 exec: true # Enable running commands in your container.
 network:
@@ -85,7 +85,6 @@ environments:
       MAVIS__SUPPORT_PASSWORD: vaccinations
   production:
     cpu: 1024
-    memory: 2048
     count: 2
     http:
       alias:


### PR DESCRIPTION
While production needs more RAM because it'll have greater workload, in other envs we are more likely to run a console and do other activity that'll require more RAM.