### PR TITLE
Match consent and consent_form reason_for_refusals

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -52,7 +52,7 @@ class Consent < ApplicationRecord
          contains_gelatine
          already_vaccinated
          will_be_vaccinated_elsewhere
-         medical
+         medical_reasons
          personal_choice
          other
        ],

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -64,7 +64,7 @@ class ConsentForm < ApplicationRecord
        %w[
          contains_gelatine
          already_received
-         given_elsewhere
+         will_be_vaccinated_elsewhere
          medical_reasons
          personal_choice
          other
@@ -261,14 +261,14 @@ class ConsentForm < ApplicationRecord
   end
 
   def reason_notes_must_be_provided?
-    refused_because_other? || refused_because_given_elsewhere? ||
+    refused_because_other? || refused_because_will_be_vaccinated_elsewhere? ||
       refused_because_medical_reasons? || refused_because_already_received?
   end
 
   private
 
   def refused_and_not_had_it_already?
-    consent_refused? && !refused_because_given_elsewhere? &&
+    consent_refused? && !refused_because_will_be_vaccinated_elsewhere? &&
       !refused_because_already_received?
   end
 

--- a/app/views/parent_interface/consent_forms/edit/reason.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/reason.html.erb
@@ -21,7 +21,7 @@
     <% end %>
     <%= f.govuk_radio_button :reason, "already_received",
       label: { text: 'Vaccine already received' } %>
-    <%= f.govuk_radio_button :reason, "given_elsewhere",
+    <%= f.govuk_radio_button :reason, "will_be_vaccinated_elsewhere",
       label: { text: 'Vaccine will be given elsewhere' } %>
     <%= f.govuk_radio_button :reason, "medical_reasons",
       label: { text: 'Medical reasons' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,7 +83,7 @@ en:
     reasons_for_refusal:
       contains_gelatine: "of the gelatine in the nasal spray"
       already_received: "they have already received the vaccine"
-      given_elsewhere: "they will be given the vaccine elsewhere"
+      will_be_vaccinated_elsewhere: "they will be given the vaccine elsewhere"
       medical_reasons: "of medical reasons"
       personal_choice: "of personal choice"
       other: "of other reasons"
@@ -152,7 +152,7 @@ en:
     reason_notes:
       title:
         already_received: Where did your child get their vaccination?
-        given_elsewhere: Where will your child get their vaccination?
+        will_be_vaccinated_elsewhere: Where will your child get their vaccination?
         medical_reasons: What medical reasons prevent your child from being vaccinated?
         personal_choice: Tell us why you don’t agree
         contains_gelatine: Tell us why you don’t agree
@@ -289,7 +289,7 @@ en:
         reasons:
           contains_gelatine: "Vaccine contains gelatine from pigs"
           already_received: "Vaccine already received"
-          given_elsewhere: "Vaccine will be given elsewhere"
+          will_be_vaccinated_elsewhere: "Vaccine will be given elsewhere"
           medical_reasons: "Medical reasons"
           personal_choice: "Personal choice"
           other: "Other"

--- a/db/sample_data/example-flu-campaign.json
+++ b/db/sample_data/example-flu-campaign.json
@@ -351,7 +351,7 @@
           "consents": [
             {
               "response": "refused",
-              "reasonForRefusal": "medical",
+              "reasonForRefusal": "medical_reasons",
               "parentName": "Lenny Kilback",
               "parentRelationship": "father",
               "parentRelationshipOther": null,

--- a/lib/example_campaign_generator.rb
+++ b/lib/example_campaign_generator.rb
@@ -773,7 +773,7 @@ class ExampleCampaignGenerator
     %i[
       already_vaccinated
       will_be_vaccinated_elsewhere
-      medical
+      medical_reasons
       personal_choice
     ].sample(random:)
   end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -400,7 +400,7 @@ RSpec.describe ConsentForm, type: :model do
     it "asks for details when patient refuses for a few different reasons" do
       %w[
         medical_reasons
-        given_elsewhere
+        will_be_vaccinated_elsewhere
         other
         already_received
       ].each do |reason|


### PR DESCRIPTION
Make them consistent so creating consents from consent_forms works OOTB.