### PR TITLE
Fix model office snags

### DIFF
--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -49,8 +49,8 @@
 end %>
 
 <%= render AppTabComponent.new title: "Consents", classes: 'nhsuk-tabs' do |slot|
+  consent_tab(slot, :no_consent?)
   consent_tab(slot, :consent_given?)
   consent_tab(slot, :consent_refused?, columns: %i[name dob reason])
   consent_tab(slot, :consent_conflicts?)
-  consent_tab(slot, :no_consent?)
 end %>

--- a/app/views/edit_sessions/confirm.html.erb
+++ b/app/views/edit_sessions/confirm.html.erb
@@ -13,8 +13,7 @@
 
 <% if @session.send_consent_at.today? %>
   <%= govuk_inset_text do %>
-    After clicking confirm, consent request emails will be sent today at
-    <%= Time.zone.now.strftime("%H:%M") %>.
+    After clicking confirm, consent request emails will be sent immediately.
   <% end %>
 <% end %>
 

--- a/tests/consent.spec.ts
+++ b/tests/consent.spec.ts
@@ -31,6 +31,7 @@ async function then_i_see_the_consents_page() {
 }
 
 async function when_i_click_on_a_patient() {
+  await p.getByRole("tab", { name: "Given" }).click();
   await p.getByRole("link", { name: fixtures.patientThatNeedsTriage }).click();
 }
 

--- a/tests/full_journey.spec.ts
+++ b/tests/full_journey.spec.ts
@@ -78,6 +78,7 @@ async function then_i_see_that_the_child_has_gotten_consent() {
   await expect(p.locator(".nhsuk-notification-banner__content")).toContainText(
     `Record saved for ${fixtures.patientThatNeedsConsent}`,
   );
+  await p.getByRole("tab", { name: "Given" }).click();
   const row = p.locator(`tr`, { hasText: fixtures.patientThatNeedsConsent });
   await expect(row).toBeVisible();
 }

--- a/tests/nurse_consent_conflicting_consent.spec.ts
+++ b/tests/nurse_consent_conflicting_consent.spec.ts
@@ -81,6 +81,7 @@ async function then_i_see_the_success_banner() {
 }
 
 async function when_i_select_the_same_patient() {
+  await p.getByRole("tab", { name: "Given" }).click();
   await p
     .getByRole("link", { name: fixtures.patientWithConflictingConsent })
     .click();

--- a/tests/schools_match_response.spec.ts
+++ b/tests/schools_match_response.spec.ts
@@ -46,6 +46,7 @@ async function and_i_click_on_the_check_consent_responses_link() {
 }
 
 async function and_a_specific_cohort_record_is_not_present() {
+  await p.getByRole("tab", { name: "Given" }).click();
   await expect(
     p
       .locator(
@@ -127,6 +128,7 @@ async function and_i_link_the_response_with_the_record() {
 }
 
 async function and_the_matched_cohort_appears_in_the_consent_given_list() {
+  await p.getByRole("tab", { name: "Given" }).click();
   await expect(
     p
       .locator(


### PR DESCRIPTION
See commits.

### Make "No consent" tab first in tab order

<img width="1287" alt="Screenshot 2024-02-23 at 10 04 33" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/6e2f8e14-dca6-4a47-a118-b7ad8ef415bf">

### Update "After clicking confirm" confirmation text

<img width="998" alt="Screenshot 2024-02-23 at 10 05 02" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/ef0549bb-568b-490f-b5a3-7dd6e465be43">
