### PR TITLE
Protect good-job dashboard with basic auth

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,0 +1,23 @@
+# Prompt for a username if either the support user is defined, or we are in
+# production. In production, if no support user is defined then no access is
+# available.
+
+support_user_defined =
+  Settings.support_username.present? && Settings.support_password.present?
+
+if Rails.env.production? || support_user_defined
+  GoodJob::Engine
+    .middleware
+    .use(Rack::Auth::Basic) do |username, password|
+      if support_user_defined
+        ActiveSupport::SecurityUtils.secure_compare(
+          Settings.support_username,
+          username
+        ) &&
+          ActiveSupport::SecurityUtils.secure_compare(
+            Settings.support_password,
+            password
+          )
+      end
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,9 @@ Rails.application.routes.draw do
 
   root to: redirect("/start")
 
+  mount GoodJob::Engine => "/good-job"
   constraints -> { !Rails.env.production? } do
     mount Avo::Engine, at: Avo.configuration.root_path
-    mount GoodJob::Engine => "/good-job"
     mount Flipper::UI.app => "/flipper"
   end
 


### PR DESCRIPTION
This job will send out consent request emails to parents on the configured day for each session.