### PR TITLE
Use pundit policies in all necessary controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,9 @@ class ApplicationController < ActionController::Base
   before_action :set_phase_banner_text
   before_action :authenticate_basic
 
+  after_action :verify_policy_scoped,
+               if: -> { Rails.env.development? || Rails.env.test? }
+
   class UnprocessableEntity < StandardError
   end
 

--- a/app/controllers/cohort_lists_controller.rb
+++ b/app/controllers/cohort_lists_controller.rb
@@ -1,6 +1,8 @@
 class CohortListsController < ApplicationController
   layout "two_thirds"
 
+  skip_after_action :verify_policy_scoped, only: %i[new create success]
+
   before_action :set_team, only: %i[new create]
 
   def new

--- a/app/controllers/consent_forms_controller.rb
+++ b/app/controllers/consent_forms_controller.rb
@@ -1,4 +1,6 @@
 class ConsentFormsController < ApplicationController
+  skip_after_action :verify_policy_scoped
+
   def unmatched_responses
     @session =
       policy_scope(Session).find(

--- a/app/controllers/csrf_controller.rb
+++ b/app/controllers/csrf_controller.rb
@@ -1,5 +1,6 @@
 class CSRFController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_after_action :verify_policy_scoped
 
   def new
     render json: { token: form_authenticity_token }

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,6 @@
 class DashboardController < ApplicationController
+  skip_after_action :verify_policy_scoped, only: :index
+
   layout "two_thirds"
 
   def index

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -2,6 +2,8 @@ require "rake"
 
 class DevController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_after_action :verify_policy_scoped
+
   before_action :ensure_dev_env
 
   def reset

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,7 @@
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
   skip_before_action :authenticate_user!
+  skip_after_action :verify_policy_scoped
 
   layout "two_thirds"
 

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -128,7 +128,7 @@ class ManageConsentsController < ApplicationController
   end
 
   def set_session
-    @session = Session.find(params.fetch(:session_id))
+    @session = policy_scope(Session).find(params.fetch(:session_id))
   end
 
   def set_patient
@@ -136,7 +136,7 @@ class ManageConsentsController < ApplicationController
   end
 
   def set_consent
-    @consent = Consent.find(params[:consent_id])
+    @consent = policy_scope(Consent).find(params[:consent_id])
   end
 
   def set_patient_session

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,6 @@
 class PagesController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_after_action :verify_policy_scoped, only: :start
 
   def start
   end

--- a/app/controllers/parent_interface/consent_forms/base_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/base_controller.rb
@@ -1,6 +1,8 @@
 module ParentInterface
   class ConsentForms::BaseController < ApplicationController
     skip_before_action :authenticate_user!
+    skip_after_action :verify_policy_scoped
+
     before_action :set_session
     before_action :set_consent_form
     before_action :authenticate_consent_form_user!

--- a/app/controllers/pilot_controller.rb
+++ b/app/controllers/pilot_controller.rb
@@ -8,11 +8,11 @@ class PilotController < ApplicationController
   end
 
   def registrations
-    @schools = current_user.team.locations.includes(:registrations)
+    @schools = policy_scope(Location).includes(:registrations)
   end
 
   def download
-    registrations = Registration.where(location: current_user.team.locations)
+    registrations = policy_scope(Registration)
     csv = CohortList.from_registrations(registrations).to_csv
     send_data(csv, filename: "registered_parents.csv")
   end

--- a/app/controllers/pilot_controller.rb
+++ b/app/controllers/pilot_controller.rb
@@ -1,4 +1,6 @@
 class PilotController < ApplicationController
+  skip_after_action :verify_policy_scoped, only: %i[manage manual]
+
   layout "two_thirds", except: %i[registrations]
 
   def manage

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,5 +1,7 @@
 class RegistrationsController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_after_action :verify_policy_scoped, only: %i[new create confirmation]
+
   before_action :set_school
 
   layout "registration"

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -23,7 +23,7 @@ class SchoolsController < ApplicationController
 
   def set_school
     # The only kind of locations we have currently are schools.
-    @school = Location.find(params[:id])
+    @school = policy_scope(Location).find(params[:id])
   end
 
   def set_unmatched_consent_responses

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,6 +5,8 @@ class SessionsController < ApplicationController
   layout "two_thirds", except: %i[index show]
 
   def create
+    skip_policy_scope
+
     campaign = current_user.team.campaigns.first
 
     @session = Session.create!(draft: true, campaign:)

--- a/app/controllers/testing_controller.rb
+++ b/app/controllers/testing_controller.rb
@@ -2,11 +2,12 @@ require "faker"
 
 class TestingController < ApplicationController
   skip_before_action :authenticate_user!
+  skip_before_action :verify_authenticity_token
+  skip_after_action :verify_policy_scoped
+
   before_action :ensure_dev_or_test_env
 
   layout "two_thirds"
-
-  skip_before_action :verify_authenticity_token
 
   def show_campaign
     @campaign = Campaign.find(params[:id])

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  skip_after_action :verify_policy_scoped
+
   layout "two_thirds"
 end

--- a/app/controllers/vaccinations/batches_controller.rb
+++ b/app/controllers/vaccinations/batches_controller.rb
@@ -34,7 +34,10 @@ class Vaccinations::BatchesController < ApplicationController
   end
 
   def set_patient
-    @patient = Patient.find(params.fetch(:patient_id) { params.fetch(:id) })
+    @patient =
+      policy_scope(Patient).find(
+        params.fetch(:patient_id) { params.fetch(:id) }
+      )
   end
 
   def set_patient_session
@@ -42,7 +45,10 @@ class Vaccinations::BatchesController < ApplicationController
   end
 
   def set_session
-    @session = Session.find(params.fetch(:session_id) { params.fetch(:id) })
+    @session =
+      policy_scope(Session).find(
+        params.fetch(:session_id) { params.fetch(:id) }
+      )
   end
 
   def update_default_batch_for_today

--- a/app/controllers/vaccinations/delivery_site_controller.rb
+++ b/app/controllers/vaccinations/delivery_site_controller.rb
@@ -44,7 +44,10 @@ class Vaccinations::DeliverySiteController < ApplicationController
   end
 
   def set_patient
-    @patient = Patient.find(params.fetch(:patient_id) { params.fetch(:id) })
+    @patient =
+      policy_scope(Patient).find(
+        params.fetch(:patient_id) { params.fetch(:id) }
+      )
   end
 
   def set_patient_session
@@ -52,7 +55,10 @@ class Vaccinations::DeliverySiteController < ApplicationController
   end
 
   def set_session
-    @session = Session.find(params.fetch(:session_id) { params.fetch(:id) })
+    @session =
+      policy_scope(Session).find(
+        params.fetch(:session_id) { params.fetch(:id) }
+      )
   end
 
   def vaccination_record_delivery_params

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -208,7 +208,10 @@ class VaccinationsController < ApplicationController
   end
 
   def set_patient
-    @patient = Patient.find(params.fetch(:patient_id) { params.fetch(:id) })
+    @patient =
+      policy_scope(Patient).find(
+        params.fetch(:patient_id) { params.fetch(:id) }
+      )
   end
 
   def set_patient_sessions

--- a/app/policies/consent_policy.rb
+++ b/app/policies/consent_policy.rb
@@ -1,0 +1,12 @@
+class ConsentPolicy
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      @scope.joins(:campaign).where(campaign: { team_id: @user.teams.ids })
+    end
+  end
+end

--- a/app/policies/registration_policy.rb
+++ b/app/policies/registration_policy.rb
@@ -1,0 +1,12 @@
+class RegistrationPolicy
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      @scope.includes(:location).where(location: @user.team.locations)
+    end
+  end
+end

--- a/lib/load_example_campaign.rb
+++ b/lib/load_example_campaign.rb
@@ -48,16 +48,16 @@ module LoadExampleCampaign
         create_consent_forms(consent_forms:, session:)
       end
 
+      schools_with_no_session =
+        example.schools_with_no_session.map do |school_attributes|
+          create_school(team:, school_attributes:)
+        end
+
       create_children(
         patient_attributes: example.patients_with_no_session,
         campaign: nil,
         session: nil
       )
-
-      schools_with_no_session =
-        example.schools_with_no_session.map do |school_attributes|
-          create_school(team:, school_attributes:)
-        end
 
       location = team.locations.first || schools_with_no_session.first
       example.registrations.each do |registration_attributes|
@@ -173,11 +173,17 @@ module LoadExampleCampaign
       triage_attributes = attributes.delete(:triage)
       consents_attributes = attributes.delete(:consents)
       location_name = attributes.delete(:location)
+      location =
+        if location_name.blank?
+          session&.location
+        else
+          Location.find_by(name: location_name)
+        end
 
       patient =
         Patient.find_or_initialize_by(nhs_number: attributes[:nhs_number])
       patient.update!(attributes)
-      patient.location = Location.find_by(name: location_name)
+      patient.location = location
       patient.save!
 
       next if session.blank?

--- a/tests/pilot_upload_cohort.spec.ts
+++ b/tests/pilot_upload_cohort.spec.ts
@@ -71,7 +71,7 @@ async function then_i_should_see_the_upload_cohort_page() {
     p.getByRole("heading", { name: "Upload the cohort list" }),
   ).toBeVisible();
   await expect(p.locator(".nhsuk-inset-text")).toContainText(
-    "Your current cohort has 5 children",
+    "Your current cohort has 21 children",
   );
 }
 


### PR DESCRIPTION
This is a security measure to ensure we always scope the DB requests appropriately to the current user.

We also fix the data as many patients were being created without a link to location.