### PR TITLE
Fix back links on mobile in Mavis

### DIFF
--- a/app/components/app_breadcrumb_component.html.erb
+++ b/app/components/app_breadcrumb_component.html.erb
@@ -11,9 +11,9 @@
     </ol>
     <p class="nhsuk-breadcrumb__back">
       <a class="nhsuk-breadcrumb__backlink"
-         href="<%= @items.last[:href] %>">
+         href="<%= linkable_items.last[:href] %>">
         <span class="nhsuk-u-visually-hidden">Back to &nbsp;</span>
-        <%= @items.last[:text] %>
+        <%= linkable_items.last[:text] %>
       </a>
     </p>
   </div>

--- a/app/components/app_breadcrumb_component.rb
+++ b/app/components/app_breadcrumb_component.rb
@@ -6,4 +6,8 @@ class AppBreadcrumbComponent < ViewComponent::Base
     @classes = classes
     @attributes = attributes
   end
+
+  def linkable_items
+    @items.select { |item| item[:href] }
+  end
 end

--- a/spec/components/app_breadcrumb_component_spec.rb
+++ b/spec/components/app_breadcrumb_component_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe AppBreadcrumbComponent, type: :component do
+  before { render_inline(component) }
+
+  subject { page }
+
+  let(:component) { described_class.new(items:, classes:, attributes:) }
+
+  # in the app, we set the current page as plain text and the previous page as a link
+  let(:items) do
+    [
+      { href: "/previous-page", text: "Previous page" },
+      { text: "Current page" }
+    ]
+  end
+  let(:classes) { "additional-class" }
+  let(:attributes) { { id: "breadcrumb" } }
+
+  it { should have_link("Previous page", href: "/previous-page") }
+  it { should have_text("Current page") }
+  it { should have_css("nav.additional-class") }
+end

--- a/spec/components/app_breadcrumb_component_spec.rb
+++ b/spec/components/app_breadcrumb_component_spec.rb
@@ -20,4 +20,12 @@ RSpec.describe AppBreadcrumbComponent, type: :component do
   it { should have_link("Previous page", href: "/previous-page") }
   it { should have_text("Current page") }
   it { should have_css("nav.additional-class") }
+
+  it "renders a back link on narrow viewports" do
+    expect(page).to have_link(
+      "Previous page",
+      href: "/previous-page",
+      class: "nhsuk-breadcrumb__backlink"
+    )
+  end
 end


### PR DESCRIPTION
On narrow viewports, back links were linking to the last element, which was the title of the current page.
It should be linking to the last actual link in the breadcrumb.

## Before

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/e2aa0d67-798e-46b7-abeb-d647bac0420d)

## After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/de2e6cb3-2666-4b5c-a6e1-72e906fda25d)
