### PR TITLE
Only set run name on workflow_dispatch events

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,5 @@
 name: Deploy
-run-name: Deploy to ${{ inputs.environment }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && format('Deploy to {0}', inputs.environment) || null }}
 
 on:
   push:


### PR DESCRIPTION
This is an attempt to fix the run name being set to "Deploy to " for the deploy GitHub actions. After some testing `null` appears to restore the default behaviour, so we use that if we've been triggered by anything other than a `workflow_dispatch` event.

The use of a `null` value has been tested, but the real test will be when this gets deployed on PR merge.