### PR TITLE
Add jobs to send consent reminders

### DIFF
--- a/app/jobs/consent_reminders_job.rb
+++ b/app/jobs/consent_reminders_job.rb
@@ -1,0 +1,14 @@
+# This job triggers a job to send a batch of consent reminders for each sessions
+# that needs them sent today.
+
+class ConsentRemindersJob < ApplicationJob
+  queue_as :default
+
+  def perform(*_args)
+    Session.active.each do |session|
+      if session.send_reminders_at&.today?
+        ConsentRemindersSessionBatchJob.perform_later(session)
+      end
+    end
+  end
+end

--- a/app/jobs/consent_reminders_session_batch_job.rb
+++ b/app/jobs/consent_reminders_session_batch_job.rb
@@ -1,0 +1,20 @@
+# This job sends consent reminders for a session.
+#
+# Each patient that hasn't been sent a consent reminder yet will be sent one.
+# Typically this should happen on the day that the session has set as the date
+# for sending consent reminders.
+#
+# It is safe to re-run this job as it marks each patient as having been sent a
+# consent reminder, however only one of these jobs should be run at a time as
+# once started this job is not concurrency-safe.
+
+class ConsentRemindersSessionBatchJob < ApplicationJob
+  queue_as :default
+
+  def perform(session)
+    session.patients.consent_not_sent.each do |patient|
+      ConsentRequestMailer.consent_reminder(session, patient).deliver_now
+      patient.update!(sent_consent_at: Time.zone.now)
+    end
+  end
+end

--- a/app/jobs/consent_requests_session_batch_job.rb
+++ b/app/jobs/consent_requests_session_batch_job.rb
@@ -1,4 +1,4 @@
-# This job is sends consent requests for a session.
+# This job sends consent requests for a session.
 #
 # Each patient that hasn't been sent a consent request yet will be sent one.
 # Typically this should happen on the day that the session has set as the date

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -124,6 +124,11 @@ Rails.application.configure do
       cron: "every day at 9am",
       class: "ConsentRequestsJob",
       description: "Send consent request emails to parents for each session"
+    },
+    consent_reminder: {
+      cron: "every day at 9am",
+      class: "ConsentRemindersJob",
+      description: "Send consent reminder emails to parents for each session"
     }
   }
 end

--- a/spec/jobs/consent_reminders_job_spec.rb
+++ b/spec/jobs/consent_reminders_job_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe ConsentRemindersJob, type: :job do
+  before { ActiveJob::Base.queue_adapter.enqueued_jobs.clear }
+
+  context "with draft and active sessions" do
+    it "enqueues ConsentRemindersSessionBatchJob for each active sessions" do
+      active_session =
+        create(:session, draft: false, send_reminders_at: Time.zone.today)
+      _draft_session = create(:session, draft: true)
+
+      described_class.perform_now
+      expect(ConsentRemindersSessionBatchJob).to have_been_enqueued.once
+      expect(ConsentRemindersSessionBatchJob).to have_been_enqueued.with(
+        active_session
+      )
+    end
+  end
+
+  context "with sessions set to send consent today and in the future" do
+    it "enqueues ConsentRemindersSessionBatchJob for the session set to send consent today" do
+      active_session =
+        create(:session, draft: false, send_reminders_at: Time.zone.today)
+      _later_session =
+        create(:session, draft: false, send_reminders_at: 2.days.from_now)
+
+      described_class.perform_now
+      expect(ConsentRemindersSessionBatchJob).to have_been_enqueued.once
+      expect(ConsentRemindersSessionBatchJob).to have_been_enqueued.with(
+        active_session
+      )
+    end
+  end
+end

--- a/spec/jobs/consent_reminders_session_batch_job_spec.rb
+++ b/spec/jobs/consent_reminders_session_batch_job_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe ConsentRemindersSessionBatchJob, type: :job do
+  before { ActionMailer::Base.deliveries.clear }
+
+  it "only sends emails to patients parents to whom they have not been sent yet" do
+    patient_with_consent_sent =
+      create(:patient, sent_consent_at: Time.zone.today)
+    patient_not_sent_consent = create(:patient)
+    session =
+      create(
+        :session,
+        patients: [patient_with_consent_sent, patient_not_sent_consent]
+      )
+
+    expect { described_class.perform_now(session) }.to send_email(
+      to: patient_not_sent_consent.parent_email
+    )
+
+    expect(ActionMailer::Base.deliveries.count).to eq(1)
+  end
+
+  it "updates the sent_consent_at attribute for patients" do
+    patient = create(:patient, sent_consent_at: nil)
+    session = create(:session, patients: [patient])
+
+    described_class.perform_now(session)
+    expect(patient.reload.sent_consent_at).to be_today
+  end
+end


### PR DESCRIPTION
Same as the consent requests, nearly an identical copy. It may be tempting to move these into the same job, but by keeping them separate it will offer finer grained control in case we need to pause or stop one job and not the other.