### PR TITLE
Exclude test team from performance stats

### DIFF
--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -4,10 +4,12 @@ task :performance, [] => :environment do |_task, _args|
   puts ""
   puts ":chart_with_upwards_trend: *PILOT PERFORMANCE* _#{Time.zone.now.to_fs(:nhsuk_date_day_of_week)}_"
   puts ""
-  puts "#{emoji_count(Registration.count)} *Expressions of interest (total)*"
-  puts ""
 
   teams = Team.all - Team.where(name: "Team MAVIS")
+
+  eoi_total = Registration.where(location: teams.map(&:locations).flatten).count
+  puts "#{emoji_count(eoi_total)} *Expressions of interest (total)*"
+
   teams.each do |team|
     puts ""
     puts ""


### PR DESCRIPTION
The count does not add up as it checks total registrations from every team.