### PR TITLE
Use flipper and avo only in dev and test

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,10 +10,6 @@ Rails.application.routes.draw do
   root to: redirect("/start")
 
   mount GoodJob::Engine => "/good-job"
-  constraints -> { !Rails.env.production? } do
-    mount Avo::Engine, at: Avo.configuration.root_path
-    mount Flipper::UI.app => "/flipper"
-  end
 
   get "/start", to: "pages#start"
   get "/dashboard", to: "dashboard#index"
@@ -32,6 +28,9 @@ Rails.application.routes.draw do
       get "/campaigns/:id", action: :show_campaign, as: "show_campaign"
       post "generate-campaign"
     end
+
+    mount Flipper::UI.app => "/flipper"
+    mount Avo::Engine, at: Avo.configuration.root_path
   end
 
   get "/csrf", to: "csrf#new"


### PR DESCRIPTION
We can add them back in once we have a better way to differentiate between the different environments.