### PR TITLE
Add health questions task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "phonelib"
 gem "propshaft"
 gem "puma", "~> 6.4"
 gem "pundit"
+gem "rainbow"
 gem "sentry-rails"
 gem "sentry-ruby"
 gem "silencer", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -683,6 +683,7 @@ DEPENDENCIES
   pundit
   rails (~> 7.1.3)
   rails-erd
+  rainbow
   rladr
   rspec
   rspec-html-matchers

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -234,9 +234,7 @@ class ConsentForm < ApplicationRecord
   end
 
   def any_health_answers_truthy?
-    health_answers.to_set.any? do |health_answer|
-      health_answer.response == "yes"
-    end
+    health_answers.any? { _1.response == "yes" }
   end
 
   def who_responded

--- a/app/models/health_question.rb
+++ b/app/models/health_question.rb
@@ -42,6 +42,12 @@ class HealthQuestion < ApplicationRecord
     find id_set.first
   end
 
+  def self.last_health_question
+    question = first_health_question
+    question = question.next_question until question.next_question.nil?
+    question
+  end
+
   def self.in_order
     first_health_question.remaining_questions
   end

--- a/app/models/health_question.rb
+++ b/app/models/health_question.rb
@@ -43,21 +43,24 @@ class HealthQuestion < ApplicationRecord
   end
 
   def self.in_order
-    first_health_question.to_set
+    first_health_question.remaining_questions
   end
 
   def self.to_health_answers
     HealthAnswer.from_health_questions(in_order)
   end
 
-  # Turn the health questions into an array.
-  def to_set(set = nil)
-    set ||= Set.new
-    set << self
+  # Turn the health questions into an array ordered by follow_up_questions and
+  # next_questions.
+  def remaining_questions(ary = nil)
+    ary ||= []
+    ary << self
 
-    follow_up_question.to_set(set) if follow_up_question.present?
-    next_question.to_set(set) if next_question.present?
+    follow_up_question.remaining_questions(ary) if follow_up_question.present?
+    if next_question.present? && !next_question.in?(ary)
+      next_question.remaining_questions(ary)
+    end
 
-    set
+    ary
   end
 end

--- a/lib/tasks/add_health_questions.rake
+++ b/lib/tasks/add_health_questions.rake
@@ -44,7 +44,7 @@ task :add_health_questions,
   puts "Enter an empty line to finish."
 
   health_questions = []
-  num = 0
+  num = replace ? 0 : existing_health_questions.count - 1
   loop do
     response =
       Readline.readline Rainbow("health question #{num + 1}: ").green, true

--- a/lib/tasks/add_health_questions.rake
+++ b/lib/tasks/add_health_questions.rake
@@ -1,0 +1,101 @@
+require_relative "../task_helpers"
+
+desc <<-DESC
+  Add health questions to a vaccine.
+
+  Usage:
+    rake add_health_questions[team_id,vaccine_id,replace]
+
+  The vaccine must belong to the team given, this is a safety check.
+
+  Use "replace" for the replace arg to replace the existing health questions.
+
+  Example:
+
+    rake add_health_questions[1,1,replace]
+DESC
+task :add_health_questions,
+     %i[team_id vaccine_id replace] => :environment do |_task, args|
+  team = Team.find(args[:team_id])
+  vaccine = team.campaign.vaccines.find(args[:vaccine_id])
+  existing_health_questions = vaccine.health_questions.in_order
+  puts "Existing health questions for #{team.name}'s #{vaccine.type} vaccine #{vaccine.brand}"
+  if existing_health_questions.any?
+    existing_health_questions.each do |health_question|
+      puts Rainbow("  #{health_question.question}").yellow
+    end
+  else
+    puts Rainbow("  [none]").black
+  end
+
+  puts ""
+  print "Enter health questions line-by-line below."
+
+  replace = args[:replace]&.downcase == "replace"
+  if replace
+    if existing_health_questions.any?
+      puts Rainbow(" These health questions will replace the ones above.").red
+    end
+  else
+    puts " These health questions will added to the ones above."
+  end
+
+  puts ""
+  puts "Enter an empty line to finish."
+
+  health_questions = []
+  num = 0
+  loop do
+    response =
+      Readline.readline Rainbow("health question #{num + 1}: ").green, true
+    break if response == ""
+    health_questions[num] = response
+    num += 1
+  end
+
+  if health_questions.empty?
+    puts "No responses entered, quitting"
+    next
+  end
+
+  puts "\nThese will be the health questions for #{team.name}'s #{vaccine.type} vaccine #{vaccine.brand}:"
+  unless replace
+    existing_health_questions.each do |health_question|
+      puts Rainbow("  [old] #{health_question.question}").black
+    end
+  end
+  health_questions.each do |health_question|
+    puts Rainbow("  [new] #{health_question}").white
+  end
+
+  puts ""
+  response = Readline.readline "Continue? (y/N) "
+  if response[0].downcase == "y"
+    update_health_questions(vaccine:, health_questions:, replace:)
+    puts Rainbow("Health questions added").green
+  else
+    puts Rainbow("Exiting without adding health questions").red
+  end
+end
+
+def update_health_questions(vaccine:, health_questions:, replace:)
+  vaccine.health_questions.delete_all if replace
+
+  last_question = vaccine.health_questions.last_health_question unless replace
+
+  hq_objects =
+    health_questions.map do |health_question|
+      HealthQuestion.new(question: health_question)
+    end
+  vaccine.health_questions << hq_objects
+
+  last_id = nil
+  hq_objects.reverse.each do |hq|
+    hq.update!(next_question_id: last_id) if last_id.present?
+    last_id = hq.id
+  end
+
+  if last_question.present?
+    last_question.update!(next_question: hq_objects.first)
+  end
+end

--- a/spec/models/health_question_spec.rb
+++ b/spec/models/health_question_spec.rb
@@ -73,24 +73,24 @@ RSpec.describe HealthQuestion do
     end
   end
 
-  describe "#to_set" do
+  describe "#remaining_questions" do
     let(:vaccine) { create :vaccine, type: "tester" }
     let(:hq1) { create :health_question, vaccine: }
     let(:hq2) { create :health_question, vaccine: }
     let(:hq3) { create :health_question, vaccine: }
 
-    it "returns a set ordered by next_question" do
+    it "returns remaining questions in order" do
       hq1.update! next_question: hq2
       hq2.update! next_question: hq3
 
-      expect(hq1.to_set).to eq(Set[hq1, hq2, hq3])
+      expect(hq1.remaining_questions).to eq([hq1, hq2, hq3])
     end
 
     it "orders follow up questions before next questions" do
       hq1.update! next_question: hq2, follow_up_question: hq3
       hq3.update! next_question: hq2
 
-      expect(hq1.to_set).to eq(Set[hq1, hq3, hq2])
+      expect(hq1.remaining_questions).to eq([hq1, hq3, hq2])
     end
   end
 end

--- a/spec/models/health_question_spec.rb
+++ b/spec/models/health_question_spec.rb
@@ -73,6 +73,34 @@ RSpec.describe HealthQuestion do
     end
   end
 
+  describe ".last_health_question" do
+    let(:vaccine) { create :vaccine, type: "tester" }
+    let!(:hq1) { create :health_question, vaccine: }
+    let!(:hq2) { create :health_question, vaccine: }
+    let!(:hq3) { create :health_question, vaccine: }
+
+    it "returns the last health question" do
+      hq1.update! next_question: hq2
+      hq2.update! next_question: hq3
+
+      expect(vaccine.health_questions.last_health_question).to eq(hq3)
+    end
+
+    it "ignores health questions outside of the scoped collection" do
+      create :health_question
+
+      hq1.update! next_question: hq2
+      hq2.update! next_question: hq3
+
+      expect(
+        vaccine
+          .health_questions
+          .where(id: [hq1.id, hq2.id, hq3.id])
+          .last_health_question
+      ).to eq(hq3)
+    end
+  end
+
   describe "#remaining_questions" do
     let(:vaccine) { create :vaccine, type: "tester" }
     let(:hq1) { create :health_question, vaccine: }


### PR DESCRIPTION
To enable adding or replacing health questions in deployed environments.

## Replacing existing health questions

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/ab5fe998-8b6d-4254-9b86-16fabd2826be)

## Adding to existing health questions

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/d73ed925-9185-4799-b252-90a84a337757)

## Aborting updating health questions

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/7b53c6b7-2337-4e73-ad79-da02d0ede427)

