### PR TITLE
Add db:prepare:ignore_concurrent_migration_exceptions

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,7 +2,7 @@
 
 # If running the rails server then create or migrate existing database
 if [ "${*}" == "./bin/rails server" ]; then
-  ./bin/rails db:prepare
+  ./bin/rails db:prepare:ignore_concurrent_migration_exceptions
 fi
 
 exec "${@}"

--- a/bin/release
+++ b/bin/release
@@ -6,5 +6,5 @@ if [[ "$MAVIS__IS_REVIEW" == "true" && `bin/rails db:version | grep version` == 
   bin/rails db:schema:load
   bin/rails db:seed
 else
-  bin/rails db:migrate
+  bin/rails db:prepare:ignore_concurrent_migration_exceptions
 fi

--- a/lib/tasks/prepare_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/prepare_swallowing_concurrent_migration_exceptions.rake
@@ -1,0 +1,10 @@
+namespace :db do
+  namespace :prepare do
+    desc "Run db:prepare but ignore ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["db:prepare"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end


### PR DESCRIPTION
Because we deploy to multiple machines at the same time, it's possible to run into concurrent migration issues. It's safe to swallow these errors and let the deploy carry on.