### PR TITLE
Remove contact method page from parental consent

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -143,7 +143,7 @@ class ConsentForm < ApplicationRecord
     validates :parent_phone, phone: true, if: :parent_phone?
   end
 
-  on_wizard_step :contact_method do
+  on_wizard_step :contact_method, exact: true do
     validates :contact_method, presence: true
     validates :contact_method_other, presence: true, if: :contact_method_other?
   end
@@ -193,7 +193,7 @@ class ConsentForm < ApplicationRecord
       :date_of_birth,
       :school,
       :parent,
-      (:contact_method if parent_phone.present?),
+      (:contact_method if ask_for_contact_method?),
       :consent,
       (:reason if consent_refused?),
       (:reason_notes if consent_refused? && reason_notes_must_be_provided?),
@@ -322,5 +322,9 @@ class ConsentForm < ApplicationRecord
       end
     end
     true
+  end
+
+  def ask_for_contact_method?
+    Flipper.enabled?(:parent_contact_method) && parent_phone.present?
   end
 end

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -171,12 +171,14 @@ end %>
           visually_hidden_text: "your phone")
       end
 
-      summary_list.with_row do |row|
-        row.with_key { "Phone contact method" }
-        row.with_value { contact_method_for(@consent_form) }
-        row.with_action(text: "Change",
-          href: change_link[:contact_method],
-          visually_hidden_text: "your phone contact method")
+      if @consent_form.contact_method.present?
+        summary_list.with_row do |row|
+          row.with_key { "Phone contact method" }
+          row.with_value { contact_method_for(@consent_form) }
+          row.with_action(text: "Change",
+            href: change_link[:contact_method],
+            visually_hidden_text: "your phone contact method")
+        end
       end
     else
       summary_list.with_row do |row|

--- a/spec/features/parent_gives_consent_spec.rb
+++ b/spec/features/parent_gives_consent_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Parent gives consent", type: :feature do
   include SessionCreationSteps
 
   before do
+    Flipper.enable(:parent_contact_method)
     team = create(:team, name: "School Nurses")
     @campaign = create(:campaign, :hpv, team:)
     create(

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -340,6 +340,7 @@ RSpec.describe ConsentForm, type: :model do
 
   describe "#form_steps" do
     it "asks for contact method if phone is specified" do
+      Flipper.enable(:parent_contact_method)
       consent_form = build(:consent_form, parent_phone: "0123456789")
       expect(consent_form.form_steps).to include(:contact_method)
     end

--- a/tests/parental_consent_asthma_route.spec.ts
+++ b/tests/parental_consent_asthma_route.spec.ts
@@ -21,6 +21,16 @@ test("Parental consent asthma route", async ({ page }) => {
 
 async function given_the_app_is_setup() {
   await p.goto("/reset");
+
+  // Enable parent contact method feature
+  await p.goto("/flipper/features/parent_contact_method");
+  await expect(
+    p.getByText("Home Features parent_contact_method"),
+  ).toBeVisible();
+  if (await p.getByText("Disabled").isVisible()) {
+    await p.getByRole("button", { name: "Fully Enable" }).click();
+    await expect(p.getByText("Fully enabled")).toBeVisible();
+  }
 }
 
 async function when_i_go_to_the_consent_start_page() {


### PR DESCRIPTION
At the moment the service won't be able to honour this if set.

This also removes the form page and validation, since they're easy to re-add, but leaves the db field in case we want to populate it another way at some point.