### PR TITLE
Use parent name from consent in triage email

### DIFF
--- a/app/mailers/triage_mailer.rb
+++ b/app/mailers/triage_mailer.rb
@@ -1,5 +1,7 @@
 class TriageMailer < ApplicationMailer
   def vaccination_will_happen(patient_session)
+    @patient_session = patient_session
+
     template_mail(
       "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
       **opts(patient_session)
@@ -7,9 +9,25 @@ class TriageMailer < ApplicationMailer
   end
 
   def vaccination_wont_happen(patient_session)
+    @patient_session = patient_session
+
     template_mail(
       "d1faf47e-ccc3-4481-975b-1ec34211a21f",
       **opts(patient_session)
     )
+  end
+
+  private
+
+  def consent
+    @patient_session.consents.order(:created_at).last
+  end
+
+  def to
+    consent.parent_email
+  end
+
+  def parent_name
+    consent.parent_name
   end
 end

--- a/spec/mailers/triage_mailer_spec.rb
+++ b/spec/mailers/triage_mailer_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe TriageMailer, type: :mailer do
+  describe "#vaccination_will_happen" do
+    let(:patient_session) { create(:patient_session) }
+    let(:consent) { create(:consent, patient_session:) }
+
+    subject(:mail) { TriageMailer.vaccination_will_happen(patient_session) }
+
+    it { should have_attributes(to: [consent.parent_email]) }
+
+    describe "personalisation" do
+      subject { mail.message.header["personalisation"].unparsed_value }
+
+      it { should include(parent_name: consent.parent_name) }
+    end
+  end
+
+  describe "#vaccination_wont_happen" do
+    let(:patient_session) { create(:patient_session) }
+    let(:consent) { create(:consent, patient_session:) }
+
+    subject(:mail) { TriageMailer.vaccination_wont_happen(patient_session) }
+
+    it { should have_attributes(to: [consent.parent_email]) }
+
+    describe "personalisation" do
+      subject { mail.message.header["personalisation"].unparsed_value }
+
+      it { should include(parent_name: consent.parent_name) }
+    end
+  end
+end


### PR DESCRIPTION
The consent object gets the parent's name from the consent form or from the nurse when they call the parent. This is more likely to be accurate and up-to-date than what's on the patient record.

There's still the question of what to do when more than one parent has submitted consent, how do we know we have the right parent?