### PR TITLE
Run good_job in external mode using supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,11 @@ FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential curl git libpq-dev node-gyp pkg-config python-is-python3 && \
+    apt-get install --no-install-recommends -y build-essential curl git libpq-dev node-gyp pkg-config python-is-python3 supervisor && \
     apt-get clean
+
+# Configure supervisord to run background processes
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Install JavaScript dependencies
 ARG NODE_VERSION=18.1.0
@@ -79,6 +82,6 @@ USER rails:rails
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
-# Start the server by default, this can be overwritten at runtime
+# Start the server and background jobs with supervisord
 EXPOSE 3000
-CMD ["./bin/rails", "server"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,6 +119,7 @@ Rails.application.configure do
   }
 
   config.good_job.enable_cron = true
+  config.good_job.execution_mode = :external
   config.good_job.cron = {
     consent_request: {
       cron: "every day at 9am",

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+
+[program:good_job]
+command=bin/bundle exec good_job start
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/good_job.err.log
+stdout_logfile=/var/log/good_job.out.log
+
+[program:rails_server]
+command=bin/rails server
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/rails_server.err.log
+stdout_logfile=/var/log/rails_server.out.log


### PR DESCRIPTION
This attempts to fix the current issue with running `good_job` in async mode. It switches to external mode and runs `bundle exec good_job start` as a separate process in the Docker container.

Because Docker containers are designed to be single process, we need to use `supervisor` to manage running the two processes.