### PR TITLE
Remove temporary parental consent feature flag

### DIFF
--- a/app/assets/stylesheets/registration.scss
+++ b/app/assets/stylesheets/registration.scss
@@ -131,7 +131,6 @@ html {
 }
 
 .nhsuk-inset-text {
-  // margin-top: nhsuk-spacing(3);
   max-width: 100%;
   padding-bottom: 0;
   padding-top: 0;

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -37,11 +37,9 @@ module ParentInterface
 
       session.delete(:consent_form_id)
 
-      if Flipper.enabled?(:parental_consent_jobs)
-        send_record_mail(@consent_form)
+      send_record_mail(@consent_form)
 
-        ConsentFormMatchingJob.perform_later(@consent_form.id)
-      end
+      ConsentFormMatchingJob.perform_later(@consent_form.id)
     end
 
     private

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -25,12 +25,5 @@ FLIPPER_INITIALIZERS = {
     else
       Flipper.disable(:pilot_phase_1)
     end
-  end,
-  parental_consent_jobs: -> do
-    if Rails.env.staging? || Rails.env.production?
-      Flipper.disable(:parental_consent_jobs)
-    else
-      Flipper.enable(:parental_consent_jobs)
-    end
   end
 }.freeze

--- a/spec/features/parent_gives_consent_spec.rb
+++ b/spec/features/parent_gives_consent_spec.rb
@@ -3,10 +3,7 @@ require "rails_helper"
 RSpec.feature "Parent gives consent", type: :feature do
   include SessionCreationSteps
 
-  before do
-    Flipper.enable(:parent_contact_method)
-    Flipper.enable(:parental_consent_jobs)
-  end
+  before { Flipper.enable(:parent_contact_method) }
 
   scenario "Parent gives consent, their consent form exactly matches the cohort" do
     given_the_local_sais_team_is_running_an_hpv_vaccination_campaign

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -60,12 +60,7 @@ RSpec.feature "Pilot journey", type: :feature do
   end
 
   def and_registration_is_open
-    visit "/flipper/features/registration_open"
-    expect(page).to have_text("Home Features registration_open")
-    if page.has_text?("Disabled")
-      click_on "Fully Enable"
-      expect(page).to have_text("Fully enabled")
-    end
+    Flipper.enable :registration_open
   end
 
   def when_i_register_for_the_pilot_as_a_parent


### PR DESCRIPTION
This was added during an incident and can be removed now.