### PR TITLE
Add Timecop freeze to pilot journey test

### DIFF
--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -78,7 +78,7 @@ class Session < ApplicationRecord
     validates :send_consent_at,
               presence: true,
               comparison: {
-                greater_than_or_equal_to: Time.zone.today,
+                greater_than_or_equal_to: -> { Time.zone.today },
                 less_than_or_equal_to: ->(object) { object.date }
               }
 

--- a/spec/features/pilot_journey_spec.rb
+++ b/spec/features/pilot_journey_spec.rb
@@ -3,6 +3,9 @@
 require "rails_helper"
 
 RSpec.feature "Pilot journey", type: :feature do
+  before { Timecop.freeze(Time.zone.local(2024, 2, 1)) }
+  after { Timecop.return }
+
   scenario "Complete journey from registration to session creation and consent checks" do
     given_the_local_sais_team_is_running_an_hpv_vaccination_campaign
     and_they_arranged_for_my_childs_school_to_be_in_the_pilot


### PR DESCRIPTION
Validations started failing in this test because we went past the 27th of Feb and certain dates can't be in the past.