### PR TITLE
Use sequence for team name instead of random

### DIFF
--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
   factory :team do
     transient do
       random { Random.new }
-      identifier { random.rand(1..10_000) }
+      sequence(:identifier) { _1 }
     end
 
     name { "Team #{identifier}" }


### PR DESCRIPTION
When we create many teams within the same transaction we can occasionally get a duplicate that causes the unique index on team name to raise an error. Using a sequence avoids this.

This was tested with the following rspec. Using the random identifier didn't seem to clash very often, but we've seen this issue at least once and probably more in CI, so better to tidy it up.

```
require 'rails_helper'

RSpec.describe Team do
  100.times do |n|
    it "works #{n}" do
      create_list(:team, 20)
    end
  end
end
```