### PR TITLE
Always ask for password for good_job dashboard

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -1,23 +1,12 @@
-# Prompt for a username if either the support user is defined, or we are in
-# production. In production, if no support user is defined then no access is
-# available.
-
-support_user_defined =
-  Settings.support_username.present? && Settings.support_password.present?
-
-if Rails.env.production? || support_user_defined
-  GoodJob::Engine
-    .middleware
-    .use(Rack::Auth::Basic) do |username, password|
-      if support_user_defined
-        ActiveSupport::SecurityUtils.secure_compare(
-          Settings.support_username,
-          username
-        ) &&
-          ActiveSupport::SecurityUtils.secure_compare(
-            Settings.support_password,
-            password
-          )
-      end
-    end
-end
+GoodJob::Engine
+  .middleware
+  .use(Rack::Auth::Basic) do |username, password|
+    ActiveSupport::SecurityUtils.secure_compare(
+      Settings.support_username,
+      username
+    ) &&
+      ActiveSupport::SecurityUtils.secure_compare(
+        Settings.support_password,
+        password
+      )
+  end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,6 @@
+support_username: manage
+support_password: vaccinations
+
 pilot:
   earliest_session_date: 1-3-2024
   latest_session_date: 30-3-2024


### PR DESCRIPTION
This makes /good-job consistently ask for a password in all environments, including development, to make it more similar to production.