### PR TITLE
Don't explicitly triage consent forms from "other" carer

### DIFF
--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -143,8 +143,7 @@ class Consent < ApplicationRecord
   end
 
   def triage_needed?
-    response_given? &&
-      (parent_relationship_other? || health_answers_require_follow_up?)
+    response_given? && health_answers_require_follow_up?
   end
 
   def who_responded
@@ -161,7 +160,6 @@ class Consent < ApplicationRecord
 
   def reasons_triage_needed
     reasons = []
-    reasons << "Check parental responsibility" if parent_relationship_other?
     if health_answers_require_follow_up?
       reasons << "Health questions need triage"
     end

--- a/spec/components/app_patient_medical_history_card_component_spec.rb
+++ b/spec/components/app_patient_medical_history_card_component_spec.rb
@@ -41,53 +41,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
     end
   end
 
-  context "parent is other and triage is not done" do
-    let(:consent) do
-      create :consent, :from_granddad, patient:, campaign: session.campaign
-    end
-
-    it "renders correctly" do
-      expect(page).to have_css("p:first", text: "Triage needed")
-      expect(page).to have_css("li", text: "Check parental responsibility")
-      expect(page).to have_css(
-        ".nhsuk-details__summary-text",
-        text: "Show answers"
-      )
-    end
-  end
-
-  context "parent is other and triage is done with notes" do
-    let(:consent) do
-      create :consent, :from_granddad, patient:, campaign: session.campaign
-    end
-    let(:triage_notes) { "These are triage notes" }
-    let(:triage) { create :triage, patient_session:, notes: triage_notes }
-
-    it "renders correctly" do
-      expect(page).to have_css("h2:nth(2)", text: "Triage notes")
-      expect(page).to have_css("p:first", text: triage_notes)
-      expect(page).to have_css(
-        ".nhsuk-details__summary-text",
-        text: "Show answers"
-      )
-    end
-  end
-
-  context "parent is other and triage is done without notes" do
-    let(:consent) do
-      create :consent, :from_granddad, patient:, campaign: session.campaign
-    end
-    let(:triage) { create :triage, patient_session:, notes: nil }
-
-    it "renders correctly" do
-      expect(page).to have_css("p:first", text: "Triage complete - no notes")
-      expect(page).to have_css(
-        ".nhsuk-details__summary-text",
-        text: "Show answers"
-      )
-    end
-  end
-
   context "health question is yes and triage is done with notes" do
     let(:health_answers) do
       [
@@ -146,35 +99,6 @@ RSpec.describe AppPatientMedicalHistoryCardComponent, type: :component do
     it "renders correctly" do
       expect(page).to have_css("p:first", text: "Triage needed")
       expect(page).to have_css("li:first", text: "Health questions need triage")
-      expect(page).to have_css(
-        ".nhsuk-details__summary-text",
-        text: "Show answers"
-      )
-    end
-  end
-
-  context "health question is yes and parent is other but triage is not done" do
-    let(:health_answers) do
-      [
-        HealthAnswer.new(
-          question: "Is there anything else we should know?",
-          response: "yes",
-          notes: "These are notes"
-        )
-      ]
-    end
-    let(:consent) do
-      create :consent,
-             :from_granddad,
-             patient:,
-             campaign: session.campaign,
-             health_answers:
-    end
-
-    it "renders correctly" do
-      expect(page).to have_css("p:first", text: "Triage needed")
-      expect(page).to have_css("li", text: "Check parental responsibility")
-      expect(page).to have_css("li", text: "Health questions need triage")
       expect(page).to have_css(
         ".nhsuk-details__summary-text",
         text: "Show answers"

--- a/spec/models/concerns/patient_session_state_machine_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_machine_concern_spec.rb
@@ -428,7 +428,7 @@ RSpec.describe PatientSessionStateMachineConcern do
     end
   end
 
-  describe "when consent given by other, triage and follow-up needed, the vaccination is administered" do
+  describe "when consent given by other, no triage needed, the vaccination is administered" do
     it "steps through the right actions and outcomes" do
       session = create(:session, patients_in_session: 1)
       patient = session.patients.first
@@ -442,17 +442,7 @@ RSpec.describe PatientSessionStateMachineConcern do
         campaign: session.campaign
       )
       patient_session.do_consent
-      expect(patient_session).to be_consent_given_triage_needed
-
-      # follow-up needed
-      triage = create(:triage, patient_session:, status: :needs_follow_up)
-      patient_session.do_triage
-      expect(patient_session).to be_triaged_kept_in_triage
-
-      # triage done
-      triage.update!(status: :ready_to_vaccinate)
-      patient_session.do_triage
-      expect(patient_session).to be_triaged_ready_to_vaccinate
+      expect(patient_session).to be_consent_given_triage_not_needed
 
       # vaccination administered
       create(
@@ -480,7 +470,7 @@ RSpec.describe PatientSessionStateMachineConcern do
         campaign: session.campaign
       )
       patient_session.do_consent
-      expect(patient_session).to be_consent_given_triage_needed
+      expect(patient_session).to be_consent_given_triage_not_needed
 
       # triage decides not to vaccinate
       create(:triage, patient_session:, status: :do_not_vaccinate)

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -42,15 +42,7 @@ RSpec.describe Consent do
     end
   end
 
-  describe "when consent given by someone who's not a parent or a guardian" do
-    it "does require triage" do
-      response = build(:consent_given, parent_relationship: :other)
-
-      expect(response).to be_triage_needed
-    end
-  end
-
-  describe "when consent given by parent or guardian, but some info for health questions" do
+  describe "when consent given by parent or guardian, but some info provided in the health questions" do
     it "does require triage" do
       health_answers = [
         HealthAnswer.new(
@@ -64,40 +56,13 @@ RSpec.describe Consent do
 
       expect(response).to be_triage_needed
     end
-  end
 
-  describe "#reasons_triage_needed" do
-    context "parent relationship is other" do
-      it "returns check parental responsibility" do
-        response = build(:consent_given, :from_granddad)
+    it "returns notes need triage" do
+      response = build(:consent_given, :health_question_notes)
 
-        expect(response.reasons_triage_needed).to eq(
-          ["Check parental responsibility"]
-        )
-      end
-    end
-
-    context "health questions indicate followup needed" do
-      it "returns notes need triage" do
-        response = build(:consent_given, :health_question_notes)
-
-        expect(response.reasons_triage_needed).to eq(
-          ["Health questions need triage"]
-        )
-      end
-    end
-
-    context "parent relationship is other and health questions indicate followup needed" do
-      it "returns both check parental responsibility and notes need triage" do
-        response = build(:consent_given, :health_question_notes, :from_granddad)
-
-        expect(response.reasons_triage_needed).to include(
-          "Health questions need triage"
-        )
-        expect(response.reasons_triage_needed).to include(
-          "Check parental responsibility"
-        )
-      end
+      expect(response.reasons_triage_needed).to eq(
+        ["Health questions need triage"]
+      )
     end
   end
 


### PR DESCRIPTION
Before this change, if the consent form was submitted by "other" carer, it would automatically go to triage.

Since we're changing the design so that "other" carers have to explicitly confirm parental responsibility on the consent form, this special case is no longer necessary.