### PR TITLE
Add parental responsibility radio to parent page

### DIFF
--- a/app/controllers/parent_interface/consent_forms/edit_controller.rb
+++ b/app/controllers/parent_interface/consent_forms/edit_controller.rb
@@ -32,7 +32,17 @@ module ParentInterface
 
       if current_step == :school && @consent_form.is_this_their_school == "no"
         return(
-          redirect_to session_parent_interface_consent_form_cannot_consent_path(
+          redirect_to session_parent_interface_consent_form_cannot_consent_school_path(
+                        @session,
+                        @consent_form
+                      )
+        )
+      end
+
+      if current_step == :parent &&
+           @consent_form.parental_responsibility == "no"
+        return(
+          redirect_to session_parent_interface_consent_form_cannot_consent_responsibility_path(
                         @session,
                         @consent_form
                       )
@@ -70,6 +80,7 @@ module ParentInterface
           parent_name
           parent_relationship
           parent_relationship_other
+          parental_responsibility
           parent_email
           parent_phone
         ],

--- a/app/controllers/parent_interface/consent_forms_controller.rb
+++ b/app/controllers/parent_interface/consent_forms_controller.rb
@@ -26,7 +26,10 @@ module ParentInterface
                   )
     end
 
-    def cannot_consent
+    def cannot_consent_school
+    end
+
+    def cannot_consent_responsibility
     end
 
     def confirm

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -50,7 +50,9 @@ class ConsentForm < ApplicationRecord
   scope :unmatched, -> { where(consent_id: nil) }
   scope :recorded, -> { where.not(recorded_at: nil) }
 
-  attr_accessor :health_question_number, :is_this_their_school
+  attr_accessor :health_question_number,
+                :is_this_their_school,
+                :parental_responsibility
 
   audited
 
@@ -142,6 +144,14 @@ class ConsentForm < ApplicationRecord
     validates :parent_email, presence: true, email: true
     validates :parent_phone, phone: true, if: :parent_phone?
   end
+
+  validates :parental_responsibility,
+            inclusion: {
+              in: %w[yes]
+            },
+            if: ->(object) do
+              object.parent_relationship_other? && object.form_step == :parent
+            end
 
   on_wizard_step :contact_method, exact: true do
     validates :contact_method, presence: true

--- a/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_responsibility.html.erb
@@ -1,0 +1,19 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: session_parent_interface_consent_form_edit_path(@session, @consent_form, :parent),
+    name: "edit your details page"
+  ) %>
+<% end %>
+
+<%= h1 "You cannot give or refuse consent through this service" %>
+
+<p>
+  To give or refuse consent for a child’s vaccination, you need to have parental responsibility.
+</p>
+
+<p>
+  If you have any questions, please contact the local health team by calling
+  <%= @session.campaign.team.phone %>, or email
+  <a class="nhsuk-link" href="mailto:<%= @session.campaign.team.email %>">
+    <%= @session.campaign.team.email %></a>.
+</p>

--- a/app/views/parent_interface/consent_forms/cannot_consent_school.html.erb
+++ b/app/views/parent_interface/consent_forms/cannot_consent_school.html.erb
@@ -11,8 +11,8 @@
 parents whose children attend participating schools.</p>
 
 <p>
-  To give or refuse consent for your child’s vaccination, please use the paper
-  form sent by your child’s school. If you have any questions, please contact
-  <a class="nhsuk-link" href="mailto:<%= t('service.email') %>">
-    <%= t('service.email') %></a>.
+  If you have any questions, please contact the local health team by calling
+  <%= @session.campaign.team.phone %>, or email
+  <a class="nhsuk-link" href="mailto:<%= @session.campaign.team.email %>">
+    <%= @session.campaign.team.email %></a>.
 </p>

--- a/app/views/parent_interface/consent_forms/edit/parent.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/parent.html.erb
@@ -23,14 +23,22 @@
       label: { text: 'Guardian' } %>
     <%= f.govuk_radio_button :parent_relationship, "other",
       label: { text: 'Other' } do %>
-      <p>
-        You need parental responsibility to give consent. This means you have
-        legal rights and duties relating to the child.
-      </p>
-
       <%= f.govuk_text_field :parent_relationship_other,
-        label: { text: 'Relationship to the child' },
-        hint: { text: 'For example, carer' } %>
+        # The radio button already has a consent-form-parent-relationship-other
+        # id, so we need to use a different one here.
+        label: { text: 'Relationship to the child',
+                 for: "parent-relationship-other" },
+        hint: { text: 'For example, carer' },
+        id: "parent-relationship-other" %>
+      <%= f.govuk_radio_buttons_fieldset(:parental_responsibility,
+        legend: { size: "s",
+                  text: "Do you have parental responsibility?" },
+        hint: { text: "This means you have legal rights and duties relating to the child" }) do %>
+        <%= f.govuk_radio_button :parental_responsibility, "yes",
+          label: { text: "Yes" }, link_errors: true %>
+        <%= f.govuk_radio_button :parental_responsibility, "no",
+          label: { text: "No" } %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -416,6 +416,8 @@ en:
             parent_relationship_other:
               blank: Enter your relationship
               too_long: Enter a relationship that are less than 300 characters long
+            parental_responsibility:
+              inclusion: You need parental responsibility to give consent
             parent_email:
               blank: Enter your email address
               invalid: Enter a valid email address, such as j.doe@gmail.com

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,8 @@ Rails.application.routes.draw do
     namespace :parent_interface, path: "/" do
       resources :consent_forms, path: :consents, only: [:create] do
         get "start", on: :collection
-        get "cannot-consent"
+        get "cannot-consent-school"
+        get "cannot-consent-responsibility"
         get "confirm"
         put "record"
 

--- a/tests/parental_consent_change_answers.spec.ts
+++ b/tests/parental_consent_change_answers.spec.ts
@@ -10,6 +10,18 @@ test("Parental consent change answers", async ({ page }) => {
   await when_i_go_to_a_prefilled_consent_form();
   await then_i_see_the_consent_confirm_page();
 
+  await when_i_change_my_parental_relationship_to_other();
+  await then_i_see_the_parental_responsibility_error();
+
+  await when_i_refuse_parental_responsibility();
+  await then_i_see_the_cannot_consent_responsibility_page();
+
+  await when_i_accept_parental_responsibility();
+  await then_i_see_the_consent_confirm_page();
+
+  await when_i_change_my_parental_relationship_to_dad();
+  await then_i_see_the_consent_confirm_page();
+
   await when_i_change_the_patients_name();
   await then_i_see_the_updated_name();
 
@@ -172,4 +184,52 @@ async function then_i_see_the_refused_confirmation_page() {
   await expect(
     p.locator("p", { hasText: "having an injection instead" }),
   ).not.toBeVisible();
+}
+
+async function when_i_change_my_parental_relationship_to_other() {
+  await p
+    .getByRole("link", { name: "Change your relationship", exact: true })
+    .click();
+  await p.getByRole("radio", { name: "Other" }).click();
+  await p.getByLabel("Relationship to the child").fill("Granddad");
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_parental_responsibility_error() {
+  await expect(p.locator(".nhsuk-error-summary")).toContainText(
+    "You need parental responsibility to give consent",
+  );
+}
+
+async function when_i_accept_parental_responsibility() {
+  await p.getByRole("link", { name: "Back" }).click();
+  await p.getByRole("radio", { name: "Other" }).click();
+  await p.getByLabel("Relationship to the child").fill("Granddad");
+  await p.getByRole("radio", { name: "Yes" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+  // BUG: The page should be the consent confirm page, but because we
+  // encountered a validation error, the skip_to_confirm flag gets lost and we
+  // end up on the next page in the wizard.
+  for (let i = 0; i < 12; i++) {
+    await p.getByRole("button", { name: "Continue" }).click();
+  }
+}
+
+async function when_i_change_my_parental_relationship_to_dad() {
+  await p
+    .getByRole("link", { name: "Change your relationship", exact: true })
+    .click();
+  await p.getByRole("radio", { name: "Dad" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function when_i_refuse_parental_responsibility() {
+  await p.getByRole("radio", { name: "No" }).click();
+  await p.getByRole("button", { name: "Continue" }).click();
+}
+
+async function then_i_see_the_cannot_consent_responsibility_page() {
+  await expect(p.locator("h1")).toContainText(
+    "You cannot give or refuse consent",
+  );
 }


### PR DESCRIPTION
This ensures that consent forms can't be submitted by a parent who isn't mum/dad/guardian unless they accept a radio button confirming they have parental responsibility.