### PR TITLE
Remove "Nurse" wording from UI

### DIFF
--- a/app/components/app_status_banner_component.rb
+++ b/app/components/app_status_banner_component.rb
@@ -185,7 +185,7 @@ class AppStatusBannerComponent < ViewComponent::Base
       end
 
       summary_list.with_row do |row|
-        row.with_key { "Nurse" }
+        row.with_key { "Vaccinator" }
         row.with_value { nurse_name_summary }
       end
 
@@ -231,7 +231,7 @@ class AppStatusBannerComponent < ViewComponent::Base
       end
 
       summary_list.with_row do |row|
-        row.with_key { "Nurse" }
+        row.with_key { "Vaccinator" }
         row.with_value { nurse_name_summary }
       end
 

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -29,12 +29,12 @@ en:
       colour: red
       text: Delay vaccination
       banner_title: Delay vaccination to a later date
-      banner_explanation: "Nurse %{triage_nurse} decided that %{full_name}’s vaccination should be delayed."
+      banner_explanation: "%{triage_nurse} decided that %{full_name}’s vaccination should be delayed."
     triaged_do_not_vaccinate:
       colour: red
       text: Could not vaccinate
       banner_title: Could not vaccinate
-      banner_explanation: A nurse decided that %{full_name} should not be vaccinated.
+      banner_explanation: "%{triage_nurse} that %{full_name} should not be vaccinated."
     triaged_kept_in_triage:
       colour: blue
       text: Triage started
@@ -44,7 +44,7 @@ en:
       colour: purple
       text: Vaccinate
       banner_title: Safe to vaccinate
-      banner_explanation: "Nurse %{triage_nurse} decided that %{full_name} is safe to vaccinate."
+      banner_explanation: "%{triage_nurse} decided that %{full_name} is safe to vaccinate."
     unable_to_vaccinate:
       colour: red
       text: Could not vaccinate

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
     it { should have_css(".nhsuk-card__heading", text: "Safe to vaccinate") }
     it "explains who took the decision that the patient should be vaccinated" do
       expect(component.explanation).to eq(
-        "Nurse #{triage_nurse_name} decided that #{patient_name} is safe to vaccinate."
+        "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate."
       )
     end
   end
@@ -125,7 +125,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
     it { should have_text("ReasonDo not vaccinate in campaign") }
     it { should have_text("DateToday (#{date})") }
     it { should have_text("Location#{location.name}") }
-    it { should have_text("NurseYou (#{triage.user.full_name})") }
+    it { should have_text("VaccinatorYou (#{triage.user.full_name})") }
 
     context "recorded_at is not today" do
       let(:date) { Time.zone.now - 2.days }


### PR DESCRIPTION
We currently hardcode the string “Nurse” in a few places in Mavis. This isn’t inclusive of paramedics and we should use people’s names instead.