### PR TITLE
Set good_job to async in production 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -119,7 +119,6 @@ Rails.application.configure do
   }
 
   config.good_job.enable_cron = true
-  config.good_job.execution_mode = :external
   config.good_job.cron = {
     consent_request: {
       cron: "every day at 9am",

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -20,11 +20,18 @@ else
 end
 
 # Specifies the `environment` that Puma will run in.
-#
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+
+# Cleanly shut down GoodJob when Puma is shut down.
+# See https://github.com/bensheldon/good_job#execute-jobs-async--in-process
+MAIN_PID = Process.pid
+before_fork { GoodJob.shutdown }
+on_worker_boot { GoodJob.restart }
+on_worker_shutdown { GoodJob.shutdown }
+at_exit { GoodJob.shutdown if Process.pid == MAIN_PID }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -63,6 +63,7 @@ environments:
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "staging.give-or-refuse-consent-for-vaccinations.nhs.uk"
       WEB_CONCURRENCY: 2
   test:
+    count: 2
     http:
       alias:
         - "test.mavistesting.com"
@@ -72,6 +73,7 @@ environments:
       RAILS_ENV: staging
       MAVIS__HOST: "test.mavistesting.com"
       MAVIS__GIVE_OR_REFUSE_CONSENT_HOST: "test.mavistesting.com"
+      WEB_CONCURRENCY: 2
   training:
     http:
       alias:


### PR DESCRIPTION
This simplifies our infrastructure and deploy pipeline, and should be resilient now that we found the Puma restart bug that previously led to jobs not being enqueued successfully in production.

First commit sets up Puma to cleanly restart good_job when it restarts following the advice in https://github.com/bensheldon/good_job?tab=readme-ov-file#execute-jobs-async--in-process

Second makes `test` more similar to `staging`, so that we can test this more thoroughly and also shut down staging once we switch to using `test` more (after this change ships successfully most likely).

Third removes the `good_job` execution mode override in `production.rb`, finishing the transition.

Follow-up PR to this will remove the `goodjob/manifest.yml` service and infrastructure.

This also fixes job execution on Heroku which is currently broken.