### PR TITLE
Persist selected action table filters

### DIFF
--- a/app/components/app_patient_table_component.html.erb
+++ b/app/components/app_patient_table_component.html.erb
@@ -4,7 +4,7 @@
   </h2>
 <% end %>
 
-<action-table class="nhsuk-grid-row" sort="name">
+<action-table id="<%= @tab_id %>" class="nhsuk-grid-row" sort="name" store>
   <div class="nhsuk-grid-column-one-quarter">
     <%= render AppPatientTableFilterComponent.new(tab_id: @tab_id) %>
   </div>

--- a/app/views/consent_forms/show.html.erb
+++ b/app/views/consent_forms/show.html.erb
@@ -21,6 +21,7 @@
   if @patient_sessions.count > 0
     render AppPatientTableComponent.new(
       patient_sessions: @patient_sessions,
+      tab_id: "cohort",
       columns: %i[name postcode dob select_for_matching],
       route: :matching,
       consent_form: @consent_form

--- a/app/views/vaccinations/_patients_with_actions.html.erb
+++ b/app/views/vaccinations/_patients_with_actions.html.erb
@@ -1,6 +1,6 @@
 <h2 class="nhsuk-heading-s nhsuk-u-margin-0 app-visually-hidden-from-tablet"><%= caption %></h2>
 
-<action-table class="nhsuk-grid-row" sort="name">
+<action-table store="<%= id %>" class="nhsuk-grid-row" sort="name">
   <div class="nhsuk-grid-column-one-quarter">
     <%= render AppPatientTableFilterComponent.new(tab_id: id, filter_actions: true) %>
   </div>

--- a/app/views/vaccinations/_patients_with_outcomes.html.erb
+++ b/app/views/vaccinations/_patients_with_outcomes.html.erb
@@ -1,6 +1,6 @@
 <h2 class="nhsuk-heading-s nhsuk-u-margin-0 app-visually-hidden-from-tablet"><%= caption %></h2>
 
-<action-table class="nhsuk-grid-row" sort="name">
+<action-table store="<%= id %>" class="nhsuk-grid-row" sort="name">
   <div class="nhsuk-grid-column-one-quarter">
     <%= render AppPatientTableFilterComponent.new(tab_id: id) %>
   </div>


### PR DESCRIPTION
I may have spend a good number of hours attempting to build this myself, only to find that the absolutely brilliant `action-table` component already had this feature built in, and all I needed to do was add a `store` attribute (and an `id` to identify saved filters in local storage) to the relevant `action-table`s. FML (and always RTFM).

Anyhoo… added this feature to all patient tables, and to the cohort matching table. There might be some lingering UX issues, in that it’s not immediately obvious if filters have been persisted, but we can cross that bridge when we come to it. We might want a clearer CTA to clear selected filters.