### PR TITLE
Allow SAIS team members to add vaccine batches, see existing batches

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -8,12 +8,6 @@
     max-width: auto;
   }
 
-  &__navigation-list {
-    .nhsuk-header__navigation-item:first-of-type {
-      margin-right: auto;
-    }
-  }
-
   &__button-link {
     @extend .nhsuk-header__navigation-link;
     border: none;
@@ -24,4 +18,8 @@
     text-align: left;
     cursor: pointer;
   }
+}
+
+.app-header__navigation-item--divider {
+  margin-right: auto;
 }

--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,0 +1,37 @@
+class BatchesController < ApplicationController
+  layout "two_thirds"
+
+  before_action :set_vaccine
+
+  def new
+    @batch = Batch.new(vaccine:)
+  end
+
+  def create
+    @batch = Batch.new(batch_params.merge(vaccine:))
+
+    if @batch.save
+      flash[:success] = "Batch #{@batch.name} added"
+      redirect_to vaccines_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+  attr_reader :vaccine
+
+  def set_vaccine
+    @vaccine = policy_scope(Vaccine).find(params[:vaccine_id])
+  end
+
+  def batch_params
+    params.require(:batch).permit(
+      :name,
+      :"expiry(3i)",
+      :"expiry(2i)",
+      :"expiry(1i)"
+    )
+  end
+end

--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -1,0 +1,5 @@
+class VaccinesController < ApplicationController
+  def index
+    @vaccines = policy_scope(Vaccine).order(:name)
+  end
+end

--- a/app/policies/vaccine_policy.rb
+++ b/app/policies/vaccine_policy.rb
@@ -1,0 +1,12 @@
+class VaccinePolicy
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      @scope.joins(:campaigns).where(campaigns: { team_id: @user.teams.ids })
+    end
+  end
+end

--- a/app/views/batches/new.html.erb
+++ b/app/views/batches/new.html.erb
@@ -1,0 +1,26 @@
+<% content_for :before_main do %>
+  <%= render AppBacklinkComponent.new(
+    href: vaccines_path,
+    name: "manage vaccines"
+  ) %>
+<% end %>
+
+<% page_title = "Add batch" %>
+
+<%= h1 page_title: do %>
+  <span class="nhsuk-caption-l nhsuk-u-margin-top-2">
+    <%= @batch.vaccine.brand %>
+  </span>
+  <%= page_title %>
+<% end %>
+
+<%= form_with model: @batch, url: vaccine_batches_path(@vaccine), method: :post do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%= form.govuk_text_field :name, label: { text: "Batch" }, width: 10 %>
+  <%= form.govuk_date_field :expiry,
+                            legend: { text: "Expiry date" },
+                            hint: { text: 'For example, 27 10 2025' },
+                            link_errors: true %>
+  <%= form.govuk_submit "Add batch" %>
+<% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -13,6 +13,11 @@
   <li>record vaccinations</li>
 </ul>
 
+<h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">
+  <%= link_to "Manage vaccines", vaccines_path %>
+</h2>
+<p class="nhsuk-u-margin-bottom-2">View and add batches</p>
+
 <hr>
 
 <h2 class="nhsuk-heading-m nhsuk-u-margin-bottom-1">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,6 +46,9 @@
               <%= link_to "School sessions", sessions_path, class: "nhsuk-header__navigation-link" %>
             </li>
             <li class="nhsuk-header__navigation-item">
+              <%= link_to "Manage vaccines", vaccines_path, class: "nhsuk-header__navigation-link" %>
+            </li>
+            <li class="nhsuk-header__navigation-item">
               <span class="nhsuk-header__navigation-link app-u-text-decoration-none">
                 <%= current_user.email %>
               </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
             <li class="nhsuk-header__navigation-item">
               <%= link_to "School sessions", sessions_path, class: "nhsuk-header__navigation-link" %>
             </li>
-            <li class="nhsuk-header__navigation-item">
+            <li class="nhsuk-header__navigation-item app-header__navigation-item--divider">
               <%= link_to "Manage vaccines", vaccines_path, class: "nhsuk-header__navigation-link" %>
             </li>
             <li class="nhsuk-header__navigation-item">

--- a/app/views/pilot/manage.html.erb
+++ b/app/views/pilot/manage.html.erb
@@ -1,4 +1,13 @@
-<%= h1 "Manage pilot" %>
+<% page_title = "Manage pilot" %>
+
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+    { text: 'Home', href: dashboard_path },
+    { text: page_title },
+  ]) %>
+<% end %>
+
+<%= h1 page_title, size: "xl" %>
 
 <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-1">
   <%= link_to "See who’s interested in the pilot", pilot_registrations_path %>

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -1,0 +1,33 @@
+<% page_title = "Manage vaccines" %>
+
+<%= h1 page_title, page_title:, size: "xl" %>
+
+<% @vaccines.each do |vaccine| %>
+  <%= render AppCardComponent.new(heading: "#{vaccine.brand} (#{vaccine.type})") do %>
+    <p class="govuk-body">
+      <%= link_to "Add batch", new_vaccine_batch_path(vaccine) %>
+    </p>
+
+    <% if vaccine.batches.any? %>
+      <%= govuk_table do |table| %>
+        <%= table.with_head do |head| %>
+          <%= head.with_row do |row| %>
+            <%= row.with_cell(text: "Batch") %>
+            <%= row.with_cell(text: "Entered") %>
+            <%= row.with_cell(text: "Expiry") %>
+          <% end %>
+        <% end %>
+
+        <%= table.with_body do |body| %>
+          <% vaccine.batches.order(:name).each do |batch| %>
+            <%= body.with_row do |row|
+                  row.with_cell(text: batch.name)
+                  row.with_cell(text: batch.created_at.to_fs(:nhsuk_date))
+                  row.with_cell(text: batch.expiry.to_fs(:nhsuk_date))
+                end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -1,5 +1,12 @@
 <% page_title = "Manage vaccines" %>
 
+<% content_for :before_main do %>
+  <%= render AppBreadcrumbComponent.new(items: [
+    { text: 'Home', href: dashboard_path },
+    { text: page_title },
+  ]) %>
+<% end %>
+
 <%= h1 page_title, page_title:, size: "xl" %>
 
 <% @vaccines.each do |vaccine| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -370,6 +370,12 @@ en:
             gillick_competence_notes:
               blank: Enter details of your assessment
               too_long: Enter details that are less than 1000 characters long
+        batch:
+          attributes:
+            name:
+              blank: Enter a batch
+            expiry:
+              blank: Enter an expiry date
         consent:
           attributes:
             parent_name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,10 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :vaccines, only: %i[index] do
+    resources :batches, only: %i[new create]
+  end
+
   resources :schools, only: [] do
     get "close_registration", on: :member
     post "close_registration",

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+require "rake"
+
+RSpec.feature "Manage batches", type: :feature do
+  before do
+    Rails.application.load_tasks
+    Timecop.freeze(Time.zone.local(2024, 2, 29)) # so we don't worry about expiry dates
+  end
+
+  after { Timecop.return }
+
+  scenario "Add a new batch" do
+    given_my_team_is_running_an_hpv_vaccination_campaign
+
+    when_i_manage_vaccines
+    then_i_see_an_hpv_vaccine_with_no_batches_set_up
+
+    when_i_add_a_new_batch
+    then_i_see_the_batch_i_just_added_on_the_vaccines_page
+  end
+
+  def given_my_team_is_running_an_hpv_vaccination_campaign
+    team = build(:team) # get some fake data
+
+    suppress_output do
+      Rake::Task["add_new_hpv_team"].invoke(
+        team.email,
+        team.name,
+        team.phone,
+        team.ods_code,
+        team.privacy_policy_url,
+        team.reply_to_id
+      )
+    end
+
+    created_team = Team.find_by(email: team.email)
+
+    suppress_output do
+      Rake::Task["add_new_user"].invoke(
+        "nurse.testy@example.com",
+        "nurse.testy@example.com",
+        "Nurse Testy",
+        created_team.id,
+        ""
+      )
+    end
+  end
+
+  def when_i_manage_vaccines
+    sign_in_as_nurse_testy
+
+    click_on "Manage vaccines"
+  end
+
+  def sign_in_as_nurse_testy
+    if page.current_url.present? && page.has_content?("Sign out")
+      click_on "Sign out"
+    end
+
+    visit "/dashboard"
+    fill_in "Email address", with: "nurse.testy@example.com"
+    fill_in "Password", with: "nurse.testy@example.com"
+    click_button "Sign in"
+    expect(page).to have_content("Signed in successfully.")
+  end
+
+  def then_i_see_an_hpv_vaccine_with_no_batches_set_up
+    expect(page).to have_content("Gardasil 9 (HPV)")
+    expect(page).not_to have_css("table")
+  end
+
+  def when_i_add_a_new_batch
+    click_on "Add batch"
+
+    fill_in "Batch", with: "AB1234"
+
+    # expiry date
+    fill_in "Day", with: "30"
+    fill_in "Month", with: "3"
+    fill_in "Year", with: "2024"
+
+    click_on "Add batch"
+
+    expect(page).to have_content("Batch AB1234 added")
+  end
+
+  def then_i_see_the_batch_i_just_added_on_the_vaccines_page
+    expect(page).to have_content("Gardasil 9 (HPV)")
+    expect(page).to have_css("table")
+    expect(page).to have_content(
+      [
+        "AB1234",
+        "29 February 2024", # date entered
+        "30 March 2024" # expiry
+      ].join("")
+    )
+  end
+
+  def suppress_output
+    original_stdout = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original_stdout
+  end
+end

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature "Manage batches", type: :feature do
   def when_i_manage_vaccines
     sign_in_as_nurse_testy
 
-    click_on "Manage vaccines"
+    click_on "Manage vaccines", match: :first
   end
 
   def sign_in_as_nurse_testy


### PR DESCRIPTION
## New link in the header

<img width="1008" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/03e47d9c-9370-4aea-a74a-ff524895a7ac">

## Dashboard

<img width="618" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/9e5c19e6-ed15-424d-a7de-8d2562846094">

## Manage vaccines

<img width="841" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/73007f37-51ca-41d9-a392-10d782815fb0">

## Add a batch

<img width="548" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/23af66c8-8428-4f69-9945-360cece4e888">

## Add a batch with errors

<img width="578" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/b2b54771-45f5-4069-b9ab-5102b6b943da">

## Batch added successfully

<img width="758" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/f7596260-9f33-4fdd-9bd5-e48ff3a00eb6">

## Notes for reviewers

This PR includes another experiment in the feature spec; instead of using FactoryBot to set up data, I'm calling operational Rake tasks (as this is how teams / vaccines / users are set up in production-like environments). This should hopefully mean that this feature spec is more likely to spot issues with these Rake tasks, and less prone to suffer from factory bugs. The  Rake task calls are wrapped in a method that temporarily suppresses STDOUT output, to prevent stray noise in the test runner.
