### PR TITLE
Show nurse who recorded verbal consent 

### DIFF
--- a/app/components/app_consent_response_component.rb
+++ b/app/components/app_consent_response_component.rb
@@ -56,6 +56,13 @@ class AppConsentResponseComponent < ViewComponent::Base
   end
 
   def recorded_by_link(consent:)
-    link_to(consent.parent_name, "mailto:#{consent.parent_email}")
+    if consent.respond_to?(:via_phone?) && consent.via_phone?
+      link_to(
+        consent.recorded_by.full_name,
+        "mailto:#{consent.recorded_by.email}"
+      )
+    else
+      link_to(consent.parent_name, "mailto:#{consent.parent_email}")
+    end
   end
 end

--- a/spec/components/app_consent_response_component_spec.rb
+++ b/spec/components/app_consent_response_component_spec.rb
@@ -30,9 +30,10 @@ RSpec.describe AppConsentResponseComponent, type: :component do
   end
 
   context "with consent taken over the phone" do
-    let(:consent) { create(:consent, :given, route: "phone") }
+    let(:consent) { create(:consent, :given_verbally) }
 
     it { should have_text("Consent given (phone)") }
+    it { should have_text("Test User") }
   end
 
   context "with consent_form" do

--- a/spec/factories/consents.rb
+++ b/spec/factories/consents.rb
@@ -64,6 +64,11 @@ FactoryBot.define do
       response { :given }
     end
 
+    trait :given_verbally do
+      route { "phone" }
+      recorded_by { create(:user) }
+    end
+
     trait :refused do
       response { :refused }
       reason_for_refusal { :personal_choice }


### PR DESCRIPTION
Depends on https://github.com/nhsuk/manage-childrens-vaccinations/pull/1110.

This uses the recorded_by attribute which captures the user who handled the verbal consent.

Must be deployed only after all environments have `recorded_by` populated on `Consent`.

### Before (Parent)

<img width="823" alt="Screenshot 2024-03-01 at 12 49 55" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/d7d7bd58-6c40-43fd-89b9-47c2cbfab932">

### After (Nurse Joy)

<img width="816" alt="Screenshot 2024-03-01 at 12 49 44" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/9a85428e-c5f3-4d4e-9c60-85ac3c643630">
