### PR TITLE
Manage batch defaults

### DIFF
--- a/app/controllers/batches_controller.rb
+++ b/app/controllers/batches_controller.rb
@@ -1,4 +1,6 @@
 class BatchesController < ApplicationController
+  include TodaysBatchConcern
+
   layout "two_thirds"
 
   before_action :set_vaccine
@@ -16,6 +18,16 @@ class BatchesController < ApplicationController
     else
       render :new
     end
+  end
+
+  def make_default
+    self.todays_batch_id = params[:id]
+    redirect_to vaccines_path
+  end
+
+  def remove_default
+    unset_todays_batch
+    redirect_to vaccines_path
   end
 
   private

--- a/app/controllers/concerns/todays_batch_concern.rb
+++ b/app/controllers/concerns/todays_batch_concern.rb
@@ -1,0 +1,24 @@
+module TodaysBatchConcern
+  extend ActiveSupport::Concern
+
+  def todays_batch_id
+    if session.key?(:todays_batch_id) && session.key?(:todays_batch_date)
+      if session[:todays_batch_date] == Time.zone.today.iso8601
+        session[:todays_batch_id]
+      else
+        unset_todays_batch
+        nil
+      end
+    end
+  end
+
+  def todays_batch_id=(batch_id)
+    session[:todays_batch_id] = batch_id
+    session[:todays_batch_date] = Time.zone.today.iso8601
+  end
+
+  def unset_todays_batch
+    session.delete(:todays_batch_id)
+    session.delete(:todays_batch_date)
+  end
+end

--- a/app/controllers/concerns/todays_batch_concern.rb
+++ b/app/controllers/concerns/todays_batch_concern.rb
@@ -4,7 +4,7 @@ module TodaysBatchConcern
   def todays_batch_id
     if session.key?(:todays_batch_id) && session.key?(:todays_batch_date)
       if session[:todays_batch_date] == Time.zone.today.iso8601
-        session[:todays_batch_id]
+        session[:todays_batch_id].to_i
       else
         unset_todays_batch
         nil

--- a/app/controllers/vaccinations/batches_controller.rb
+++ b/app/controllers/vaccinations/batches_controller.rb
@@ -1,4 +1,6 @@
 class Vaccinations::BatchesController < ApplicationController
+  include TodaysBatchConcern
+
   before_action :set_session, only: %i[edit update]
   before_action :set_patient, only: %i[edit update]
   before_action :set_patient_session, only: %i[edit update]
@@ -56,11 +58,7 @@ class Vaccinations::BatchesController < ApplicationController
          vaccination_record_batch_params[:batch_id].in?(
            params[:vaccination_record][:todays_batch]
          )
-      session[:todays_batch_id] = vaccination_record_batch_params[:batch_id]
-      session[:todays_batch_date] = Time.zone.now.to_date
-    elsif session.key?(:todays_batch_date) != Time.zone.now.to_date.to_s
-      session.delete(:todays_batch_id)
-      session.delete(:todays_batch_date)
+      self.todays_batch_id = vaccination_record_batch_params[:batch_id]
     end
   end
 

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -1,4 +1,6 @@
 class VaccinationsController < ApplicationController
+  include TodaysBatchConcern
+
   before_action :set_session
   before_action :set_patient, except: %i[index record_template]
   before_action :set_patient_sessions, only: %i[index record_template]
@@ -223,10 +225,7 @@ class VaccinationsController < ApplicationController
   end
 
   def set_todays_batch_id
-    if session.key?(:todays_batch_id) && session.key?(:todays_batch_date) &&
-         session[:todays_batch_date] == Time.zone.now.to_date.to_s
-      @todays_batch_id = session[:todays_batch_id]
-    end
+    @todays_batch_id = todays_batch_id
   end
 
   def confirm_params

--- a/app/controllers/vaccines_controller.rb
+++ b/app/controllers/vaccines_controller.rb
@@ -1,5 +1,8 @@
 class VaccinesController < ApplicationController
+  include TodaysBatchConcern
+
   def index
     @vaccines = policy_scope(Vaccine).order(:name)
+    @todays_batch_id = todays_batch_id
   end
 end

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -22,16 +22,36 @@
             <%= row.with_cell(text: "Batch") %>
             <%= row.with_cell(text: "Entered") %>
             <%= row.with_cell(text: "Expiry") %>
+            <%= row.with_cell(text: "Default") %>
           <% end %>
         <% end %>
 
         <%= table.with_body do |body| %>
           <% vaccine.batches.order(:name).each do |batch| %>
-            <%= body.with_row do |row|
-                  row.with_cell(text: batch.name)
-                  row.with_cell(text: batch.created_at.to_fs(:nhsuk_date))
-                  row.with_cell(text: batch.expiry.to_fs(:nhsuk_date))
-                end %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: batch.name) do %>
+                <%= batch.name %>
+                <% if batch.id == @todays_batch_id %>
+                  <br>
+                  <span class="govuk-caption-m">
+                    (Your default)
+                  </span>
+                <% end %>
+              <% end %>
+              <% row.with_cell(text: batch.created_at.to_fs(:nhsuk_date)) %>
+              <% row.with_cell(text: batch.expiry.to_fs(:nhsuk_date)) %>
+              <% row.with_cell do %>
+                <% if batch.id == @todays_batch_id %>
+                  <%= form_tag remove_default_vaccine_batch_path(batch, vaccine_id: batch.vaccine.id), method: :post do %>
+                    <%= submit_tag "Remove default", class: "govuk-link" %>
+                  <% end %>
+                <% else %>
+                  <%= form_tag make_default_vaccine_batch_path(batch, vaccine_id: batch.vaccine.id), method: :post do %>
+                    <%= submit_tag "Make default", class: "govuk-link" %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,7 +117,10 @@ Rails.application.routes.draw do
   end
 
   resources :vaccines, only: %i[index] do
-    resources :batches, only: %i[new create]
+    resources :batches, only: %i[new create] do
+      post "make-default", on: :member, as: :make_default
+      post "remove-default", on: :member, as: :remove_default
+    end
   end
 
   resources :schools, only: [] do

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -43,7 +43,10 @@ FactoryBot.define do
     end
 
     after :create do |session, context|
-      create_list :patient, context.patients_in_session, sessions: [session]
+      create_list :patient,
+                  context.patients_in_session,
+                  sessions: [session],
+                  location: session.location
     end
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
         create(:user, **options)
       end
     end
+
+    trait :with_one_location do
+      after(:create) { |team| create(:location, team:) }
+    end
   end
 end

--- a/spec/features/manage_batches_spec.rb
+++ b/spec/features/manage_batches_spec.rb
@@ -6,17 +6,36 @@ RSpec.describe "Manage batches" do
 
   scenario "Add a new batch" do
     given_my_team_is_running_an_hpv_vaccination_campaign
+    and_there_is_a_vaccination_session_today_at_one_of_my_teams_schools
 
     when_i_manage_vaccines
     then_i_see_an_hpv_vaccine_with_no_batches_set_up
 
     when_i_add_a_new_batch
     then_i_see_the_batch_i_just_added_on_the_vaccines_page
+
+    when_i_set_the_batch_as_default
+    and_i_start_vaccinating_a_patient
+    then_i_am_not_asked_to_select_a_batch
+    and_the_batch_is_recorded_against_the_patient
   end
 
   def given_my_team_is_running_an_hpv_vaccination_campaign
-    @team = create(:team, :with_one_nurse)
-    create(:campaign, :hpv_no_batches, team: @team)
+    @team = create(:team, :with_one_nurse, :with_one_location)
+    @campaign = create(:campaign, :hpv_no_batches, team: @team)
+  end
+
+  def and_there_is_a_vaccination_session_today_at_one_of_my_teams_schools
+    session =
+      create(
+        :session,
+        :in_progress,
+        campaign: @campaign,
+        location: @team.locations.first,
+        patients_in_session: 1
+      )
+
+    @patient = session.patients.first
   end
 
   def when_i_manage_vaccines
@@ -49,12 +68,69 @@ RSpec.describe "Manage batches" do
   def then_i_see_the_batch_i_just_added_on_the_vaccines_page
     expect(page).to have_content("Gardasil 9 (HPV)")
     expect(page).to have_css("table")
-    expect(page).to have_content(
-      [
-        "AB1234",
-        "29 February 2024", # date entered
-        "30 March 2024" # expiry
-      ].join("")
-    )
+    expect(page).to have_content("AB1234 29 February 202430 March 2024")
+  end
+
+  def when_i_set_the_batch_as_default
+    click_on "Make default"
+  end
+
+  def and_i_start_vaccinating_a_patient
+    click_on "School sessions", match: :first
+    click_on @team.locations.first.name
+    click_on "Record vaccinations"
+
+    # patient is in the "get consent state" so need to get to the vaccination state
+    record_self_consent
+
+    click_on @patient.full_name
+    choose "Yes, they got the HPV vaccine"
+    choose "Left arm (upper position)"
+
+    click_on "Continue"
+  end
+
+  def record_self_consent
+    click_on @patient.full_name
+
+    click_on "Assess Gillick competence"
+    click_on "Give your assessment"
+
+    choose "Yes, they are Gillick competent"
+
+    fill_in "Give details of your assessment",
+            with: "They understand the benefits and risks of the vaccine"
+    click_on "Continue"
+
+    # record consent
+    choose "Yes, they agree"
+    click_on "Continue"
+
+    # answer the health questions
+    all("label", text: "No").each(&:click)
+    choose "Yes, it’s safe to vaccinate"
+    click_on "Continue"
+
+    # confirmation page
+    click_on "Confirm"
+
+    expect(page).to have_content("Record vaccinations")
+  end
+
+  def then_i_am_not_asked_to_select_a_batch
+    expect(page).not_to have_content("Which batch did you use?")
+    expect(page).to have_content("Check and confirm")
+    expect(page).to have_content("AB1234")
+
+    click_on "Confirm"
+  end
+
+  def and_the_batch_is_recorded_against_the_patient
+    expect(page).to have_content("Record saved for #{@patient.full_name}")
+
+    click_on "View child record"
+
+    expect(page).to have_content("Vaccinated")
+    expect(page).to have_content("HPV (Gardasil 9, AB1234)")
   end
 end


### PR DESCRIPTION
## No default set

<img width="990" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/c527b1ab-a394-4d62-a95c-fc6f0c4e494b">

## A default is set

<img width="1011" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/51d2dba3-089a-42c1-9fd8-07cc02003ff7">

## Notes for review

PR is best reviewed commit-by-commit.

I ran out of time to fix the following (will be sorted in subsequent PRs):

* The included spec doesn't cover removing a default.
* There's overlap between `manage_batches_spec.rb` and `vaccination_default_batch.spec.ts` (probably resolved by consolidating into RSpec land)
* The factories don't make it obviously straightforward to create a patient in a session who is ready to vaccinate. This requires the spec to go through self-consent to get the patient into the right state.
* The "set default" and "remove default" should look like links but they currently don't have the right styling.