### PR TITLE
Prevent users from double-tapping on stand-alone buttons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,9 @@ gem "flipper"
 gem "flipper-active_record"
 gem "flipper-ui"
 gem "good_job"
-gem "govuk-components"
+gem "govuk-components",
+    github: "misaka/govuk-components",
+    branch: "add-data-module-to-buttons"
 gem "govuk_design_system_formbuilder"
 gem "govuk_markdown"
 gem "jbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,16 @@ GIT
     faker (3.2.0)
       i18n (>= 1.8.11, < 2)
 
+GIT
+  remote: https://github.com/misaka/govuk-components.git
+  revision: 56d592fef1cb18aa0b330c99ae482d6791d51c19
+  branch: add-data-module-to-buttons
+  specs:
+    govuk-components (5.2.1)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (~> 6.0)
+      view_component (>= 3.9, < 3.11)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -159,8 +169,7 @@ GEM
     diff-lcs (1.5.1)
     dockerfile-rails (1.6.5)
       rails (>= 3.0.0)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     dry-configurable (1.1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
@@ -230,10 +239,6 @@ GEM
       fugit (>= 1.1)
       railties (>= 6.0.0)
       thor (>= 0.14.1)
-    govuk-components (5.2.1)
-      html-attributes-utils (~> 1.0.0, >= 1.0.0)
-      pagy (~> 6.0)
-      view_component (>= 3.9, < 3.11)
     govuk_design_system_formbuilder (5.2.0)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -464,7 +469,6 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     sanitize (6.1.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -576,7 +580,7 @@ DEPENDENCIES
   flipper-active_record
   flipper-ui
   good_job
-  govuk-components
+  govuk-components!
   govuk_design_system_formbuilder
   govuk_markdown
   jbuilder

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -10,8 +10,8 @@ application.register("check-all", CheckAllController);
 import GovukAccordionController from "./govuk_accordion_controller";
 application.register("govuk-accordion", GovukAccordionController);
 
-import GovukButtonController from "./govuk_button_controller";
-application.register("govuk-button", GovukButtonController);
+import NhsukButtonController from "./nhsuk_button_controller";
+application.register("nhsuk-button", NhsukButtonController);
 
 import GovukCharacterCountController from "./govuk_character_count_controller";
 application.register("govuk-character-count", GovukCharacterCountController);

--- a/app/javascript/controllers/nhsuk_button_controller.js
+++ b/app/javascript/controllers/nhsuk_button_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { Button } from "govuk-frontend";
 
-// Connects to data-module="govuk-button"
+// Connects to data-module="nhsuk-button"
 export default class extends Controller {
   connect() {
     new Button(this.element).init();

--- a/app/views/edit_sessions/confirm.html.erb
+++ b/app/views/edit_sessions/confirm.html.erb
@@ -17,4 +17,7 @@
   <% end %>
 <% end %>
 
-<%= govuk_button_to "Confirm", wizard_path, method: :put %>
+<%= govuk_button_to "Confirm",
+                    wizard_path,
+                    method: :put,
+                    prevent_double_click: true %>

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -46,4 +46,4 @@
   <% end %>
 <% end %>
 
-<%= govuk_button_to "Confirm", wizard_path, method: :put %>
+<%= govuk_button_to "Confirm", wizard_path, method: :put, prevent_double_click: true %>

--- a/app/views/parent_interface/consent_forms/confirm.html.erb
+++ b/app/views/parent_interface/consent_forms/confirm.html.erb
@@ -208,4 +208,7 @@ end %>
   <% end %>
 <% end %>
 
-<%= govuk_button_to "Confirm", url_for(action: :record), method: :put %>
+<%= govuk_button_to "Confirm",
+                    url_for(action: :record),
+                    method: :put,
+                    prevent_double_click: true %>

--- a/app/views/sessions/show.html.erb
+++ b/app/views/sessions/show.html.erb
@@ -80,7 +80,8 @@
         "Set session in progress for today",
         make_in_progress_session_path,
         method: :put,
-        secondary: true
+        secondary: true,
+        prevent_double_click: true
       ) %>
     <% end %>
   <% end %>


### PR DESCRIPTION
We've confirmed that double-tapping these stand-alone buttons cause errors to show, even if the actual action is performed. Usually the first POST/PUT works, but the subsequent one is the one that error and that the user sees.

This change relies on https://github.com/x-govuk/govuk-components/pull/513 being accepted and merged (which seems imminent), and released. Until then we are using the fork I created get the functionality now.