### PR TITLE
Before vaccination, open the health questions if there are notes

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -16,7 +16,8 @@ class AppConsentComponent < ViewComponent::Base
   end
 
   def open_health_questions?
-    @patient_session.next_step == :triage
+    @patient_session.consents.any?(&:health_answers_require_follow_up?) &&
+      @patient_session.vaccination_records.administered.none?
   end
 
   def display_gillick_consent_button?

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -37,6 +37,8 @@ class VaccinationRecord < ApplicationRecord
   belongs_to :user
   has_one :vaccine, through: :batch
 
+  scope :administered, -> { where(administered: true) }
+
   enum :delivery_method, %w[intramuscular subcutaneous], prefix: true
   enum :delivery_site,
        %w[

--- a/spec/components/app_consent_component_spec.rb
+++ b/spec/components/app_consent_component_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe AppConsentComponent, type: :component do
     it { should_not have_css("a", text: "Contact #{consent.parent_name}") }
     it { should have_css("details", text: "Responses to health questions") }
 
-    it "does not open the health questions details" do
+    it "does not open the health questions details (as there are no notes in the health questions)" do
       should have_css "details:not([open])",
                       text: "Responses to health questions"
     end
@@ -91,9 +91,8 @@ RSpec.describe AppConsentComponent, type: :component do
     let(:summary) { "Consent given by #{consent.parent_name} (#{relation})" }
     it { should have_css("details[open]", text: summary) }
 
-    it "does not open the health questions details" do
-      should have_css "details:not([open])",
-                      text: "Responses to health questions"
+    it "opens the health questions details (because there are notes in the health questions)" do
+      should have_css "details[open]", text: "Responses to health questions"
     end
   end
 
@@ -103,7 +102,7 @@ RSpec.describe AppConsentComponent, type: :component do
     let(:summary) { "Consent given by #{consent.parent_name} (#{relation})" }
     it { should have_css("details:not([open])", text: summary) }
 
-    it "does not open the health questions details" do
+    it "doesn't open the health questions details (because there are notes in the health questions)" do
       should have_css "details:not([open])",
                       text: "Responses to health questions"
     end
@@ -117,9 +116,8 @@ RSpec.describe AppConsentComponent, type: :component do
     let(:summary) { "Consent given by #{consent.parent_name} (#{relation})" }
     it { should have_css("details:not([open])", text: summary) }
 
-    it "does not open the health questions details" do
-      should have_css "details:not([open])",
-                      text: "Responses to health questions"
+    it "opens the health questions details (because there are notes in the health questions)" do
+      should have_css "details[open]", text: "Responses to health questions"
     end
   end
 end

--- a/tests/vaccination.spec.ts
+++ b/tests/vaccination.spec.ts
@@ -13,9 +13,6 @@ test("Vaccination", async ({ page }) => {
   await then_i_see_the_vaccination_page();
   await then_i_see_the_responses_to_health_questions();
 
-  await when_i_click_on_the_responses();
-  await then_i_should_see_health_question_responses();
-
   // Successful vaccination
   await when_i_record_a_vaccination();
   await then_i_should_see_the_select_batch_page();
@@ -70,13 +67,7 @@ async function then_i_see_the_responses_to_health_questions() {
   await expect(
     p.locator(".nhsuk-card", { hasText: "Consent given by" }),
   ).toHaveText(/Responses to health questions/);
-}
 
-async function when_i_click_on_the_responses() {
-  await p.getByText("Responses to health questions").click();
-}
-
-async function then_i_should_see_health_question_responses() {
   await expect(
     p.locator("dt", { hasText: "Does the child have any severe allergies" }),
   ).toBeVisible();


### PR DESCRIPTION
As they're ultimately the responsible clinician, vaccinators will often double check what notes the parents left as part of a light-touch triage just before vaccination, even if triage has already been done.

To support this, we should "unfold" the health questions whenever there are notes, before vaccination. If this isn't the case, vaccinators would have to manually open every patient's health questions to see if there are any notes there or not.