### PR TITLE
Prevent crash on patient page after conflicting consent

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -214,12 +214,6 @@ class ConsentForm < ApplicationRecord
     ].compact
   end
 
-  def form_steps_for_health_questions
-    return [] unless consent_given?
-
-    health_answers.map.with_index { |_args, idx| :"health_#{idx + 1}" }
-  end
-
   def each_health_answer
     return if health_answers.empty?
     return to_enum(:each_health_answer) unless block_given?

--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -47,6 +47,8 @@ class ConsentForm < ApplicationRecord
   include WizardFormConcern
   include AgeConcern
 
+  before_save :remove_health_questions_if_consent_refused
+
   scope :unmatched, -> { where(consent_id: nil) }
   scope :recorded, -> { where.not(recorded_at: nil) }
 
@@ -330,5 +332,10 @@ class ConsentForm < ApplicationRecord
 
   def ask_for_contact_method?
     Flipper.enabled?(:parent_contact_method) && parent_phone.present?
+  end
+
+  def remove_health_questions_if_consent_refused
+    return unless consent_refused? || health_answers.empty?
+    self.health_answers = []
   end
 end

--- a/app/models/health_answer.rb
+++ b/app/models/health_answer.rb
@@ -50,7 +50,7 @@ class HealthAnswer
 
   class ArraySerializer
     def self.load(arr)
-      return [] if arr.nil?
+      return if arr.nil?
       arr.map.with_index { |(item), idx| HealthAnswer.new(item.merge(id: idx)) }
     end
 

--- a/spec/factories/consent_forms.rb
+++ b/spec/factories/consent_forms.rb
@@ -84,16 +84,19 @@ FactoryBot.define do
             id: 0,
             question:
               "Does the child have any severe allergies that have led to an anaphylactic reaction?",
-            next_question: 1
+            next_question: 1,
+            response: "no"
           ),
           HealthAnswer.new(
             id: 1,
             question: "Does the child have any existing medical conditions?",
-            next_question: 2
+            next_question: 2,
+            response: "no"
           ),
           HealthAnswer.new(
             id: 2,
-            question: "Does the child take any regular medication?"
+            question: "Does the child take any regular medication?",
+            response: "no"
           )
         ]
       end
@@ -106,17 +109,21 @@ FactoryBot.define do
             id: 0,
             question: "Has your child been diagnosed with asthma?",
             next_question: 2,
-            follow_up_question: 1
+            follow_up_question: 1,
+            response: "yes",
+            notes: "Notes"
           ),
           HealthAnswer.new(
             id: 1,
             question: "Have they taken oral steroids in the last 2 weeks?",
-            next_question: 2
+            next_question: 2,
+            response: "no"
           ),
           HealthAnswer.new(
             id: 2,
             question:
-              "Has your child had a flu vaccination in the last 5 months?"
+              "Has your child had a flu vaccination in the last 5 months?",
+            response: "no"
           )
         ]
       end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -727,4 +727,24 @@ RSpec.describe ConsentForm, type: :model do
       it { is_expected.to eq patients.first }
     end
   end
+
+  it "removes the health questions when the parent refuses consent" do
+    consent_form =
+      create(:consent_form, :with_health_answers_no_branching, response: nil)
+
+    consent_form.update!(response: "refused", reason: "personal_choice")
+    consent_form.reload
+
+    expect(consent_form.health_answers).to be_empty
+  end
+
+  it "leaves the health questions when the parent gives consent" do
+    consent_form =
+      create(:consent_form, :with_health_answers_no_branching, response: nil)
+
+    consent_form.update!(response: "given")
+    consent_form.reload
+
+    expect(consent_form.health_answers).not_to be_empty
+  end
 end


### PR DESCRIPTION
## Problem

The patient page in Mavis crashes when:
* two different parents give conflicting consent, and
* the consenting parent leaves notes.

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/1763319a-61bd-49c8-b4a3-4875ea61fc84)

## Investigation

Prior to this PR, because that parent never provides any health answers, "refused consent" forms had invalid health answers: where the question is present but a response is `nil`.

This had a knock-on effect on `AppHealthQuestionsComponent` which crashed if two different parents happened to give conflicting consent. This manifested itself as an exception when a nurse tried to view the child's page after the conflicting consent responses.

## Proposed solution

The proposed solution is to add a `before_save` action on `ConsentForm` which sets `health_answers = []` as soon as consent is refused.

This fix exposed another, unrelated issue, which manifested itself as a `ActiveRecord::NotNullViolation` exception when trying to save a `ConsentForm` with `health_answers = []`. This bug was tracked down to the serialisation logic within HealthAnswer and also fixed as part of this commit.