### PR TITLE
Remove production checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,10 +52,7 @@ COPY --link . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 \
-    MAVIS__GOVUK_NOTIFY__API_KEY=1 \
-  ./bin/rails assets:precompile
-
+RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN bundle exec bootsnap precompile app/ lib/
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 \
     MAVIS__GOVUK_NOTIFY__API_KEY=1 \
-    SKIP_PRODUCTION_CHECKS=1 \
   ./bin/rails assets:precompile
 
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,7 +115,7 @@ Rails.application.configure do
   }
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
-    api_key: Settings.govuk_notify.api_key
+    api_key: Settings.govuk_notify&.api_key
   }
 
   config.good_job.enable_cron = true

--- a/config/initializers/check_production.rb
+++ b/config/initializers/check_production.rb
@@ -1,5 +1,0 @@
-if Rails.env.production? && ENV["SKIP_PRODUCTION_CHECKS"].blank? &&
-     ENV.fetch("SENTRY_DSN", "").blank?
-  raise "Application is running in production mode but SENTRY_DSN is not set
-    up. Please set up Sentry."
-end


### PR DESCRIPTION
We're running in production now and it feels unlikely that we'd ship an environment without Sentry setup given that we use the same IAAS templates for everything.

Second commit allows RAILS_ENV=production without a Notify key being set, making it easier to test it locally. This is slightly more controversial as you can argue that it's better if the app refuses to boot up if Notify isn't set, but same logic as the SENTRY_DSN; I think we're protecting from a fairly low risk...