### PR TITLE
Request feedback form parents after verbal consent

### DIFF
--- a/app/controllers/concerns/triage_mailer_concern.rb
+++ b/app/controllers/concerns/triage_mailer_concern.rb
@@ -2,12 +2,13 @@ module TriageMailerConcern
   extend ActiveSupport::Concern
 
   def send_triage_mail(patient_session, consent = nil)
+    session = patient_session.session
+
     if send_vaccination_will_happen_email?(patient_session, consent)
       TriageMailer.vaccination_will_happen(patient_session).deliver_later
     elsif send_vaccination_wont_happen_email?(patient_session, consent)
       TriageMailer.vaccination_wont_happen(patient_session).deliver_later
     elsif consent
-      session = patient_session.session
       if consent&.response_refused?
         ConsentFormMailer.confirmation_refused(consent:, session:).deliver_later
       elsif consent.triage_needed?
@@ -18,6 +19,12 @@ module TriageMailerConcern
       else
         ConsentFormMailer.confirmation(consent:, session:).deliver_later
       end
+    end
+
+    if consent.present?
+      ConsentFormMailer.give_feedback(consent:, session:).deliver_later(
+        wait: 1.hour
+      )
     end
   end
 

--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -55,7 +55,8 @@ class ConsentFormMailer < ApplicationMailer
   end
 
   def survey_deadline_date
-    return unless @consent_form
-    (@consent_form.recorded_at + 7.days).to_fs(:nhsuk_date)
+    recorded_at = @consent_form&.recorded_at || @consent.recorded_at
+
+    (recorded_at + 7.days).to_fs(:nhsuk_date)
   end
 end

--- a/spec/controllers/concerns/triage_mailer_concern_spec.rb
+++ b/spec/controllers/concerns/triage_mailer_concern_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe TriageMailerConcern do
             patient_session
           )
         end
+
+        it "doesn't send a feedback email" do
+          expect(ConsentFormMailer).not_to have_received(:give_feedback)
+        end
       end
 
       context "when the parents agree, triage is required but it isn't safe to vaccinate" do
@@ -98,6 +102,14 @@ RSpec.describe TriageMailerConcern do
           expect(TriageMailer).to have_received(:vaccination_will_happen).with(
             patient_session
           )
+        end
+
+        it "sends a feedback email" do
+          expect(ConsentFormMailer).to have_received(:give_feedback).with(
+            consent:,
+            session: patient_session.session
+          )
+          expect(mail).to have_received(:deliver_later).with(wait: 1.hour)
         end
       end
 

--- a/spec/features/verbal_consent_given_needs_triage_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_needs_triage_do_not_vaccinate_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Verbal consent" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_do_not_vaccinate
     and_the_will_not_vaccinate_email_is_sent_to_the_parent
+    and_an_email_is_sent_to_the_parent_to_give_feedback
   end
 
   def given_i_am_signed_in
@@ -69,10 +70,21 @@ RSpec.describe "Verbal consent" do
 
   def and_the_will_not_vaccinate_email_is_sent_to_the_parent
     perform_enqueued_jobs
-    email = ActionMailer::Base.deliveries.last
+
+    email = ActionMailer::Base.deliveries.first
     expect(email.to).to eq [@patient.parent_email]
     expect(
       email[:template_id].value
     ).to eq "d1faf47e-ccc3-4481-975b-1ec34211a21f"
+  end
+
+  def and_an_email_is_sent_to_the_parent_to_give_feedback
+    perform_enqueued_jobs
+
+    email = ActionMailer::Base.deliveries.second
+    expect(email.to).to eq [@patient.parent_email]
+    expect(
+      email[:template_id].value
+    ).to eq "1250c83b-2a5a-4456-8922-657946eba1fd"
   end
 end

--- a/spec/features/verbal_consent_given_needs_triage_kept_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_needs_triage_kept_in_triage_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Verbal consent" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_needs_triage
     and_the_kept_in_triage_email_is_sent_to_the_parent
+    and_an_email_is_sent_to_the_parent_to_give_feedback
   end
 
   def given_i_am_signed_in
@@ -69,10 +70,21 @@ RSpec.describe "Verbal consent" do
 
   def and_the_kept_in_triage_email_is_sent_to_the_parent
     perform_enqueued_jobs
-    email = ActionMailer::Base.deliveries.last
+
+    email = ActionMailer::Base.deliveries.first
     expect(email.to).to eq [@patient.parent_email]
     expect(
       email[:template_id].value
     ).to eq "604ee667-c996-471e-b986-79ab98d0767c"
+  end
+
+  def and_an_email_is_sent_to_the_parent_to_give_feedback
+    perform_enqueued_jobs
+
+    email = ActionMailer::Base.deliveries.second
+    expect(email.to).to eq [@patient.parent_email]
+    expect(
+      email[:template_id].value
+    ).to eq "1250c83b-2a5a-4456-8922-657946eba1fd"
   end
 end

--- a/spec/features/verbal_consent_given_needs_triage_ready_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_needs_triage_ready_to_vaccinate_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Verbal consent" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_safe_to_vaccinate
     and_the_kept_in_triage_email_is_sent_to_the_parent
+    and_an_email_is_sent_to_the_parent_to_give_feedback
   end
 
   def given_i_am_signed_in
@@ -69,10 +70,20 @@ RSpec.describe "Verbal consent" do
 
   def and_the_kept_in_triage_email_is_sent_to_the_parent
     perform_enqueued_jobs
-    email = ActionMailer::Base.deliveries.last
+    email = ActionMailer::Base.deliveries.first
     expect(email.to).to eq [@patient.parent_email]
     expect(
       email[:template_id].value
     ).to eq "fa3c8dd5-4688-4b93-960a-1d422c4e5597"
+  end
+
+  def and_an_email_is_sent_to_the_parent_to_give_feedback
+    perform_enqueued_jobs
+
+    email = ActionMailer::Base.deliveries.second
+    expect(email.to).to eq [@patient.parent_email]
+    expect(
+      email[:template_id].value
+    ).to eq "1250c83b-2a5a-4456-8922-657946eba1fd"
   end
 end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Verbal consent" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_do_not_vaccinate
     and_an_email_is_sent_to_the_parent_confirming_the_vaccination
+    and_an_email_is_sent_to_the_parent_to_give_feedback
   end
 
   def given_i_am_signed_in
@@ -67,10 +68,21 @@ RSpec.describe "Verbal consent" do
 
   def and_an_email_is_sent_to_the_parent_confirming_the_vaccination
     perform_enqueued_jobs
-    email = ActionMailer::Base.deliveries.last
+
+    email = ActionMailer::Base.deliveries.first
     expect(email.to).to eq [@patient.parent_email]
     expect(
       email[:template_id].value
     ).to eq "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73"
+  end
+
+  def and_an_email_is_sent_to_the_parent_to_give_feedback
+    perform_enqueued_jobs
+
+    email = ActionMailer::Base.deliveries.second
+    expect(email.to).to eq [@patient.parent_email]
+    expect(
+      email[:template_id].value
+    ).to eq "1250c83b-2a5a-4456-8922-657946eba1fd"
   end
 end

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Verbal consent" do
     when_i_go_to_the_patient
     then_i_see_that_the_status_is_do_not_vaccinate
     and_an_email_is_sent_to_the_parent_confirming_the_refusal
+    and_an_email_is_sent_to_the_parent_to_give_feedback
   end
 
   def given_i_am_signed_in
@@ -71,10 +72,21 @@ RSpec.describe "Verbal consent" do
 
   def and_an_email_is_sent_to_the_parent_confirming_the_refusal
     perform_enqueued_jobs
-    email = ActionMailer::Base.deliveries.last
+
+    email = ActionMailer::Base.deliveries.first
     expect(email.to).to eq [@patient.parent_email]
     expect(
       email[:template_id].value
     ).to eq "5a676dac-3385-49e4-98c2-fc6b45b5a851"
+  end
+
+  def and_an_email_is_sent_to_the_parent_to_give_feedback
+    perform_enqueued_jobs
+
+    email = ActionMailer::Base.deliveries.second
+    expect(email.to).to eq [@patient.parent_email]
+    expect(
+      email[:template_id].value
+    ).to eq "1250c83b-2a5a-4456-8922-657946eba1fd"
   end
 end

--- a/spec/mailers/consent_form_mailer_spec.rb
+++ b/spec/mailers/consent_form_mailer_spec.rb
@@ -22,15 +22,29 @@ RSpec.describe ConsentFormMailer, type: :mailer do
   end
 
   describe "#give_feedback" do
-    it "calls template_mail with correct survey_deadline_date" do
-      mail =
-        described_class.give_feedback(
-          consent_form: build(:consent_form, recorded_at: Date.new(2021, 1, 1))
-        )
+    context "with a consent form" do
+      it "calls template_mail with correct survey_deadline_date" do
+        consent_form = build(:consent_form, recorded_at: Date.new(2021, 1, 1))
+        mail = described_class.give_feedback(consent_form:)
 
-      expect(mail.message.header["personalisation"].unparsed_value).to include(
-        survey_deadline_date: "8 January 2021"
-      )
+        expect(
+          mail.message.header["personalisation"].unparsed_value
+        ).to include(survey_deadline_date: "8 January 2021")
+      end
+    end
+
+    context "with a consent record" do
+      it "calls template_mail with correct survey_deadline_date" do
+        patient_session = build :patient_session
+        session = patient_session.session
+        consent =
+          build(:consent, recorded_at: Date.new(2021, 1, 1), patient_session:)
+        mail = described_class.give_feedback(consent:, session:)
+
+        expect(
+          mail.message.header["personalisation"].unparsed_value
+        ).to include(survey_deadline_date: "8 January 2021")
+      end
     end
   end
 end


### PR DESCRIPTION
We normally request feedback after they fill in the consent form, but for those parents who need to be contacted during the session to get feedback, we need to trigger sending them a request for feedback separately.

This has been manually tested to check the personalisations match what GOVUK is looking for:

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/15608/93e310c2-25e7-4ee5-9998-9099af4c7810)
