### PR TITLE
Show the preferred name in consent, triage, record and matching patient lists

### DIFF
--- a/app/components/app_patient_table_component.rb
+++ b/app/components/app_patient_table_component.rb
@@ -36,7 +36,7 @@ class AppPatientTableComponent < ViewComponent::Base
   def column_value(patient_session, column)
     case column
     when :name
-      { text: patient_link(patient_session) }
+      { text: name_cell(patient_session) }
     when :dob
       {
         text:
@@ -64,6 +64,21 @@ class AppPatientTableComponent < ViewComponent::Base
     else
       raise ArgumentError, "Unknown column: #{column}"
     end
+  end
+
+  def name_cell(patient_session)
+    safe_join(
+      [
+        patient_link(patient_session),
+        (
+          if patient_session.patient.common_name.present?
+            "<span class=\"nhsuk-u-font-size-16\">Known as: ".html_safe +
+              patient_session.patient.common_name + "</span>".html_safe
+          end
+        )
+      ].compact,
+      tag.br
+    )
   end
 
   def patient_link(patient_session)

--- a/app/controllers/component_previews_controller.rb
+++ b/app/controllers/component_previews_controller.rb
@@ -1,0 +1,14 @@
+class ComponentPreviewsController < ApplicationController
+  include ViewComponent::PreviewActions
+  skip_before_action :authenticate_user!
+  skip_after_action :verify_policy_scoped
+
+  around_action :wrap_in_rollbackable_transaction
+
+  def wrap_in_rollbackable_transaction
+    ActiveRecord::Base.transaction do
+      yield
+      raise ActiveRecord::Rollback
+    end
+  end
+end

--- a/app/controllers/component_previews_controller.rb
+++ b/app/controllers/component_previews_controller.rb
@@ -4,11 +4,16 @@ class ComponentPreviewsController < ApplicationController
   skip_after_action :verify_policy_scoped
 
   around_action :wrap_in_rollbackable_transaction
+  before_action :set_up_faker_locale
 
   def wrap_in_rollbackable_transaction
     ActiveRecord::Base.transaction do
       yield
       raise ActiveRecord::Rollback
     end
+  end
+
+  def set_up_faker_locale
+    Faker::Config.locale = "en-GB"
   end
 end

--- a/app/views/vaccinations/_patient_row.html.erb
+++ b/app/views/vaccinations/_patient_row.html.erb
@@ -3,6 +3,10 @@
     <%= link_to patient_session.patient.full_name,
                 session_patient_vaccinations_path(patient_session.session, patient_session.patient),
       "data-testid": "child-link" %>
+    <% if patient_session.patient.common_name.present? %>
+      <br>
+      <span class="nhsuk-u-font-size-16">Known as: <%= patient_session.patient.common_name %></span>
+    <% end %>
   </td>
   <td class="nhsuk-table__cell" style="width: 150px" data-filter="<%= patient_session.patient.date_of_birth.strftime("%d/%m/%Y") %>" data-sort="<%= patient_session.patient.date_of_birth %>">
     <%= patient_session.patient.date_of_birth.to_fs(:nhsuk_date_short_month) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,5 +66,6 @@ module ManageVaccinations
       .join("spec/components/previews")
       .to_s
     config.view_component.default_preview_layout = "component_preview"
+    config.view_component.preview_controller = "ComponentPreviewsController"
   end
 end

--- a/spec/components/app_patient_table_component_spec.rb
+++ b/spec/components/app_patient_table_component_spec.rb
@@ -28,6 +28,22 @@ RSpec.describe AppPatientTableComponent, type: :component do
   it { should have_column("Date of birth") }
   it { should have_css(".nhsuk-table__head .nhsuk-table__row", count: 1) }
 
+  it "includes the patient's full name" do
+    expect(page).to have_text(patient_sessions.first.patient.full_name)
+  end
+
+  describe "when the patient has a common name" do
+    let(:patient_sessions) do
+      create_list(:patient_session, 2).tap do |ps|
+        ps.first.patient.update!(common_name: "Bobby")
+      end
+    end
+
+    it "includes the patient's common name" do
+      expect(page).to have_text("Bobby")
+    end
+  end
+
   it { should have_css(".nhsuk-table__body") }
   it { should have_css(".nhsuk-table__body .nhsuk-table__row", count: 2) }
   it { should have_link(patient_sessions.first.patient.full_name) }

--- a/spec/components/previews/app_patient_table_component_preview.rb
+++ b/spec/components/previews/app_patient_table_component_preview.rb
@@ -1,0 +1,39 @@
+class AppPatientTableComponentPreview < ViewComponent::Preview
+  def check_consent
+    patient_sessions =
+      FactoryBot.create_list(:patient_session, 2, :triaged_ready_to_vaccinate)
+
+    # add a common name to one of the patients
+    patient_sessions.first.patient.update!(common_name: "Bobby")
+
+    render AppPatientTableComponent.new(
+             patient_sessions:,
+             caption: I18n.t("states.consent_given.title"),
+             columns: %i[name dob],
+             route: :consent
+           )
+  end
+
+  def matching_consent_form_to_a_patient
+    patient_sessions =
+      FactoryBot.create_list(:patient_session, 2, :added_to_session)
+
+    # add a common name to one of the patients above
+    patient_sessions.first.patient.update!(common_name: "Bobby")
+
+    # set postcode for both patients
+    patient_sessions.each do |ps|
+      ps.patient.update!(address_postcode: Faker::Address.postcode)
+    end
+
+    consent_form =
+      FactoryBot.create(:consent_form, session: patient_sessions.first.session)
+
+    render AppPatientTableComponent.new(
+             patient_sessions:,
+             columns: %i[name postcode dob select_for_matching],
+             route: :matching,
+             consent_form:
+           )
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -32,7 +32,7 @@ FactoryBot.define do
     sequence(:full_name) { |n| "Test User #{n}" }
     sequence(:email) { |n| "test-#{n}@localhost" }
     sequence(:teams) { [Team.first || create(:team)] }
-    password { "power overwhelming" }
+    password { "power overwhelming!" } # avoid a password that was found in a data breach
     registration { "SW608658 (HCPC)" }
   end
 end


### PR DESCRIPTION
## Matching

<img width="992" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/94c72a42-d2df-4843-8668-4bc24463401f">

## Consent

<img width="927" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/e4df2d98-6c73-4aff-8dae-1b0fa9cf7b48">

## Triage

<img width="988" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/e2c05866-4c76-4b5f-aa15-52eb1fd6ad29">

## Record

<img width="1043" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/15e36f8c-d657-48a2-8fe9-7c9c0194d118">

## Improvements to ViewComponent previews

To test this change, it was handy to add a preview for `AppPatientTableComponent`. The preview relied on factories and I ran into problems when refreshing the preview because of sequence clashes in the factories.

To deal with this, I introduced a custom preview controller (see 7ad28aeb84bd16969892391efdfe64994f85c9d7) that wraps a transaction around the preview action and silently rolls everything back after it's run, so the development DB isn't polluted and the sequence clashes can be avoided. This seems to be working well so far 🤞 .