### PR TITLE
Make consents list look right with multiple consents for same parent

### DIFF
--- a/app/assets/stylesheets/_list.scss
+++ b/app/assets/stylesheets/_list.scss
@@ -1,0 +1,18 @@
+.app-list--events {
+  p {
+    margin-bottom: nhsuk-spacing(1);
+  }
+
+  li {
+    padding-bottom: nhsuk-spacing(1);
+  }
+
+  li + li {
+    border-top: 1px solid $nhsuk-border-color;
+    padding-top: nhsuk-spacing(2);
+  }
+}
+
+.nhsuk-summary-list__value:has(.app-list--events) {
+  padding-right: 0;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,6 +32,7 @@ $color_app-pale-blue: #ccdff1;
 @import "header";
 @import "globals";
 @import "inset-text";
+@import "list";
 @import "notification-banner";
 @import "offline";
 @import "panel";

--- a/app/components/app_consent_response_component.rb
+++ b/app/components/app_consent_response_component.rb
@@ -1,68 +1,62 @@
 class AppConsentResponseComponent < ViewComponent::Base
-  def call
-    response_contents =
-      @consents.map do |consent|
-        [
-          tag.p(class: "nhsuk-body") do
-            "#{response(consent:)} (#{route(consent:)})"
-          end,
-          tag.p(class: date_and_time_p_classes) do
-            [
-              recorded_by_link(consent:),
-              date_and_time(consent.recorded_at)
-            ].join("<br />").html_safe
-          end
-        ].join("\n").html_safe
+  class AppSingleConsentResponseComponent < ViewComponent::Base
+    erb_template <<-ERB
+      <p class="nhsuk-body">
+        <%= response %> (<%= route %>)
+      </p>
+      <p class="nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color nhsuk-u-font-size-16 nhsuk-u-margin-bottom-0">
+        <%= recorded_by_link %><br />
+        <%= consent.recorded_at.to_fs(:nhsuk_date) %> at <%= consent.recorded_at.to_fs(:time) %>
+      </p>
+    ERB
+
+    attr_reader :consent
+
+    def initialize(consent:)
+      super
+      @consent = consent
+    end
+
+    def response
+      consent.human_enum_name(:response).capitalize
+    end
+
+    def route
+      if consent.respond_to?(:route)
+        consent.human_enum_name(:route).downcase
+      else
+        "online"
       end
+    end
 
-    return response_contents.first if response_contents.size == 1
-
-    tag.ul(class: "nhsuk-list nhsuk-list--bullet app-list--events") do
-      safe_join(response_contents.map { |content| tag.li(content) }, "\n")
+    def recorded_by_link
+      if consent.respond_to?(:via_phone?) && consent.via_phone?
+        link_to(
+          consent.recorded_by.full_name,
+          "mailto:#{consent.recorded_by.email}"
+        )
+      else
+        link_to(consent.parent_name, "mailto:#{consent.parent_email}")
+      end
     end
   end
+
+  erb_template <<-ERB
+    <% if @consents.size == 1 %>
+      <%= render(AppSingleConsentResponseComponent.new(consent: @consents.first)) %>
+    <% elsif @consents.size > 1 %>
+      <ul class="nhsuk-list nhsuk-list--bullet app-list--events">
+        <% @consents.each do |consent| %>
+          <li>
+            <%= render(AppSingleConsentResponseComponent.new(consent: consent)) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  ERB
 
   def initialize(consents:)
     super
-
     @consents = consents
-  end
-
-  private
-
-  def date_and_time_p_classes
-    %w[
-      nhsuk-u-margin-bottom-2
-      nhsuk-u-secondary-text-color
-      nhsuk-u-font-size-16
-      nhsuk-u-margin-bottom-0
-    ].join(" ")
-  end
-
-  def date_and_time(date)
-    %(#{date.to_fs(:nhsuk_date)} at #{date.to_fs(:time)}).html_safe
-  end
-
-  def response(consent:)
-    consent.human_enum_name(:response).capitalize
-  end
-
-  def route(consent:)
-    if consent.respond_to?(:route)
-      consent.human_enum_name(:route).downcase
-    else
-      "online"
-    end
-  end
-
-  def recorded_by_link(consent:)
-    if consent.respond_to?(:via_phone?) && consent.via_phone?
-      link_to(
-        consent.recorded_by.full_name,
-        "mailto:#{consent.recorded_by.email}"
-      )
-    else
-      link_to(consent.parent_name, "mailto:#{consent.parent_email}")
-    end
   end
 end

--- a/app/components/app_consent_response_component.rb
+++ b/app/components/app_consent_response_component.rb
@@ -17,8 +17,8 @@ class AppConsentResponseComponent < ViewComponent::Base
 
     return response_contents.first if response_contents.size == 1
 
-    tag.ul(class: "nhsuk-list") do
-      response_contents.map { |content| tag.li(content) }.join("\n").html_safe
+    tag.ul(class: "nhsuk-list nhsuk-list--bullet app-list--events") do
+      safe_join(response_contents.map { |content| tag.li(content) }, "\n")
     end
   end
 

--- a/spec/components/app_consent_details_component_spec.rb
+++ b/spec/components/app_consent_details_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AppConsentDetailsComponent, type: :component do
   end
 
   it "displays the response given" do
-    should have_css("div", text: /Response ?Consent refused/)
+    should have_css("div", text: /Response(.*?)Consent refused/m)
   end
 
   it "displays the refusal reason" do
@@ -45,7 +45,7 @@ RSpec.describe AppConsentDetailsComponent, type: :component do
     end
 
     it "displays the response given" do
-      should have_css("div", text: /Response ?Consent given/)
+      should have_css("div", text: /Response(.*?)Consent given/m)
     end
   end
 end

--- a/spec/components/app_consent_response_component_spec.rb
+++ b/spec/components/app_consent_response_component_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe AppConsentResponseComponent, type: :component do
     let(:consent) { create(:consent, :given) }
     let(:consents) { [consent] }
 
+    it { should have_text("Consent given (online)") }
+    it { should have_text(consent.parent_name) }
     it do
-      should have_text "Consent given (online)\n" \
-                         "#{consent.parent_name}" \
-                         "#{consent.created_at.to_fs(:nhsuk_date)} at " \
-                         "#{consent.created_at.to_fs(:time)}"
+      should have_text(
+               "#{consent.created_at.to_fs(:nhsuk_date)} at #{consent.created_at.to_fs(:time)}"
+             )
     end
-
     it do
       should have_link(
                consent.parent_name,
@@ -40,11 +40,12 @@ RSpec.describe AppConsentResponseComponent, type: :component do
     let(:consent_form) { create(:consent_form, :recorded) }
     let(:consents) { [consent_form] }
 
+    it { should have_text("Consent given (online)") }
+    it { should have_text(consent_form.parent_name) }
     it do
-      should have_text "Consent given (online)\n" \
-                         "#{consent_form.parent_name}" \
-                         "#{consent_form.created_at.to_fs(:nhsuk_date)} at " \
-                         "#{consent_form.created_at.to_fs(:time)}"
+      should have_text(
+               "#{consent_form.created_at.to_fs(:nhsuk_date)} at #{consent_form.created_at.to_fs(:time)}"
+             )
     end
 
     it do

--- a/spec/components/previews/app_consent_component_preview.rb
+++ b/spec/components/previews/app_consent_component_preview.rb
@@ -1,0 +1,66 @@
+class AppConsentComponentPreview < ViewComponent::Preview
+  def consent_not_given
+    setup
+
+    patient_session =
+      FactoryBot.create(:patient_session, :consent_refused, session:)
+
+    render AppConsentComponent.new(patient_session:, route: "triage")
+  end
+
+  def consent_given
+    setup
+
+    patient_session =
+      FactoryBot.create(
+        :patient_session,
+        :consent_given_triage_not_needed,
+        session:
+      )
+    render AppConsentComponent.new(patient_session:, route: "triage")
+  end
+
+  def two_refusals_from_the_same_parent
+    setup
+
+    patient_session =
+      FactoryBot.create(:patient_session, :consent_refused, session:)
+    FactoryBot.create(
+      :consent,
+      :refused,
+      patient_session:,
+      parent_relationship: patient_session.consents.first.parent_relationship,
+      parent_name: patient_session.consents.first.parent_name
+    )
+
+    render AppConsentComponent.new(patient_session:, route: "triage")
+  end
+
+  def conflicting_consents_from_different_parents
+    setup
+
+    patient_session =
+      FactoryBot.create(
+        :patient_session,
+        :consent_given_triage_not_needed,
+        session:
+      )
+    FactoryBot.create(:consent, :refused, :from_mum, patient_session:)
+
+    render AppConsentComponent.new(patient_session:, route: "triage")
+  end
+
+  private
+
+  attr_reader :campaign, :session
+
+  def setup
+    @campaign =
+      FactoryBot.create(
+        :campaign,
+        :hpv,
+        team: Team.first || FactoryBot.create(:team)
+      )
+    @session = FactoryBot.create(:session, patients_in_session: 0, campaign:)
+  end
+end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -74,7 +74,13 @@ FactoryBot.define do
 
     trait :consent_given_triage_not_needed do
       after(:create) do |patient, evaluator|
-        create(:consent, :given, campaign: evaluator.campaign, patient:)
+        create(
+          :consent,
+          :given,
+          campaign: evaluator.campaign,
+          patient:,
+          parent_relationship: patient.parent_relationship
+        )
       end
     end
 


### PR DESCRIPTION
## Before

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/3242fa63-7e51-4e6b-ad11-24d2e144a717)

## After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/5b6bae8d-745f-4cc9-8014-9d9e0db92574)

## Other changes included

* add a preview for `AppConsentComponent`
* refactor `AppConsentResponseComponent` to use ERB templates, to make it a bit to parse at a glance. Also split out the logic for rendering a single consent response, and logic needed to render a list of them