### PR TITLE
Display refusal notes from consent forms in Mavis

### DIFF
--- a/app/components/app_consent_details_component.rb
+++ b/app/components/app_consent_details_component.rb
@@ -30,7 +30,10 @@ class AppConsentDetailsComponent < ViewComponent::Base
       if refused_consents.any?
         summary_list.with_row do |row|
           row.with_key { "Refusal reason" }
-          row.with_value { reason_for_refusal }
+          row.with_value do
+            safe_join [reason_for_refusal, reason_for_refusal_notes].compact,
+                      tag.br
+          end
         end
       end
     end
@@ -82,6 +85,14 @@ class AppConsentDetailsComponent < ViewComponent::Base
       refused_consents.first.human_enum_name(:reason)
     else
       refused_consents.first.human_enum_name(:reason_for_refusal)
+    end
+  end
+
+  def reason_for_refusal_notes
+    if refused_consents.first.respond_to?(:reason_notes)
+      refused_consents.first.reason_notes
+    else
+      refused_consents.first.reason_for_refusal_notes
     end
   end
 end

--- a/spec/components/app_consent_details_component_spec.rb
+++ b/spec/components/app_consent_details_component_spec.rb
@@ -23,8 +23,27 @@ RSpec.describe AppConsentDetailsComponent, type: :component do
     should have_css("div", text: /Response(.*?)Consent refused/m)
   end
 
-  it "displays the refusal reason" do
+  it "displays only the refusal reason if there are no notes" do
     should have_css("div", text: /Refusal reason ?Personal choice/)
+  end
+
+  context "with a refusal reason with notes" do
+    let(:consent) do
+      create(
+        :consent,
+        :refused,
+        reason_for_refusal: :already_vaccinated,
+        reason_for_refusal_notes: "Had it at the GP"
+      )
+    end
+
+    it "displays both the refusal reason and notes" do
+      should have_css(
+               "div",
+               text:
+                 /Refusal reason ?Vaccine already received ?Had it at the GP/
+             )
+    end
   end
 
   context "with a consent_form" do
@@ -46,6 +65,34 @@ RSpec.describe AppConsentDetailsComponent, type: :component do
 
     it "displays the response given" do
       should have_css("div", text: /Response(.*?)Consent given/m)
+    end
+
+    context "with a refusal reason wihout notes" do
+      let(:consent_form) do
+        create :consent_form, :recorded, :refused, reason: :personal_choice
+      end
+
+      it "displays only the refusal reason" do
+        should have_css("div", text: /Refusal reason ?Personal choice/)
+      end
+    end
+
+    context "with a refusal reason with notes" do
+      let(:consent_form) do
+        create :consent_form,
+               :recorded,
+               :refused,
+               reason: :already_vaccinated,
+               reason_notes: "Already had the vaccine at the GP"
+      end
+
+      it "displays the refusal reason and notes" do
+        should have_css(
+                 "div",
+                 text:
+                   /Refusal reason ?Vaccine already received ?Already had the vaccine at the GP/
+               )
+      end
     end
   end
 end

--- a/spec/components/previews/app_consent_component_preview.rb
+++ b/spec/components/previews/app_consent_component_preview.rb
@@ -1,9 +1,18 @@
 class AppConsentComponentPreview < ViewComponent::Preview
-  def consent_not_given
+  def consent_refused_without_notes
     setup
 
     patient_session =
       FactoryBot.create(:patient_session, :consent_refused, session:)
+
+    render AppConsentComponent.new(patient_session:, route: "triage")
+  end
+
+  def consent_refused_with_notes
+    setup
+
+    patient_session =
+      FactoryBot.create(:patient_session, :consent_refused_with_notes, session:)
 
     render AppConsentComponent.new(patient_session:, route: "triage")
   end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -49,6 +49,11 @@ FactoryBot.define do
       patient { create :patient, :consent_refused, session: }
     end
 
+    trait :consent_refused_with_notes do
+      state { "consent_refused" }
+      patient { create :patient, :consent_refused_with_notes, session: }
+    end
+
     trait :consent_conflicting do
       state { "consent_refused" }
       patient { create :patient, :consent_conflicting, session: }

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -108,6 +108,20 @@ FactoryBot.define do
       end
     end
 
+    trait :consent_refused_with_notes do
+      after(:create) do |patient, evaluator|
+        create(
+          :consent,
+          :refused,
+          :from_mum,
+          campaign: evaluator.campaign,
+          reason_for_refusal: "already_vaccinated",
+          reason_for_refusal_notes: "Already had the vaccine at the GP",
+          patient:
+        )
+      end
+    end
+
     trait :consent_conflicting do
       after(:create) do |patient, evaluator|
         create(


### PR DESCRIPTION
## Consents on the patient page

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/334ce1e8-2ebf-4278-936c-54772834e4a3)

## When manually matching consent forms to cohort records

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/1bf5d2f4-c4dd-4b52-9cab-51accffae045)
