### PR TITLE
Enable gzip compression

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,6 +42,8 @@ module ManageVaccinations
       ] = "postgres://#{username}:#{password}@#{host}:#{port}/#{dbname}"
     end
 
+    config.middleware.use Rack::Deflater
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/precompile.rb
+++ b/config/initializers/precompile.rb
@@ -1,0 +1,21 @@
+require "rake"
+require "zlib"
+
+Rake::Task["assets:precompile"].enhance do
+  assembly = Rails.application.assets
+  output_path = assembly.config.output_path
+
+  assembly.load_path.assets.each do |asset|
+    asset_path = output_path.join(asset.digested_path)
+    compressed_path = output_path.join("#{asset.digested_path}.gz")
+
+    next if compressed_path.exist?
+    Propshaft.logger.info "Compressing #{asset.digested_path}"
+
+    Zlib::GzipWriter.open(compressed_path, Zlib::BEST_COMPRESSION) do |gz|
+      gz.mtime = File.mtime(asset_path)
+      gz.orig_name = asset_path.to_s
+      gz.write File.binread(asset_path)
+    end
+  end
+end if Rake::Task.task_defined?("assets:precompile")


### PR DESCRIPTION
Significantly reduces asset sizes.

Propshaft requires some additional changes to `assets:precompile` in order to manually gzip assets.

This can be removed in Rails 8 once Thruster is released.

https://github.com/rails/rails/issues/50479

![Screenshot 2024-03-06 at 11 35 03](https://github.com/nhsuk/manage-childrens-vaccinations/assets/1650875/42da8cbb-8a2a-470c-9aa2-7ff7c5f995b7)
