### PR TITLE
Reduce asset size

### DIFF
--- a/app/assets/stylesheets/_inset-text.scss
+++ b/app/assets/stylesheets/_inset-text.scss
@@ -1,3 +1,0 @@
-.nhsuk-inset-text {
-  @extend .govuk-inset-text;
-}

--- a/app/assets/stylesheets/_offline.scss
+++ b/app/assets/stylesheets/_offline.scss
@@ -1,5 +1,5 @@
 .app-offline-indicator {
-  background: $color_app-pale-blue;
+  background: #ccdff1;
   padding: nhsuk-spacing(3) 0 nhsuk-spacing(3);
   display: none;
 }

--- a/app/assets/stylesheets/_summary-list.scss
+++ b/app/assets/stylesheets/_summary-list.scss
@@ -1,5 +1,5 @@
 .app-summary-list--no-bottom-border {
-  .govuk-summary-list__row:last-child {
+  .nhsuk-summary-list__row:last-child {
     border-bottom: none;
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,7 +31,6 @@ $color_app-pale-blue: #ccdff1;
 @import "file-upload";
 @import "header";
 @import "globals";
-@import "inset-text";
 @import "list";
 @import "notification-banner";
 @import "offline";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,29 +1,32 @@
-@use "govuk-frontend/dist/govuk/all" with (
-  $govuk-font-family: (
-    Frutiger W01,
-    Arial,
-    sans-serif,
-  ),
-  $govuk-border-colour: #d8dde0,
-  $govuk-brand-colour: #005eb8,
-  $govuk-error-colour: #d5281b,
-  $govuk-success-colour: #007f3b,
-  $govuk-global-styles: false,
-  $govuk-assets-path: "/",
-  $mq-breakpoints: (
-    mobile: 320px,
-    tablet: 641px,
-    desktop: 769px,
-    wide: 1300px,
-  )
-);
+// Configure and import GOV.UK Frontend
+$govuk-font-family: "Frutiger W01", Arial, sans-serif;
+$govuk-border-colour: #d8dde0;
+$govuk-brand-colour: #005eb8;
+$govuk-error-colour: #d5281b;
+$govuk-success-colour: #007f3b;
+$govuk-global-styles: false;
+$govuk-assets-path: "/";
 
+@import "govuk-frontend/dist/govuk/base";
+@import "govuk-frontend/dist/govuk/components/file-upload/index";
+@import "govuk-frontend/dist/govuk/components/notification-banner/index";
+@import "govuk-frontend/dist/govuk/components/panel/index";
+@import "govuk-frontend/dist/govuk/components/phase-banner/index";
+
+// Configure and import NHS.UK Frontend
 $nhsuk-fonts-path: "/";
+$mq-breakpoints: (
+  mobile: 320px,
+  tablet: 641px,
+  desktop: 769px,
+  wide: 1300px,
+);
 
 @import "nhsuk-frontend/packages/nhsuk";
 
 $color_app-pale-blue: #ccdff1;
 
+// Application components
 @import "action-table";
 @import "button";
 @import "card";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,8 +24,6 @@ $mq-breakpoints: (
 
 @import "nhsuk-frontend/packages/nhsuk";
 
-$color_app-pale-blue: #ccdff1;
-
 // Application components
 @import "action-table";
 @import "button";
@@ -36,7 +34,7 @@ $color_app-pale-blue: #ccdff1;
 @import "globals";
 @import "list";
 @import "notification-banner";
-@import "offline";
+// @import "offline";
 @import "panel";
 @import "phase-banner";
 @import "table";

--- a/app/javascript/controllers/govuk_accordion_controller.js
+++ b/app/javascript/controllers/govuk_accordion_controller.js
@@ -1,9 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-import { Accordion } from "govuk-frontend";
-
-// Connects to data-module="govuk-accordion"
-export default class extends Controller {
-  connect() {
-    new Accordion(this.element).init();
-  }
-}

--- a/app/javascript/controllers/govuk_header_controller.js
+++ b/app/javascript/controllers/govuk_header_controller.js
@@ -1,9 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-import { Header } from "govuk-frontend";
-
-// Connects to data-module="govuk-header"
-export default class extends Controller {
-  connect() {
-    new Header(this.element).init();
-  }
-}

--- a/app/javascript/controllers/govuk_skip_link_controller.js
+++ b/app/javascript/controllers/govuk_skip_link_controller.js
@@ -1,9 +1,0 @@
-import { Controller } from "@hotwired/stimulus";
-import { SkipLink } from "govuk-frontend";
-
-// Connects to data-module="govuk-skip-link"
-export default class extends Controller {
-  connect() {
-    new SkipLink(this.element).init();
-  }
-}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,9 +7,6 @@ import { application } from "./application";
 import CheckAllController from "./check_all_controller";
 application.register("check-all", CheckAllController);
 
-import GovukAccordionController from "./govuk_accordion_controller";
-application.register("govuk-accordion", GovukAccordionController);
-
 import NhsukButtonController from "./nhsuk_button_controller";
 application.register("nhsuk-button", NhsukButtonController);
 
@@ -18,12 +15,6 @@ application.register("govuk-character-count", GovukCharacterCountController);
 
 import GovukCheckboxesController from "./govuk_checkboxes_controller";
 application.register("govuk-checkboxes", GovukCheckboxesController);
-
-import GovukHeaderController from "./govuk_header_controller";
-application.register("govuk-header", GovukHeaderController);
-
-import GovukSkipLinkController from "./govuk_skip_link_controller";
-application.register("govuk-skip-link", GovukSkipLinkController);
 
 import NhsukErrorSummaryController from "./nhsuk_error_summary_controller";
 application.register("nhsuk-error-summary", NhsukErrorSummaryController);

--- a/app/views/vaccines/index.html.erb
+++ b/app/views/vaccines/index.html.erb
@@ -11,7 +11,7 @@
 
 <% @vaccines.each do |vaccine| %>
   <%= render AppCardComponent.new(heading: "#{vaccine.brand} (#{vaccine.type})") do %>
-    <p class="govuk-body">
+    <p>
       <%= link_to "Add batch", new_vaccine_batch_path(vaccine) %>
     </p>
 


### PR DESCRIPTION
- Remove extending `.govuk-inset-text` (NHS.UK Frontend has it’s own styles)
- Only load the component styles from GOV.UK Frontend that we are using:
  - File upload
  - Notification banner
  - Panel
  - Phase banner
- Disable offline style (not currently being used)
- Remove unused GOV.UK JavaScript controllers:
  - Accordian 
  - Header
  - Skip link

Uncompressed CSS file size before: 312 KB
Uncompressed CSS file size after: 182 KB