### PR TITLE
Cache assets forever

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,10 @@ module ManageVaccinations
 
     config.middleware.use Rack::Deflater
 
+    config.public_file_server.headers = {
+      "Cache-Control" => "public, max-age=2147483648, immutable"
+    }
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
We already use cache-busting strings, so this should be safe to do.