### PR TITLE
Minify CSS and JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "workbox-build": "^7.0.0"
   },
   "scripts": {
-    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css ./app/assets/stylesheets/registration.scss:./app/assets/builds/registration.css --no-source-map --load-path=node_modules --quiet-deps",
-    "build": "esbuild app/javascript/*.[jt]s app/javascript/controllers/*.[jt]s --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
-    "build:serviceworker": "esbuild app/javascript/serviceworker/main.js --bundle --sourcemap --outfile=public/sw.js",
+    "build:css": "sass ./app/assets/stylesheets/application.scss:./app/assets/builds/application.css ./app/assets/stylesheets/registration.scss:./app/assets/builds/registration.css --no-source-map --load-path=node_modules --quiet-deps --style compressed",
+    "build": "esbuild app/javascript/*.[jt]s app/javascript/controllers/*.[jt]s --bundle --sourcemap --outdir=app/assets/builds --public-path=assets --minify",
+    "build:serviceworker": "esbuild app/javascript/serviceworker/main.js --bundle --sourcemap --outfile=public/sw.js --minify",
     "test:e2e": "PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS=1 playwright test",
     "test": "jest"
   },


### PR DESCRIPTION
Enable the flags for sass and esbuild.

### Before

```bash
$ wc -c app/assets/builds/application.css app/assets/builds/application.js
  181694 app/assets/builds/application.css
  206443 app/assets/builds/application.js
  388137 total
```

### After

```bash
$ wc -c app/assets/builds/application.css app/assets/builds/application.js
  126270 app/assets/builds/application.css
  115710 app/assets/builds/application.js
  241980 total
```