### PR TITLE
Show only the time of day when confirming the vaccination record

### DIFF
--- a/app/views/vaccinations/confirm.html.erb
+++ b/app/views/vaccinations/confirm.html.erb
@@ -74,7 +74,7 @@
 
       summary_list.with_row do |row|
         row.with_key { 'Time' }
-        row.with_value { Time.zone.now.to_fs(:app_date_time) }
+        row.with_value { Time.zone.now.to_fs(:time) }
       end
 
       summary_list.with_row do |row|


### PR DESCRIPTION
Remove redundant date (it's already above), match what's in the prototype.

## Before

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/65391c42-45b9-4483-9240-9d1d8ddfc739)

## After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/f8590928-ab33-4f42-b8af-3294f425148e)
