### PR TITLE
Puma worker updates

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -2,3 +2,4 @@ allow_dev_phone_numbers: true
 pilot:
   earliest_session_date: 01-01-2024
   latest_session_date: 01-01-2034
+web_concurrency: 0


### PR DESCRIPTION
Set web_concurrency to 0 in development and don't restart/shutdown GoodJob unless web_concurrency > 1.