### PR TITLE
Show right reason when unable to vaccinate

### DIFF
--- a/app/components/app_status_banner_component.rb
+++ b/app/components/app_status_banner_component.rb
@@ -176,9 +176,16 @@ class AppStatusBannerComponent < ViewComponent::Base
   end
 
   def reason_do_not_vaccinate_summary
-    I18n.t(
-      "patient_session_statuses.unable_to_vaccinate.banner_explanation.#{state}"
-    )
+    if vaccination_record&.reason.present?
+      I18n.t(
+        "patient_session_statuses.unable_to_vaccinate.banner_explanation.#{vaccination_record.reason}",
+        full_name:
+      )
+    else
+      I18n.t(
+        "patient_session_statuses.unable_to_vaccinate.banner_explanation.#{state}"
+      )
+    end
   end
 
   def time_summary

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -50,13 +50,13 @@ en:
       text: Could not vaccinate
       banner_title: Could not vaccinate
       banner_explanation:
-        refused: "%{full_name} refused it."
-        not_well: "%{full_name} was not well enough."
-        contraindications: "%{full_name} had contraindications."
-        already_had: "%{full_name} has already had the vaccine."
-        absent_from_school: "%{full_name} was absent from school."
-        absent_from_session: "%{full_name} was absent from the session."
-        gave_consent: "Their %{who_responded} gave consent."
+        refused: "%{full_name} refused it"
+        not_well: "%{full_name} was not well enough"
+        contraindications: "%{full_name} had contraindications"
+        already_had: "%{full_name} has already had the vaccine"
+        absent_from_school: "%{full_name} was absent from school"
+        absent_from_session: "%{full_name} was absent from the session"
+        gave_consent: "Their %{who_responded} gave consent"
         triaged_do_not_vaccinate: "Do not vaccinate in campaign"
         unable_to_vaccinate: "Refused vaccine"
     unable_to_vaccinate_not_assessed:

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -75,11 +75,7 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
-    it "explains who took the decision that the patient should be vaccinated" do
-      expect(component.explanation).to include(
-        "Alya Merton had contraindications"
-      )
-    end
+    it { should have_text("Alya Merton had contraindications") }
   end
 
   context "state is vaccinated" do

--- a/spec/components/previews/app_status_banner_component_preview.rb
+++ b/spec/components/previews/app_status_banner_component_preview.rb
@@ -1,0 +1,7 @@
+class AppStatusBannerComponentPreview < ViewComponent::Preview
+  def unable_to_vaccinate_with_contradications
+    patient_session = FactoryBot.create(:patient_session, :unable_to_vaccinate)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+end

--- a/spec/features/hpv_vaccination_not_administered_spec.rb
+++ b/spec/features/hpv_vaccination_not_administered_spec.rb
@@ -73,7 +73,7 @@ describe "HPV Vaccination" do
 
   def then_i_see_that_the_status_is_could_not_vaccinate
     expect(page).to have_content("Could not vaccinate")
-    expect(page).to have_content("ReasonRefused vaccine")
+    expect(page).to have_content("Reason#{@patient.full_name} refused it")
   end
 
   def and_an_email_is_sent_saying_the_vaccination_didnt_happen


### PR DESCRIPTION
If a child couldn't be vaccinated at the session for any reason other than refusal, the patient page was always showing "refused vaccine" rather than the actual recorded reason.

Below, the vaccinator recorded that the child couldn't be vaccinated due to contraindications:

## Before

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/27bb9644-f379-4823-998d-f83bccfbf84c)

## After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/4983e524-c637-4f52-84fd-5c3ae3758731)

## What's been changed

* add a component preview for this case
* fix the bug in the component spec (one was already written but it wasn't actually testing what was on the page)
* fix the bug in the component itself
* remove full stops from the banner messages (to be consistent with the other banners)