### PR TITLE
More banner fixes and improvements

### DIFF
--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -34,7 +34,6 @@ en:
       colour: red
       text: Could not vaccinate
       banner_title: Could not vaccinate
-      banner_explanation: "%{triage_nurse} that %{full_name} should not be vaccinated"
     triaged_kept_in_triage:
       colour: blue
       text: Triage started

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -24,17 +24,17 @@ en:
       colour: orange
       text: Check conflicting consent
       banner_title: Conflicting consent
-      banner_explanation: "You can only vaccinate if all respondents give consent."
+      banner_explanation: "You can only vaccinate if all respondents give consent"
     delay_vaccination:
       colour: red
       text: Delay vaccination
       banner_title: Delay vaccination to a later date
-      banner_explanation: "%{triage_nurse} decided that %{full_name}’s vaccination should be delayed."
+      banner_explanation: "%{triage_nurse} decided that %{full_name}’s vaccination should be delayed"
     triaged_do_not_vaccinate:
       colour: red
       text: Could not vaccinate
       banner_title: Could not vaccinate
-      banner_explanation: "%{triage_nurse} that %{full_name} should not be vaccinated."
+      banner_explanation: "%{triage_nurse} that %{full_name} should not be vaccinated"
     triaged_kept_in_triage:
       colour: blue
       text: Triage started
@@ -44,7 +44,7 @@ en:
       colour: purple
       text: Vaccinate
       banner_title: Safe to vaccinate
-      banner_explanation: "%{triage_nurse} decided that %{full_name} is safe to vaccinate."
+      banner_explanation: "%{triage_nurse} decided that %{full_name} is safe to vaccinate"
     unable_to_vaccinate:
       colour: red
       text: Could not vaccinate
@@ -63,12 +63,12 @@ en:
       colour: red
       text: Not vaccinated
       banner_title: Not vaccinated
-      banner_explanation: No-one responded to our requests for consent.
+      banner_explanation: No-one responded to our requests for consent
     unable_to_vaccinate_not_gillick_competent:
       colour: red
       text: Not vaccinated
       banner_title: Not vaccinated
-      banner_explanation: No-one responded to our requests for consent. When assessed, the child was not Gillick competent.
+      banner_explanation: No-one responded to our requests for consent. When assessed, the child was not Gillick competent
     vaccinated:
       colour: green
       text: Vaccinated

--- a/spec/components/app_status_banner_component_spec.rb
+++ b/spec/components/app_status_banner_component_spec.rb
@@ -63,10 +63,10 @@ RSpec.describe AppStatusBannerComponent, type: :component do
 
     it { should have_css(".app-card--purple") }
     it { should have_css(".nhsuk-card__heading", text: "Safe to vaccinate") }
-    it "explains who took the decision that the patient should be vaccinated" do
-      expect(component.explanation).to eq(
-        "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate."
-      )
+    it do
+      should have_text(
+               "#{triage_nurse_name} decided that #{patient_name} is safe to vaccinate"
+             )
     end
   end
 

--- a/spec/components/previews/app_status_banner_component_preview.rb
+++ b/spec/components/previews/app_status_banner_component_preview.rb
@@ -1,7 +1,19 @@
 class AppStatusBannerComponentPreview < ViewComponent::Preview
+  def waiting_for_consent
+    patient_session = FactoryBot.create(:patient_session, :added_to_session)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
   def no_consent_and_not_gillick_competent
     patient_session =
       FactoryBot.create(:patient_session, :not_gillick_competent)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
+  def consent_refused
+    patient_session = FactoryBot.create(:patient_session, :consent_refused)
 
     render AppStatusBannerComponent.new(patient_session:)
   end
@@ -12,14 +24,48 @@ class AppStatusBannerComponentPreview < ViewComponent::Preview
     render AppStatusBannerComponent.new(patient_session:)
   end
 
+  def needs_triage
+    patient_session =
+      FactoryBot.create(:patient_session, :consent_given_triage_needed)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
+  def triaged_keep_in_triage
+    patient_session =
+      FactoryBot.create(:patient_session, :triaged_kept_in_triage)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
+  def triaged_ready_to_vaccinate
+    patient_session =
+      FactoryBot.create(:patient_session, :triaged_ready_to_vaccinate)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
   def triaged_out_delay_vaccination
     patient_session = FactoryBot.create(:patient_session, :delay_vaccination)
 
     render AppStatusBannerComponent.new(patient_session:)
   end
 
+  def triaged_do_not_vaccinate
+    patient_session =
+      FactoryBot.create(:patient_session, :triaged_do_not_vaccinate)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
   def unable_to_vaccinate_with_contradications
     patient_session = FactoryBot.create(:patient_session, :unable_to_vaccinate)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
+  def vaccinated
+    patient_session = FactoryBot.create(:patient_session, :vaccinated)
 
     render AppStatusBannerComponent.new(patient_session:)
   end

--- a/spec/components/previews/app_status_banner_component_preview.rb
+++ b/spec/components/previews/app_status_banner_component_preview.rb
@@ -1,4 +1,10 @@
 class AppStatusBannerComponentPreview < ViewComponent::Preview
+  def consent_conflicts
+    patient_session = FactoryBot.create(:patient_session, :consent_conflicting)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
   def triaged_out_delay_vaccination
     patient_session = FactoryBot.create(:patient_session, :delay_vaccination)
 

--- a/spec/components/previews/app_status_banner_component_preview.rb
+++ b/spec/components/previews/app_status_banner_component_preview.rb
@@ -1,4 +1,10 @@
 class AppStatusBannerComponentPreview < ViewComponent::Preview
+  def triaged_out_delay_vaccination
+    patient_session = FactoryBot.create(:patient_session, :delay_vaccination)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
   def unable_to_vaccinate_with_contradications
     patient_session = FactoryBot.create(:patient_session, :unable_to_vaccinate)
 

--- a/spec/components/previews/app_status_banner_component_preview.rb
+++ b/spec/components/previews/app_status_banner_component_preview.rb
@@ -1,4 +1,11 @@
 class AppStatusBannerComponentPreview < ViewComponent::Preview
+  def no_consent_and_not_gillick_competent
+    patient_session =
+      FactoryBot.create(:patient_session, :not_gillick_competent)
+
+    render AppStatusBannerComponent.new(patient_session:)
+  end
+
   def consent_conflicts
     patient_session = FactoryBot.create(:patient_session, :consent_conflicting)
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -79,6 +79,12 @@ FactoryBot.define do
       triage { [create(:triage, status: :needs_follow_up)] }
     end
 
+    trait :delay_vaccination do
+      state { "delay_vaccination" }
+      patient { create :patient, :consent_given_triage_needed, session: }
+      triage { [create(:triage, status: :delay_vaccination)] }
+    end
+
     trait :did_not_need_triage do
       patient { create :patient, :consent_given_triage_not_needed, session: }
     end

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
     end
 
     trait :consent_conflicting do
-      state { "consent_refused" }
+      state { "consent_conflicts" }
       patient { create :patient, :consent_conflicting, session: }
     end
 

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -124,5 +124,12 @@ FactoryBot.define do
       gillick_competence_notes { "Assessed as gillick competent" }
       gillick_competence_assessor { create :user }
     end
+
+    trait :not_gillick_competent do
+      state { "unable_to_vaccinate_not_gillick_competent" }
+      gillick_competent { false }
+      gillick_competence_notes { "Assessed as not gillick competent" }
+      gillick_competence_assessor { create :user }
+    end
   end
 end


### PR DESCRIPTION
**Depends on #1155, rebase after that's merged.**

* Add previews for most patient banner types
* Remove full-stops from banner messages
* 8205df30c2a4986cc72998d3ee46c3aaead7600a: fix typo in a banner message (it might not actually be used though!)

Best reviewed commit by commit.