### PR TITLE
Reduce healthcheck times in test and training

### DIFF
--- a/copilot/webapp/manifest.yml
+++ b/copilot/webapp/manifest.yml
@@ -66,6 +66,9 @@ environments:
     http:
       alias:
         - "test.mavistesting.com"
+      healthcheck:
+        interval: "5s"
+        deregistration_delay: "5s"
     deployments:
       rolling: recreate # Disables blue-green deployment for speed
     variables:
@@ -76,6 +79,9 @@ environments:
     http:
       alias:
         - "training.mavistesting.com"
+      healthcheck:
+        interval: "5s"
+        deregistration_delay: "5s"
     variables:
       RAILS_ENV: staging
       MAVIS__HOST: "training.mavistesting.com"


### PR DESCRIPTION
This is in an attempt to speed up the deploy times. It's not quite certain how these will affect the deploys yet, so we'll try these in test and training and then see about production later.