### PR TITLE
Hide the location in the outcome banner if patient triaged out before the session

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -17,26 +17,39 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   private
 
   def rows
-    if @patient_session.vaccinated?
-      [
-        ["Vaccine", vaccine_summary],
-        ["Site", vaccination_record.human_enum_name(:delivery_site)],
-        ["Date", date_summary],
-        ["Time", last_action_time.to_fs(:time)],
-        ["Location", @patient_session.session.location.name],
-        ["Vaccinator", clinician_name],
-        ["Notes", notes]
-      ].map { |key, value| { key: { text: key }, value: { text: value } } }
-    else
-      [
-        ["Reason", reason_do_not_vaccinate],
-        ["Date", date_summary],
-        ["Time", last_action_time.to_fs(:time)],
-        ["Location", @patient_session.session.location.name],
-        ["Decided by", clinician_name],
-        ["Notes", notes]
-      ].map { |key, value| { key: { text: key }, value: { text: value } } }
+    data =
+      if @patient_session.vaccinated?
+        [
+          ["Vaccine", vaccine_summary],
+          ["Site", vaccination_record.human_enum_name(:delivery_site)],
+          ["Date", date_summary],
+          ["Time", last_action_time.to_fs(:time)],
+          ["Location", @patient_session.session.location.name],
+          ["Vaccinator", clinician_name],
+          ["Notes", notes]
+        ]
+      else
+        [
+          ["Reason", reason_do_not_vaccinate],
+          ["Date", date_summary],
+          ["Time", last_action_time.to_fs(:time)],
+          (
+            if show_location?
+              ["Location", @patient_session.session.location.name]
+            end
+          ),
+          ["Decided by", clinician_name],
+          ["Notes", notes]
+        ]
+      end
+    data.compact.map do |key, value|
+      { key: { text: key }, value: { text: value } }
     end
+  end
+
+  def show_location?
+    # location only makes sense if an attempt to vaccinate on site was made
+    @patient_session.vaccination_records.any?
   end
 
   def vaccine_summary

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe AppOutcomeBannerComponent, type: :component do
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it { should have_text("Alya Merton had contraindications") }
+    it { should have_text("Location#{patient_session.session.location.name}") }
   end
 
   context "state is vaccinated" do
@@ -64,7 +65,7 @@ RSpec.describe AppOutcomeBannerComponent, type: :component do
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
     it { should have_text("ReasonDo not vaccinate in campaign") }
     it { should have_text("DateToday (#{date})") }
-    it { should have_text("Location#{location.name}") }
+    it { should_not have_text("Location") }
     it { should have_text("Decided byYou (#{triage.user.full_name})") }
 
     context "recorded_at is not today" do


### PR DESCRIPTION
It doesn't make sense to show the location if the patient was triaged out before the school session.