### PR TITLE
Show validation error on verbal consent 'agree' page

### DIFF
--- a/app/views/manage_consents/agree.html.erb
+++ b/app/views/manage_consents/agree.html.erb
@@ -10,7 +10,7 @@
 
 <%= form_for @consent, url: wizard_path, method: :put do |f| %>
   <%= f.govuk_error_summary %>
-  <%= f.govuk_radio_buttons_fieldset(:consent,
+  <%= f.govuk_radio_buttons_fieldset(:response,
     caption: { size: 'l',
                text: @patient.full_name },
     legend: { size: 'l',


### PR DESCRIPTION
## Before

<img width="676" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/282ccfa1-5569-4bfa-a500-9e63843365c1">

## After

![image](https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/8f2327a1-ee70-4368-ae37-6a4ad5bc4fde)
