### PR TITLE
Add remaining email UUIDs

### DIFF
--- a/app/mailers/consent_form_mailer.rb
+++ b/app/mailers/consent_form_mailer.rb
@@ -1,35 +1,35 @@
 class ConsentFormMailer < ApplicationMailer
   def confirmation(consent_form: nil, consent: nil, session: nil)
     template_mail(
-      "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
+      EMAILS[:parental_consent_confirmation],
       **opts(consent_form:, consent:, session:)
     )
   end
 
   def confirmation_needs_triage(consent_form: nil, consent: nil, session: nil)
     template_mail(
-      "604ee667-c996-471e-b986-79ab98d0767c",
+      EMAILS[:parental_consent_confirmation_needs_triage],
       **opts(consent_form:, consent:, session:)
     )
   end
 
   def confirmation_injection(consent_form: nil, consent: nil, session: nil)
     template_mail(
-      "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
+      EMAILS[:parental_consent_confirmation_injection],
       **opts(consent_form:, consent:, session:)
     )
   end
 
   def confirmation_refused(consent_form: nil, consent: nil, session: nil)
     template_mail(
-      "5a676dac-3385-49e4-98c2-fc6b45b5a851",
+      EMAILS[:parental_consent_confirmation_refused],
       **opts(consent_form:, consent:, session:)
     )
   end
 
   def give_feedback(consent_form: nil, consent: nil, session: nil)
     template_mail(
-      "1250c83b-2a5a-4456-8922-657946eba1fd",
+      EMAILS[:parental_consent_give_feedback],
       **opts(consent_form:, consent:, session:)
     )
   end

--- a/app/mailers/triage_mailer.rb
+++ b/app/mailers/triage_mailer.rb
@@ -3,7 +3,7 @@ class TriageMailer < ApplicationMailer
     @patient_session = patient_session
 
     template_mail(
-      "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
+      EMAILS[:triage_vaccination_will_happen],
       **opts(patient_session)
     )
   end
@@ -12,7 +12,7 @@ class TriageMailer < ApplicationMailer
     @patient_session = patient_session
 
     template_mail(
-      "d1faf47e-ccc3-4481-975b-1ec34211a21f",
+      EMAILS[:triage_vaccination_wont_happen],
       **opts(patient_session)
     )
   end

--- a/config/initializers/email_templates.rb
+++ b/config/initializers/email_templates.rb
@@ -5,5 +5,14 @@ EMAILS = {
   confirmation_the_hpv_vaccination_has_taken_place:
     "8a65d7b5-045c-4f26-8f76-6e593c14cb6d",
   confirming_the_hpv_vaccination_didnt_happen:
-    "130fe52a-014a-45dd-9f53-8e65c1b8bb79"
+    "130fe52a-014a-45dd-9f53-8e65c1b8bb79",
+  triage_vaccination_will_happen: "fa3c8dd5-4688-4b93-960a-1d422c4e5597",
+  triage_vaccination_wont_happen: "d1faf47e-ccc3-4481-975b-1ec34211a21f",
+  parental_consent_confirmation: "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73",
+  parental_consent_confirmation_needs_triage:
+    "604ee667-c996-471e-b986-79ab98d0767c",
+  parental_consent_confirmation_injection:
+    "4d09483a-8181-4acb-8ba3-7abd6c8644cd",
+  parental_consent_confirmation_refused: "5a676dac-3385-49e4-98c2-fc6b45b5a851",
+  parental_consent_give_feedback: "1250c83b-2a5a-4456-8922-657946eba1fd"
 }.freeze

--- a/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_do_not_vaccinate_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe "Verbal consent" do
 
   def and_the_will_not_vaccinate_email_is_sent_to_the_parent
     expect_email_to @patient.parent_email,
-                    "d1faf47e-ccc3-4481-975b-1ec34211a21f"
+                    EMAILS[:triage_vaccination_wont_happen]
   end
 
   def and_an_email_is_sent_to_the_parent_to_give_feedback
     expect_email_to @patient.parent_email,
-                    "1250c83b-2a5a-4456-8922-657946eba1fd",
+                    EMAILS[:parental_consent_give_feedback],
                     :second
   end
 end

--- a/spec/features/verbal_consent_given_keep_in_triage_spec.rb
+++ b/spec/features/verbal_consent_given_keep_in_triage_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe "Verbal consent" do
 
   def and_the_kept_in_triage_email_is_sent_to_the_parent
     expect_email_to @patient.parent_email,
-                    "604ee667-c996-471e-b986-79ab98d0767c"
+                    EMAILS[:parental_consent_confirmation_needs_triage]
   end
 
   def and_an_email_is_sent_to_the_parent_to_give_feedback
     expect_email_to @patient.parent_email,
-                    "1250c83b-2a5a-4456-8922-657946eba1fd",
+                    EMAILS[:parental_consent_give_feedback],
                     :second
   end
 end

--- a/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
+++ b/spec/features/verbal_consent_given_ready_to_vaccinate_spec.rb
@@ -72,12 +72,12 @@ RSpec.describe "Verbal consent" do
 
   def and_the_kept_in_triage_email_is_sent_to_the_parent
     expect_email_to @patient.parent_email,
-                    "fa3c8dd5-4688-4b93-960a-1d422c4e5597"
+                    EMAILS[:triage_vaccination_will_happen]
   end
 
   def and_an_email_is_sent_to_the_parent_to_give_feedback
     expect_email_to @patient.parent_email,
-                    "1250c83b-2a5a-4456-8922-657946eba1fd",
+                    EMAILS[:parental_consent_give_feedback],
                     :second
   end
 end

--- a/spec/features/verbal_consent_given_spec.rb
+++ b/spec/features/verbal_consent_given_spec.rb
@@ -70,12 +70,12 @@ RSpec.describe "Verbal consent" do
 
   def and_an_email_is_sent_to_the_parent_confirming_the_vaccination
     expect_email_to @patient.parent_email,
-                    "7cda7ae5-99a2-4c40-9a3e-1863e23f7a73"
+                    EMAILS[:parental_consent_confirmation]
   end
 
   def and_an_email_is_sent_to_the_parent_to_give_feedback
     expect_email_to @patient.parent_email,
-                    "1250c83b-2a5a-4456-8922-657946eba1fd",
+                    EMAILS[:parental_consent_give_feedback],
                     :second
   end
 end

--- a/spec/features/verbal_consent_refused_spec.rb
+++ b/spec/features/verbal_consent_refused_spec.rb
@@ -74,12 +74,12 @@ RSpec.describe "Verbal consent" do
 
   def and_an_email_is_sent_to_the_parent_confirming_the_refusal
     expect_email_to @patient.parent_email,
-                    "5a676dac-3385-49e4-98c2-fc6b45b5a851"
+                    EMAILS[:parental_consent_confirmation_refused]
   end
 
   def and_an_email_is_sent_to_the_parent_to_give_feedback
     expect_email_to @patient.parent_email,
-                    "1250c83b-2a5a-4456-8922-657946eba1fd",
+                    EMAILS[:parental_consent_give_feedback],
                     :second
   end
 end


### PR DESCRIPTION
Adds the remaining email UUIDs to the mapping of email templates. This gives each UUID an understandable name.

This came out of other work to add tests, decided it was better PRed on it's own.