### PR TITLE
Return users to vaccination section when doing triage while vaccinating

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -18,6 +18,8 @@ class ConsentsController < ApplicationController
       end
 
     methods.each { |m| @tabs[m] ||= [] }
+
+    session[:current_section] = "consents"
   end
 
   private

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -104,7 +104,7 @@ class TriageController < ApplicationController
     if session[:current_section] == "vaccinations"
       vaccinations_session_path(@session)
     elsif session[:current_section] == "consents"
-      consents_session_path(@session)
+      consents_session_path(@session, anchor: "given")
     else # if current_section is triage or anything else
       triage_session_path(@session)
     end

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -38,6 +38,8 @@ class TriageController < ApplicationController
 
     # ensure all tabs are present
     tabs_to_states.each_key { |tab| @tabs[tab] ||= [] }
+
+    session[:current_section] = "triage"
   end
 
   def create
@@ -50,7 +52,7 @@ class TriageController < ApplicationController
         patient: @patient,
         view_record_link: session_patient_triage_path(@session, @patient)
       )
-      redirect_to triage_session_path(@session)
+      redirect_to redirect_path
     else
       render "patient_sessions/show", status: :unprocessable_entity
     end
@@ -66,7 +68,7 @@ class TriageController < ApplicationController
         patient: @patient,
         view_record_link: session_patient_triage_path(@session, @patient)
       )
-      redirect_to triage_session_path(@session)
+      redirect_to redirect_path
     else
       render "patient_sessions/show", status: :unprocessable_entity
     end
@@ -96,5 +98,15 @@ class TriageController < ApplicationController
 
   def triage_params
     params.require(:triage).permit(:status, :notes)
+  end
+
+  def redirect_path
+    if session[:current_section] == "vaccinations"
+      vaccinations_session_path(@session)
+    elsif session[:current_section] == "consents"
+      consents_session_path(@session)
+    else # if current_section is triage or anything else
+      triage_session_path(@session)
+    end
   end
 end

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -50,6 +50,8 @@ class VaccinationsController < ApplicationController
       format.html
       format.json { render json: @patient_outcomes.map(&:first).index_by(&:id) }
     end
+
+    session[:current_section] = "vaccinations"
   end
 
   def new

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -173,5 +173,29 @@ FactoryBot.define do
 
       consents { [build(:consent, :given, campaign:, parent_relationship:)] }
     end
+
+    factory :patient_with_consent_given_triage_needed do
+      patient_sessions do
+        [
+          build(
+            :patient_session,
+            session:,
+            state: "consent_given_triage_needed"
+          )
+        ]
+      end
+
+      consents do
+        [
+          build(
+            :consent,
+            :given,
+            :needing_triage,
+            campaign:,
+            parent_relationship:
+          )
+        ]
+      end
+    end
   end
 end

--- a/spec/features/triage_during_consent_spec.rb
+++ b/spec/features/triage_during_consent_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe "Triage" do
+  include EmailExpectations
+
+  scenario "during consent" do
+    given_a_campaign_with_a_running_session
+    and_a_patient_needing_triage
+    and_i_am_signed_in
+
+    when_i_go_to_the_given_tab_of_the_consents_page
+    and_i_go_to_the_patient_that_needs_triage
+    and_i_record_that_they_are_safe_to_vaccinate
+    then_i_see_the_consents_page
+  end
+
+  def given_a_campaign_with_a_running_session
+    @team = create(:team, :with_one_nurse, :with_one_location)
+    @campaign = create(:campaign, :hpv, team: @team)
+    @batch = @campaign.batches.first
+    @session =
+      create(:session, campaign: @campaign, location: @team.locations.first)
+  end
+
+  def and_a_patient_needing_triage
+    @patient =
+      create(
+        :patient_with_consent_given_triage_needed,
+        session: @session,
+        location: @session.location
+      )
+  end
+
+  def and_i_am_signed_in
+    sign_in @team.users.first
+  end
+
+  def when_i_go_to_the_given_tab_of_the_consents_page
+    visit consents_session_path(@session, anchor: "given")
+  end
+
+  def and_i_go_to_the_patient_that_needs_triage
+    click_link @patient.full_name
+  end
+
+  def and_i_record_that_they_are_safe_to_vaccinate
+    choose "Yes, it’s safe to vaccinate"
+    click_button "Save triage"
+  end
+
+  def then_i_see_the_consents_page
+    expect(page).to have_content("Check consent responses")
+  end
+end

--- a/spec/features/triage_during_vaccination_spec.rb
+++ b/spec/features/triage_during_vaccination_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe "Triage" do
+  include EmailExpectations
+
+  scenario "during vaccination" do
+    given_a_campaign_with_a_running_session
+    and_a_patient_needing_triage
+    and_i_am_signed_in
+
+    when_i_go_to_the_vaccinations_page
+    and_i_go_to_the_patient_that_needs_triage
+    and_i_record_that_they_are_safe_to_vaccinate
+    then_i_see_the_vaccinations_page
+    and_i_should_see_that_the_patient_is_ready_for_vaccination
+  end
+
+  def given_a_campaign_with_a_running_session
+    @team = create(:team, :with_one_nurse, :with_one_location)
+    @campaign = create(:campaign, :hpv, team: @team)
+    @batch = @campaign.batches.first
+    @session =
+      create(:session, campaign: @campaign, location: @team.locations.first)
+  end
+
+  def and_a_patient_needing_triage
+    @patient =
+      create(
+        :patient_with_consent_given_triage_needed,
+        session: @session,
+        location: @session.location
+      )
+  end
+
+  def and_i_am_signed_in
+    sign_in @team.users.first
+  end
+
+  def when_i_go_to_the_vaccinations_page
+    visit vaccinations_session_path(@session)
+  end
+
+  def and_i_go_to_the_patient_that_needs_triage
+    click_link @patient.full_name
+  end
+
+  def and_i_record_that_they_are_safe_to_vaccinate
+    choose "Yes, it’s safe to vaccinate"
+    click_button "Save triage"
+  end
+
+  def then_i_see_the_vaccinations_page
+    expect(page).to have_content("Record vaccinations")
+  end
+
+  def and_i_should_see_that_the_patient_is_ready_for_vaccination
+    within("tr", text: @patient.full_name) do
+      expect(page).to have_content("Vaccinate")
+    end
+  end
+end


### PR DESCRIPTION
The implementation here is pretty simple, although I'm still a little on the fence about it. Basically when they visit either the "Triage health questions" or the "Record vaccinations" pages, this is recorder in their session info as their `current_section` and can be `triage` or `vaccinations`. Then, the `create` or `update` actions during triage will examine `current_section` and return them to the appropriate page.

The alternative to this, admittedly quite simple, approach is to use the paths, e.g.:

> [!Note]
> This is an illustration of an alternative implementation, not what was implemented in this PR

```
# List of patients for vaccinations (existing route)
/sessions/1/vaccinations

# Viewing a patient for vaccination
/sessions/1/vaccinations/patients/2

# Then the URL used for submitting triage for this patient
/sessions/1/vaccinations/patients/2/triage

# For illustration, viewing a patient while performing triage:
/sessions/1/triage/patients/2

# And the path to POST to update triage
/sessions/1/triage/patients/2/triage
```

Reasons to do this:
- transparent and clearer what's going on (imo) vs using cookies 
- stateless approach, can be linkable

Reasons not to do this:
- URLs are a bit long
- technically the patient pages don't change (currently) between these views

Work that needs to be done in follow-up PRs:
- sort out how this same feature is implemented for other actions and back buttons
- either use or remove `:route` from the URL paths (part of above)
- don't send out a "give feedback" email after doing triage during vaccinations (bug, see tests in this PR)
- stop using `:patient_session_id` for the patient page, use `:patient_id` to make it follow convention