### PR TITLE
Record vaccinations: move refusers and conflicting responses to 'Could not vaccinate' tab

### DIFF
--- a/app/components/app_patient_table_filter_component.html.erb
+++ b/app/components/app_patient_table_filter_component.html.erb
@@ -32,12 +32,6 @@
               </label>
             </div>
             <div class="govuk-checkboxes__item">
-              <input class="govuk-checkboxes__input" id="filter-<%= @tab_id %>-action-2" name="action" type="checkbox" value="Check refusal">
-              <label class="govuk-label govuk-checkboxes__label" for="filter-<%= @tab_id %>-action-2">
-                Check refusal
-              </label>
-            </div>
-            <div class="govuk-checkboxes__item">
               <input class="govuk-checkboxes__input" id="filter-<%= @tab_id %>-action-3" name="action" type="checkbox" value="Triage">
               <label class="govuk-label govuk-checkboxes__label" for="filter-<%= @tab_id %>-action-3">
                 Triage

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -23,13 +23,13 @@ class VaccinationsController < ApplicationController
         triaged_kept_in_triage
         triaged_ready_to_vaccinate
         added_to_session
-        consent_refused
-        consent_conflicts
         consent_given_triage_not_needed
       ],
       vaccinated: %w[vaccinated],
       vaccinate_later: %w[delay_vaccination],
       not_vaccinated: %w[
+        consent_refused
+        consent_conflicts
         triaged_do_not_vaccinate
         unable_to_vaccinate
         unable_to_vaccinate_not_assessed

--- a/config/locales/patient_session_statuses.en.yml
+++ b/config/locales/patient_session_statuses.en.yml
@@ -17,12 +17,12 @@ en:
       banner_explanation: "%{full_name} is ready to vaccinate"
     consent_refused:
       colour: orange
-      text: Check refusal
+      text: Consent refused
       banner_title: Consent refused
       banner_explanation: "%{who_refused} refused to give consent"
     consent_conflicts:
       colour: orange
-      text: Check conflicting consent
+      text: Conflicting consent
       banner_title: Conflicting consent
       banner_explanation: "You can only vaccinate if all respondents give consent"
     delay_vaccination:
@@ -46,7 +46,7 @@ en:
       banner_explanation: "%{triage_nurse} decided that %{full_name} is safe to vaccinate"
     unable_to_vaccinate:
       colour: red
-      text: Unable to vaccinate
+      text: Could not vaccinate
       banner_title: Could not vaccinate
       banner_explanation:
         refused: "%{full_name} refused it"

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Parental consent" do
 
     within("div#could-not-vaccinate") do
       within("tr", text: @child.full_name) do
-        expect(page).to have_content("Check refusal")
+        expect(page).to have_content("Consent refused")
       end
     end
   end

--- a/spec/features/parental_consent_refused_spec.rb
+++ b/spec/features/parental_consent_refused_spec.rb
@@ -149,9 +149,10 @@ RSpec.describe "Parental consent" do
     click_on "Pilot School"
     click_on "Record vaccinations"
 
-    expect(page).to have_content("Action needed (1)")
-    click_on "Action needed (1)"
-    within("div#action-needed") do
+    expect(page).to have_content("Could not vaccinate (1)")
+    click_on "Could not vaccinate (1)"
+
+    within("div#could-not-vaccinate") do
       within("tr", text: @child.full_name) do
         expect(page).to have_content("Check refusal")
       end


### PR DESCRIPTION
## Action needed tab

<img width="997" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/85f8ca41-c93a-4e4f-8ee9-8d3d7288517d">

## Could not vaccinate tab

<img width="1011" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/9073a6f1-96fd-4230-88ec-22b59a9e94e1">

