### PR TITLE
Review inset text font size, spacing and visually hidden text

### DIFF
--- a/app/views/cohort_lists/new.html.erb
+++ b/app/views/cohort_lists/new.html.erb
@@ -11,7 +11,9 @@
 
 <% if @team.remaining_cohort_size.zero? %>
   <%= h1 page_title %>
-  <%= govuk_inset_text(classes: "nhsuk-u-margin-top-4") do %>
+  <%= govuk_inset_text do %>
+    <span class="nhsuk-visually-hidden">Information: </span>
+
     <p>
       Your current cohort has <%= pluralize(@team.cohort_size, "child") %>.
       You have reached the maximum number of children for this pilot.
@@ -25,7 +27,9 @@
       label: { text: page_title, tag: 'h1', size: 'l' },
       hint: { text: 'Make sure the CSV you upload has the same format as your
                      standard cohort template' } do %>
-      <%= govuk_inset_text(classes: 'nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4') do %>
+      <%= govuk_inset_text do %>
+        <span class="nhsuk-visually-hidden">Information: </span>
+
         <p>
           <% if @team.cohort_size.zero? %>
             Your current cohort is empty.

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -12,8 +12,10 @@
 <%= h1 page_title, page_title: %>
 
 <% if @unmatched_record_counts > 0 %>
-  <%= govuk_inset_text(classes: "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4") do %>
-    <p class="nhsuk-body">
+  <%= govuk_inset_text do %>
+    <span class="nhsuk-visually-hidden">Information: </span>
+
+    <p>
       <%=
         responses = pluralize(@unmatched_record_counts, 'response')
         link_to(

--- a/app/views/edit_sessions/confirm.html.erb
+++ b/app/views/edit_sessions/confirm.html.erb
@@ -13,7 +13,11 @@
 
 <% if @session.send_consent_at.today? %>
   <%= govuk_inset_text do %>
-    After clicking confirm, consent request emails will be sent immediately.
+    <span class="nhsuk-visually-hidden">Information: </span>
+
+    <p>
+      After clicking confirm, consent request emails will be sent immediately.
+    </p>
   <% end %>
 <% end %>
 

--- a/app/views/edit_sessions/timeline.html.erb
+++ b/app/views/edit_sessions/timeline.html.erb
@@ -10,8 +10,11 @@
   <%= h1 "What’s the timeline for consent requests?" %>
 
   <%= govuk_inset_text do %>
-    <span class="nhsuk-visually-hidden">Information:</span>
-    Session scheduled for <%= @session.date.to_fs(:nhsuk_date_day_of_week) %> (<%= @session.human_enum_name(:time_of_day) %>)
+    <span class="nhsuk-visually-hidden">Information: </span>
+
+    <p>
+      Session scheduled for <%= @session.date.to_fs(:nhsuk_date_day_of_week) %> (<%= @session.human_enum_name(:time_of_day) %>)
+    </p>
   <% end %>
 
   <%= f.govuk_date_field :send_consent_at,

--- a/app/views/parent_interface/consent_forms/edit/school.html.erb
+++ b/app/views/parent_interface/consent_forms/edit/school.html.erb
@@ -7,8 +7,7 @@
 
 <%= h1 "Confirm your child’s school" %>
 
-<%= govuk_inset_text(classes: 'nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4') do %>
-  <span class="nhsuk-u-visually-hidden">Information:</span>
+<%= govuk_inset_text do %>
   <p>
     <span class="nhsuk-heading-m nhsuk-u-margin-bottom-0">
       <%= @session.location.name %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -120,13 +120,11 @@
   <% end %>
 
   <%= govuk_inset_text do %>
-    <span class="nhsuk-visually-hidden">Information: </span>
-
     <h3 class="nhsuk-heading-m">
       What you’ll get for taking part in the pilot
     </h3>
 
-    <p class="nhsuk-body-m">
+    <p class="nhsuk-body">
       We’ll send you a £30 high street shopping voucher once you’ve:
     </p>
 
@@ -135,11 +133,11 @@
       <li>completed a survey about your experience</li>
     </ul>
 
-    <p class="nhsuk-body-m">
+    <p class="nhsuk-body">
       You need to do both these things to qualify for a voucher.
     </p>
 
-    <p class="nhsuk-body-m">
+    <p class="nhsuk-body">
       Vouchers are limited to one per household. If you have more than one child
       eligible for the HPV vaccination, you should only submit a consent
       response for one of your children.
@@ -149,7 +147,7 @@
       Follow-up research
     </h3>
 
-    <p class="nhsuk-body-m">
+    <p class="nhsuk-body">
       Once you’ve completed the survey, you might be asked to take part in some
       follow-up research. There are separate incentives for this, and there’s no
       obligation to take part.
@@ -157,7 +155,7 @@
 
     <h3>Your personal information </h3>
 
-    <p class="nhsuk-body-m">
+    <p class="nhsuk-body">
       Your contact details will be shared with NHS England so they can contact
       you and send you a high street shopping voucher. You can find out more
       about how NHS England will protect your personal information in their
@@ -168,7 +166,7 @@
       If you’re not chosen to take part in the pilot
     </h3>
 
-    <p class="nhsuk-body-m">
+    <p class="nhsuk-body">
       NHS England will delete your contact details within two months of the last pilot vaccination session taking place.
     </p>
   <% end %>


### PR DESCRIPTION
Spotted a few inconsistencies and missing visually hidden text when using the inset text component:

- Always use a paragraph to wrap text (ensuring correct font size)
- Always show visually hidden ‘Information: ’ text (when relevant)
- Use default top and bottom margins

Example:

| When | Screenshot |
| :- | :- |
| Before | <img width="595" alt="Screenshot 2024-03-12 at 11 33 46" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/bea076d7-7bb2-45bc-8052-dc2838204197"> |
| After | <img width="680" alt="Screenshot 2024-03-13 at 11 44 46" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/a8e86350-c63a-4e1b-9172-13dc0e384fb7"> |
