### PR TITLE
Verbal consent attempt, no response: update designs (part 2)

### DIFF
--- a/app/components/app_consent_component.rb
+++ b/app/components/app_consent_component.rb
@@ -55,12 +55,20 @@ class AppConsentComponent < ViewComponent::Base
 
   def consents_grouped_by_parent
     @consents_grouped_by_parent ||=
-      @patient_session.consents.group_by do |consent|
-        response = consent.human_enum_name(:response).capitalize
-        summary = "#{response} by #{consent.name}"
-        summary +=
-          " (#{consent.who_responded})" unless consent.via_self_consent?
-        summary
+      @patient_session.consents.group_by { |consent| summary_for(consent) }
+  end
+
+  private
+
+  def summary_for(consent)
+    summary =
+      if consent.respond_to?(:response_not_provided?) &&
+           consent.response_not_provided?
+        "Contacted #{consent.name}"
+      else
+        "#{consent.human_enum_name(:response).capitalize} by #{consent.name}"
       end
+    summary += " (#{consent.who_responded})" unless consent.via_self_consent?
+    summary
   end
 end

--- a/app/components/app_consent_response_component.rb
+++ b/app/components/app_consent_response_component.rb
@@ -18,7 +18,12 @@ class AppConsentResponseComponent < ViewComponent::Base
     end
 
     def response
-      consent.human_enum_name(:response).capitalize
+      if consent.respond_to?(:response_not_provided?) &&
+           consent.response_not_provided?
+        "No response when contacted"
+      else
+        consent.human_enum_name(:response).capitalize
+      end
     end
 
     def route

--- a/spec/components/app_consent_response_component_spec.rb
+++ b/spec/components/app_consent_response_component_spec.rb
@@ -27,13 +27,19 @@ RSpec.describe AppConsentResponseComponent, type: :component do
     end
 
     it { should_not have_css("ul") }
-  end
 
-  context "with consent taken over the phone" do
-    let(:consent) { create(:consent, :given_verbally) }
+    context "with consent refused" do
+      let(:consent) { create(:consent, :refused) }
 
-    it { should have_text("Consent given (phone)") }
-    it { should have_text("Test User") }
+      it { should have_text("Consent refused (online)") }
+    end
+
+    context "with consent taken over the phone" do
+      let(:consent) { create(:consent, :given_verbally) }
+
+      it { should have_text("Consent given (phone)") }
+      it { should have_text("Test User") }
+    end
   end
 
   context "with consent_form" do
@@ -62,11 +68,5 @@ RSpec.describe AppConsentResponseComponent, type: :component do
     let(:consents) { [consent1, consent2] }
 
     it { should have_css("ul li p", text: "Consent given (online)", count: 2) }
-  end
-
-  context "with consent refused" do
-    let(:consent) { create(:consent, :refused) }
-
-    it { should have_text("Consent refused (online)") }
   end
 end

--- a/spec/components/app_consent_response_component_spec.rb
+++ b/spec/components/app_consent_response_component_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe AppConsentResponseComponent, type: :component do
       it { should have_text("Consent given (phone)") }
       it { should have_text("Test User") }
     end
+
+    context "with no response to attempt to get verbal consent" do
+      let(:consent) { create(:consent, :not_provided) }
+
+      it { should have_text("No response when contacted") }
+    end
   end
 
   context "with consent_form" do

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -49,7 +49,9 @@ async function when_i_click_get_consent() {
 const and_i_click_get_consent = when_i_click_get_consent;
 
 async function then_i_see_the_previous_attempt_to_get_consent() {
-  await expect(p.getByText(/Not provided.*phone/)).toBeVisible();
+  await expect(
+    p.getByText(/No response when contacted.*\(phone\)/),
+  ).toBeVisible();
 }
 
 async function when_i_submit_a_consent_with_no_response() {


### PR DESCRIPTION
Follow-up to #1190. Copy changes, after discussion with designers, to the consent list on the patient page.

Before             |  After
:-------------:|:----------------:
<img width="638" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/86df1129-6bd7-42be-82ed-a8b0961bd9be">|<img width="633" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/6cf53a84-c4ce-4f40-b5cc-28932a84ffc7">
