### PR TITLE
On the outcome banner, display a location only when the vaccination record has been recorded

### DIFF
--- a/app/components/app_outcome_banner_component.rb
+++ b/app/components/app_outcome_banner_component.rb
@@ -48,8 +48,8 @@ class AppOutcomeBannerComponent < ViewComponent::Base
   end
 
   def show_location?
-    # location only makes sense if an attempt to vaccinate on site was made
-    @patient_session.vaccination_records.any?
+    # showing the location only makes sense if an attempt to vaccinate on site was made
+    @patient_session.vaccination_records.recorded.any?
   end
 
   def vaccine_summary


### PR DESCRIPTION
This prevents draft vaccs records from causing the school to be displayed.