### PR TITLE
Consent response summary: response row redesign

### DIFF
--- a/app/components/app_consent_card_component.html.erb
+++ b/app/components/app_consent_card_component.html.erb
@@ -17,17 +17,13 @@
 
     summary_list.with_row do |row|
       row.with_key { "Response" }
-      row.with_value do %>
-        <p class="nhsuk-u-margin-bottom-0">
-        <%= response_string %>
-        </p>
-        <p class="nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color nhsuk-u-font-size-16 nhsuk-u-margin-bottom-0">
-          <% if @consent.recorded_by.present? %>
-            <%= govuk_link_to @consent.recorded_by.full_name, "mailto:#{@consent.recorded_by.email}" %>,
-          <% end %>
-          <%= Time.zone.now.to_fs(:app_date_time) %>
-        </p>
-      <% end
+      row.with_value do
+        render AppTimestampedEntryComponent.new(
+          text: response_string,
+          timestamp: Time.zone.now,
+          recorded_by: @consent.recorded_by
+        )
+      end
     end
 
     if @consent.response_refused?

--- a/app/components/app_consent_response_component.rb
+++ b/app/components/app_consent_response_component.rb
@@ -1,67 +1,47 @@
 class AppConsentResponseComponent < ViewComponent::Base
-  class AppSingleConsentResponseComponent < ViewComponent::Base
-    erb_template <<-ERB
-      <p class="nhsuk-body">
-        <%= response %> (<%= route %>)
-      </p>
-      <p class="nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color nhsuk-u-font-size-16 nhsuk-u-margin-bottom-0">
-        <%= recorded_by_link %><br />
-        <%= consent.recorded_at.to_fs(:nhsuk_date) %> at <%= consent.recorded_at.to_fs(:time) %>
-      </p>
-    ERB
+  def initialize(consents:)
+    super
+    @consents = consents
+  end
 
-    attr_reader :consent
-
-    def initialize(consent:)
-      super
-      @consent = consent
-    end
-
-    def response
-      if consent.respond_to?(:response_not_provided?) &&
-           consent.response_not_provided?
-        "No response when contacted"
-      else
-        consent.human_enum_name(:response).capitalize
-      end
-    end
-
-    def route
-      if consent.respond_to?(:route)
-        consent.human_enum_name(:route).downcase
-      else
-        "online"
-      end
-    end
-
-    def recorded_by_link
-      if consent.respond_to?(:via_phone?) && consent.via_phone?
-        link_to(
-          consent.recorded_by.full_name,
-          "mailto:#{consent.recorded_by.email}"
+  def call
+    if @consents.size == 1
+      consent = @consents.first
+      render AppTimestampedEntryComponent.new(
+               text: summary_with_route(consent),
+               timestamp: consent.recorded_at,
+               recorded_by: staff_who_recorded(consent)
+             )
+    elsif @consents.size > 1
+      tag.ul(class: "nhsuk-list nhsuk-list--bullet app-list--events") do
+        safe_join(
+          @consents.map do |entry|
+            tag.li do
+              render AppTimestampedEntryComponent.new(
+                       text: summary_with_route(entry),
+                       timestamp: entry.recorded_at,
+                       recorded_by: staff_who_recorded(entry)
+                     )
+            end
+          end
         )
-      else
-        link_to(consent.parent_name, "mailto:#{consent.parent_email}")
       end
     end
   end
 
-  erb_template <<-ERB
-    <% if @consents.size == 1 %>
-      <%= render(AppSingleConsentResponseComponent.new(consent: @consents.first)) %>
-    <% elsif @consents.size > 1 %>
-      <ul class="nhsuk-list nhsuk-list--bullet app-list--events">
-        <% @consents.each do |consent| %>
-          <li>
-            <%= render(AppSingleConsentResponseComponent.new(consent: consent)) %>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
-  ERB
+  private
 
-  def initialize(consents:)
-    super
-    @consents = consents
+  def summary_with_route(consent)
+    route_string = consent.human_enum_name(:route).downcase.presence || "online"
+    if consent.respond_to?(:response_not_provided?) &&
+         consent.response_not_provided?
+      "No response when contacted (#{route_string})"
+    else
+      "#{consent.human_enum_name(:response).capitalize} (#{route_string})"
+    end
+  end
+
+  def staff_who_recorded(consent)
+    consent.recorded_by if consent.respond_to?(:recorded_by)
   end
 end

--- a/app/components/app_timestamped_entry_component.rb
+++ b/app/components/app_timestamped_entry_component.rb
@@ -1,0 +1,20 @@
+class AppTimestampedEntryComponent < ViewComponent::Base
+  erb_template <<-ERB
+    <p class="nhsuk-body">
+      <%= @text %>
+    </p>
+    <p class="nhsuk-u-margin-bottom-2 nhsuk-u-secondary-text-color nhsuk-u-font-size-16 nhsuk-u-margin-bottom-0">
+      <% if @recorded_by.present? %>
+        <%= mail_to(@recorded_by.email, @recorded_by.full_name) %>,
+      <% end %>
+      <%= @timestamp.to_fs(:app_date_time) %>
+    </p>
+  ERB
+
+  def initialize(text:, timestamp:, recorded_by: nil)
+    super
+    @text = text
+    @timestamp = timestamp || Time.zone.now
+    @recorded_by = recorded_by
+  end
+end

--- a/spec/components/app_consent_response_component_spec.rb
+++ b/spec/components/app_consent_response_component_spec.rb
@@ -3,29 +3,27 @@ require "rails_helper"
 RSpec.describe AppConsentResponseComponent, type: :component do
   let(:consents) { [consent] }
   let(:component) { described_class.new(consents:) }
+  let(:nurse) do
+    create(:user, full_name: "Test User", email: "test@example.com")
+  end
 
   subject { page }
 
   before { render_inline(component) }
 
   context "with a single consent" do
-    let(:consent) { create(:consent, :given) }
+    let(:consent) do
+      create(
+        :consent,
+        :given,
+        recorded_at: Time.zone.local(2024, 2, 29, 12, 0, 0)
+      )
+    end
     let(:consents) { [consent] }
 
     it { should have_text("Consent given (online)") }
-    it { should have_text(consent.parent_name) }
-    it do
-      should have_text(
-               "#{consent.created_at.to_fs(:nhsuk_date)} at #{consent.created_at.to_fs(:time)}"
-             )
-    end
-    it do
-      should have_link(
-               consent.parent_name,
-               href: "mailto:#{consent.parent_email}"
-             )
-    end
-
+    it { should_not have_text(consent.parent_name) }
+    it { should have_text("29 Feb 2024 at 12:00pm") }
     it { should_not have_css("ul") }
 
     context "with consent refused" do
@@ -35,43 +33,36 @@ RSpec.describe AppConsentResponseComponent, type: :component do
     end
 
     context "with consent taken over the phone" do
-      let(:consent) { create(:consent, :given_verbally) }
+      let(:consent) { create(:consent, :given_verbally, recorded_by: nurse) }
 
       it { should have_text("Consent given (phone)") }
       it { should have_text("Test User") }
     end
 
     context "with no response to attempt to get verbal consent" do
-      let(:consent) { create(:consent, :not_provided) }
+      let(:consent) { create(:consent, :not_provided, recorded_by: nurse) }
 
       it { should have_text("No response when contacted") }
     end
   end
 
   context "with consent_form" do
-    let(:consent_form) { create(:consent_form, :recorded) }
+    let(:consent_form) do
+      create(
+        :consent_form,
+        :recorded,
+        recorded_at: Time.zone.local(2024, 2, 29, 12, 0, 0)
+      )
+    end
     let(:consents) { [consent_form] }
 
     it { should have_text("Consent given (online)") }
-    it { should have_text(consent_form.parent_name) }
-    it do
-      should have_text(
-               "#{consent_form.created_at.to_fs(:nhsuk_date)} at #{consent_form.created_at.to_fs(:time)}"
-             )
-    end
-
-    it do
-      should have_link(
-               consent_form.parent_name,
-               href: "mailto:#{consent_form.parent_email}"
-             )
-    end
+    it { should have_text("29 Feb 2024 at 12:00pm") }
+    it { should_not have_text(consent_form.parent_name) }
   end
 
   context "with multiple consents" do
-    let(:consent1) { create(:consent, :given) }
-    let(:consent2) { create(:consent, :given) }
-    let(:consents) { [consent1, consent2] }
+    let(:consents) { create_list(:consent, 2, :given) }
 
     it { should have_css("ul li p", text: "Consent given (online)", count: 2) }
   end

--- a/spec/components/app_timestamped_entry_component_spec.rb
+++ b/spec/components/app_timestamped_entry_component_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe AppTimestampedEntryComponent, type: :component do
+  subject { page }
+
+  before { render_inline(component) }
+
+  context "with text and a timestamp" do
+    let(:component) do
+      described_class.new(
+        text: "Summary of a thing",
+        timestamp: Time.zone.local(2024, 2, 17, 12, 23, 0)
+      )
+    end
+
+    let(:consent) { create(:consent, :given) }
+    let(:consents) { [consent] }
+
+    it { should have_text("Summary of a thing") }
+    it { should have_text("17 Feb 2024 at 12:23pm") }
+  end
+
+  context "with a user who recorded the entry" do
+    let(:component) do
+      described_class.new(
+        text: "Summary of a thing",
+        timestamp: Time.zone.local(2024, 2, 17, 12, 23, 0),
+        recorded_by:
+          create(:user, full_name: "Test User", email: "test@example.com")
+      )
+    end
+
+    it { should have_link("Test User", href: "mailto:test@example.com") }
+  end
+end


### PR DESCRIPTION
Adopt consistent presentation for the "Response" row of the consent tables across:

* the patient page
* the "verbal consent" confirmation page
* the "manual matching" page

## The new designs

* show the timestamp when the response was recorded
* show the name of the staff member who recorded the consent, for verbal or self-consent
* don't display the parent's name for online consent (previously the parent's name was shown)
* the name and timestamp are shown on the same line (previously they were across two lines on some pages)

## Comparisons

Scenario|Before             |  After
:-------------:|:-------------:|:----------------:
Online consent|<img width="528" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/3a7eb91a-0619-4a26-b505-e61077834727">|<img width="537" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/11da6c76-66ee-490d-ba9e-33858ef14304">
Self consent – patient page|<img width="524" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/997f4cc4-d419-4274-8eee-6fcf19e7eaff">|<img width="539" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/60f81616-d292-4ad2-b63d-343c740e87df">
Verbal consent – confirmation page|<img width="574" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/f53d10a9-5eb1-4f55-a0f7-f400a2977c6e">|<img width="574" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/512a89ef-5342-4bd6-978c-6f3f4400d0cd">
Verbal consent – patient page|<img width="531" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/7c958345-24d2-432f-aac1-96e260782da6">|<img width="528" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/c0f9f4ed-7813-4bd1-8fe0-dbe3a6a4fc11">
Manual matching of consent forms|<img width="568" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/1cafd16a-f66a-4437-8ce0-9366a60f650b">|<img width="565" alt="image" src="https://github.com/nhsuk/manage-childrens-vaccinations/assets/23801/9b76cea8-d7b7-43a8-8ce9-46535baf2d96">


