### PR TITLE
VaccinationRecord: set the 'recorded' scope as default

### DIFF
--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -31,9 +31,9 @@ class PatientSessionsController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record =
-      @patient.vaccination_records_for_session(@session).find_or_initialize_by(
-        recorded_at: nil
-      )
+      @patient.draft_vaccination_records_for_session(
+        @session
+      ).find_or_initialize_by(recorded_at: nil)
   end
 
   def set_route

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -31,7 +31,7 @@ class PatientSessionsController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record =
-      @patient_session.vaccination_records.find_or_initialize_by(
+      @patient.vaccination_records_for_session(@session).find_or_initialize_by(
         recorded_at: nil
       )
   end

--- a/app/controllers/vaccinations/batches_controller.rb
+++ b/app/controllers/vaccinations/batches_controller.rb
@@ -28,7 +28,7 @@ class Vaccinations::BatchesController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record =
-      @patient.vaccination_records_for_session(@session).find_by(
+      @patient.draft_vaccination_records_for_session(@session).find_by(
         recorded_at: nil
       )
 

--- a/app/controllers/vaccinations/delivery_site_controller.rb
+++ b/app/controllers/vaccinations/delivery_site_controller.rb
@@ -36,7 +36,7 @@ class Vaccinations::DeliverySiteController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record =
-      @patient.vaccination_records_for_session(@session).find_by(
+      @patient.draft_vaccination_records_for_session(@session).find_by(
         recorded_at: nil
       )
 

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -56,11 +56,11 @@ class VaccinationsController < ApplicationController
   end
 
   def new
-    if @patient.vaccination_records_for_session(@session).any?
+    if @patient.draft_vaccination_records_for_session(@session).any?
       raise UnprocessableEntity
     end
     @draft_vaccination_record =
-      @patient.vaccination_records_for_session(@session).new
+      @patient.draft_vaccination_records_for_session(@session).new
   end
 
   def edit_reason
@@ -206,9 +206,9 @@ class VaccinationsController < ApplicationController
 
   def set_draft_vaccination_record
     @draft_vaccination_record =
-      @patient.vaccination_records_for_session(@session).find_or_initialize_by(
-        recorded_at: nil
-      )
+      @patient.draft_vaccination_records_for_session(
+        @session
+      ).find_or_initialize_by(recorded_at: nil)
   end
 
   def set_draft_vaccination_record!

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -91,7 +91,7 @@ class Patient < ApplicationRecord
     super.merge("full_name" => full_name, "age" => age)
   end
 
-  def vaccination_records_for_session(session)
+  def draft_vaccination_records_for_session(session)
     patient_sessions
       .find_by_session_id(session.id)
       .vaccination_records

--- a/app/models/patient.rb
+++ b/app/models/patient.rb
@@ -92,7 +92,10 @@ class Patient < ApplicationRecord
   end
 
   def vaccination_records_for_session(session)
-    patient_sessions.find_by_session_id(session.id).vaccination_records
+    patient_sessions
+      .find_by_session_id(session.id)
+      .vaccination_records
+      .rewhere(recorded_at: nil)
   end
 
   def year_group

--- a/app/models/vaccination_record.rb
+++ b/app/models/vaccination_record.rb
@@ -44,6 +44,8 @@ class VaccinationRecord < ApplicationRecord
   scope :administered, -> { where(administered: true) }
   scope :recorded, -> { where.not(recorded_at: nil) }
 
+  default_scope { recorded }
+
   enum :delivery_method, %w[intramuscular subcutaneous], prefix: true
   enum :delivery_site,
        %w[


### PR DESCRIPTION
This helps reduce problems like the one in #1194. 