### PR TITLE
Allow consent to be changed to given via verbal consent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,9 @@ end
 
 group :test do
   gem "capybara"
+  gem "capybara_accessible_selectors",
+      git: "https://github.com/citizensadvice/capybara_accessible_selectors",
+      branch: "main"
   gem "capybara-screenshot"
   gem "cuprite"
   gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/citizensadvice/capybara_accessible_selectors
+  revision: f9a7261a3c44cead8b40cbc4353c242a2b0ca388
+  branch: main
+  specs:
+    capybara_accessible_selectors (0.11.0)
+      capybara (~> 3.36)
+
+GIT
   remote: https://github.com/misaka/faker.git
   revision: 2c3cbbeedab7de86bbac5a1de9acf0333d268791
   branch: add_alternative_name
@@ -549,6 +557,7 @@ DEPENDENCIES
   brakeman
   capybara
   capybara-screenshot
+  capybara_accessible_selectors!
   config
   cssbundling-rails
   cuprite

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -51,6 +51,22 @@ class ManageConsentsController < ApplicationController
     render_wizard @consent
   end
 
+  def clone
+    existing_consent = Consent.find(params.delete(:consent_id))
+    @consent =
+      existing_consent.dup.tap do |consent|
+        consent.recorded_at = nil
+        consent.recorded_by = current_user
+      end
+
+    handle_agree
+    set_steps
+    setup_wizard_translated
+
+    @consent.save!
+    redirect_to wizard_path(next_step, consent_id: @consent.id)
+  end
+
   private
 
   def current_step

--- a/app/helpers/manage_consents_helper.rb
+++ b/app/helpers/manage_consents_helper.rb
@@ -1,0 +1,13 @@
+module ManageConsentsHelper
+  def form_path_for(consent)
+    consent.recorded? ? clone_session_patient_manage_consent_path : wizard_path
+  end
+
+  def form_method_for(consent)
+    consent.recorded? ? :post : :put
+  end
+
+  def include_clone_fields_for(consent)
+    consent.recorded?
+  end
+end

--- a/app/models/concerns/patient_session_state_machine_concern.rb
+++ b/app/models/concerns/patient_session_state_machine_concern.rb
@@ -113,27 +113,29 @@ module PatientSessionStateMachineConcern
     def consent_given?
       return false if no_consent?
 
-      consents.all?(&:response_given?)
+      latest_consents.all?(&:response_given?)
     end
 
     def consent_refused?
       return false if no_consent?
 
-      consents.all?(&:response_refused?)
+      latest_consents.all?(&:response_refused?)
     end
 
     def consent_conflicts?
       return false if no_consent?
 
-      consents.any?(&:response_given?) && consents.any?(&:response_refused?)
+      latest_consents.any?(&:response_refused?) &&
+        latest_consents.any?(&:response_given?)
     end
 
     def no_consent?
-      consents.empty? || consents.all?(&:response_not_provided?)
+      consents.recorded.empty? ||
+        consents.recorded.all?(&:response_not_provided?)
     end
 
     def triage_needed?
-      consents.any?(&:triage_needed?)
+      latest_consents.any?(&:triage_needed?)
     end
 
     def triage_not_needed?

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -51,6 +51,7 @@ class Consent < ApplicationRecord
 
   scope :submitted_for_campaign,
         ->(campaign) { where(campaign:).where.not(recorded_at: nil) }
+  scope :recorded, -> { where.not(recorded_at: nil) }
 
   enum :parent_contact_method, %w[text voice other any], prefix: true
   enum :parent_relationship, %w[mother father guardian other], prefix: true
@@ -231,6 +232,10 @@ class Consent < ApplicationRecord
       end
     summary += " (#{who_responded})" unless via_self_consent?
     summary
+  end
+
+  def recorded?
+    recorded_at.present?
   end
 
   private

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -64,4 +64,11 @@ class PatientSession < ApplicationRecord
     !unable_to_vaccinate? && !unable_to_vaccinate_not_assessed? &&
       !unable_to_vaccinate_not_gillick_competent?
   end
+
+  def latest_consents
+    consents
+      .recorded
+      .group_by(&:name)
+      .map { |_, consents| consents.max_by(&:recorded_at) }
+  end
 end

--- a/app/views/manage_consents/agree.html.erb
+++ b/app/views/manage_consents/agree.html.erb
@@ -8,8 +8,12 @@
 <% title = t("consents.edit_consent.title.#{ @session.type.downcase }") %>
 <% content_for :page_title, title %>
 
-<%= form_for @consent, url: wizard_path, method: :put do |f| %>
+<%= form_for @consent, url: form_path_for(@consent), method: form_method_for(@consent) do |f| %>
   <%= f.govuk_error_summary %>
+  <% if include_clone_fields_for(@consent) %>
+    <%= hidden_field_tag :clone_consent_id, @consent.id %>
+    <%= hidden_field_tag :step, "agree" %>
+  <% end %>
   <%= f.govuk_radio_buttons_fieldset(:response,
     caption: { size: 'l',
                text: @patient.full_name },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,7 +119,9 @@ Rails.application.routes.draw do
       post ":route/consents", to: "manage_consents#create", as: :manage_consents
       resources :manage_consents,
                 only: %i[show update],
-                path: ":route/consents/:consent_id/"
+                path: ":route/consents/:consent_id/" do
+        post "clone", on: :member
+      end
     end
 
     constraints -> { Flipper.enabled? :offline_working } do

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -24,10 +24,13 @@
 #
 FactoryBot.define do
   factory :patient_session do
-    transient { user { create :user } }
+    transient do
+      campaign { create :campaign }
+      user { create :user }
+    end
 
     patient { create :patient }
-    session { create :session }
+    session { create(:session, campaign:) }
 
     trait :added_to_session do
       state { "added_to_session" }

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -197,5 +197,13 @@ FactoryBot.define do
         ]
       end
     end
+
+    factory :patient_with_consent_refused do
+      patient_sessions do
+        [build(:patient_session, session:, state: "consent_refused")]
+      end
+
+      consents { [build(:consent, :refused, campaign:, parent_relationship:)] }
+    end
   end
 end

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+feature "Verbal consent" do
+  include EmailExpectations
+
+  before { Flipper.enable(:parent_contact_method) }
+
+  scenario "Given when previously refused" do
+    given_an_hpv_campaign_is_underway
+    and_a_parent_has_refused_consent_for_their_child
+    and_i_am_logged_in_as_a_nurse
+
+    when_the_nurse_checks_the_consent_responses_given
+    and_i_call_the_parent_that_has_refused_consent
+    and_consent_is_given_verbally
+    then_i_am_returned_to_the_check_consent_responses_page
+    and_i_see_the_success_alert
+    and_i_see_them_in_the_consent_given_tab
+  end
+
+  def given_an_hpv_campaign_is_underway
+    @team = create(:team, :with_one_nurse)
+    campaign = create(:campaign, :hpv, team: @team)
+    location = create(:location, name: "Pilot School", team: @team)
+    @session =
+      create(:session, :in_future, campaign:, location:, patients_in_session: 1)
+  end
+
+  def and_a_parent_has_refused_consent_for_their_child
+    @child = create(:patient_with_consent_refused, session: @session)
+  end
+
+  def and_i_am_logged_in_as_a_nurse
+    sign_in @team.users.first
+  end
+
+  def when_the_nurse_checks_the_consent_responses_given
+    visit "/dashboard"
+    click_on "School sessions", match: :first
+    click_on "Pilot School"
+    click_on "Check consent responses"
+    click_on "Refused"
+    click_on @child.full_name
+  end
+
+  def and_i_call_the_parent_that_has_refused_consent
+    click_on "Contact #{@child.consents.first.parent_name}"
+  end
+
+  def and_consent_is_given_verbally
+    choose "Yes, they agree"
+    click_button "Continue"
+
+    # Health questions
+    find_all(".edit_consent .nhsuk-fieldset")[0].choose "No"
+    find_all(".edit_consent .nhsuk-fieldset")[1].choose "No"
+    find_all(".edit_consent .nhsuk-fieldset")[2].choose "No"
+    choose "Yes, it’s safe to vaccinate"
+    click_button "Continue"
+
+    click_button "Confirm"
+  end
+
+  def then_i_am_returned_to_the_check_consent_responses_page
+    expect(page).to have_content("Check consent responses")
+  end
+
+  def and_i_see_the_success_alert
+    expect(page).to have_alert(
+      "Success",
+      text: "Record saved for #{@child.full_name}"
+    )
+  end
+
+  def and_i_see_them_in_the_consent_given_tab
+    within "div#given" do
+      expect(page).to have_content(@child.full_name)
+    end
+  end
+end

--- a/spec/models/concerns/patient_session_state_machine_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_machine_concern_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe PatientSessionStateMachineConcern do
 
       include PatientSessionStateMachineConcern
 
+      def latest_consents
+      end
+
       def consents
       end
 
@@ -25,7 +28,10 @@ RSpec.describe PatientSessionStateMachineConcern do
 
   before do
     fsm.aasm_write_state_without_persistence(state) if state
-    allow(fsm).to receive(:consents).and_return(consents)
+    allow(fsm).to receive(:latest_consents).and_return(consents)
+    allow(fsm).to receive_message_chain(:consents, :recorded).and_return(
+      consents
+    )
     allow(fsm).to receive(:triage).and_return([triage])
     allow(fsm).to receive(:vaccination_record).and_return(vaccination_record)
   end
@@ -106,7 +112,7 @@ RSpec.describe PatientSessionStateMachineConcern do
 
     describe "#do_vaccination" do
       it "transitions to unable_to_vaccinate_not_assessed when consent is nil" do
-        allow(fsm).to receive(:consents).and_return([])
+        allow(fsm).to receive_message_chain(:consents, :recorded).and_return([])
 
         fsm.do_vaccination
         expect(fsm).to be_unable_to_vaccinate_not_assessed

--- a/spec/models/consent_spec.rb
+++ b/spec/models/consent_spec.rb
@@ -196,4 +196,29 @@ RSpec.describe Consent do
       ).to eq("Refusal confirmed by Jane (Mum)")
     end
   end
+
+  describe "#recorded scope" do
+    let(:patient) { create(:patient) }
+
+    it "returns only consents that have been recorded" do
+      consent = create(:consent, patient:, recorded_at: Time.zone.now)
+      create(:consent, patient:, recorded_at: nil)
+
+      expect(patient.consents.recorded).to eq([consent])
+    end
+  end
+
+  describe "#recorded?" do
+    it "returns true if recorded_at is set" do
+      consent = build(:consent, recorded_at: Time.zone.now)
+
+      expect(consent).to be_recorded
+    end
+
+    it "returns false if recorded_at is nil" do
+      consent = build(:consent, recorded_at: nil)
+
+      expect(consent).not_to be_recorded
+    end
+  end
 end


### PR DESCRIPTION
This fixes an error triggereg when a nurse tries to record consent given verbally when it was previously refused by the parent.

We fix this by cloning the existing consent instead of editing the existing one. This means when determining the state of consent we need to only look at the most recent response from a parent. It's also exposed other missing state transitions, such as if the parent verbally refuses consent again in the above scenario, or if another consent form is filled in. Fixes to these other transitions will be done in a follow-up PR to keep this one small(er).

Re: the cloning implementation, there are a couple things to point out. Because the link to changing the consent response is a link and not a button, we can't clone consent response when they click that link. We instead clone the consent object when the nurse to submits the response on the first page. I did try adding cloning functionality to `update` or `create` so that the form didn't have to change, but that started to get weird from a REST POV so I decided to just add the `clone` action to keep it clean.
