### PR TITLE
Add state concern to replace state machine

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -36,7 +36,7 @@ class ConsentsController < ApplicationController
       @session
         .patient_sessions
         .strict_loading
-        .includes(:campaign, :consents, :patient)
+        .includes(:campaign, :consents, :patient, :triage)
         .sort_by { |ps| ps.patient.full_name }
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,11 @@ class SessionsController < ApplicationController
 
   def show
     @patient_sessions =
-      @session.patient_sessions.strict_loading.includes(:campaign, :consents)
+      @session.patient_sessions.strict_loading.includes(
+        :campaign,
+        :consents,
+        :triage
+      )
 
     @counts =
       SessionStats.new(patient_sessions: @patient_sessions, session: @session)

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -15,7 +15,7 @@ class TriageController < ApplicationController
       @session
         .patient_sessions
         .strict_loading
-        .includes(:campaign, :patient)
+        .includes(:campaign, :patient, :triage)
         .order("patients.first_name", "patients.last_name")
 
     tabs_to_states = {

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -1,0 +1,161 @@
+module PatientSessionStateConcern
+  extend ActiveSupport::Concern
+
+  included do
+    def state
+      if vaccination_administered?
+        "vaccinated"
+      elsif triage_delay_vaccination? || vaccination_can_be_delayed?
+        "delay_vaccination"
+      elsif not_gillick_competent?
+        "unable_to_vaccinate_not_gillick_competent"
+      elsif vaccination_not_administered?
+        "unable_to_vaccinate"
+      elsif triage_keep_in_triage?
+        "triaged_kept_in_triage"
+      elsif triage_ready_to_vaccinate?
+        "triaged_ready_to_vaccinate"
+      elsif triage_do_not_vaccinate?
+        "triaged_do_not_vaccinate"
+      elsif consent_given? && triage_needed?
+        "consent_given_triage_needed"
+      elsif consent_given? && triage_not_needed?
+        "consent_given_triage_not_needed"
+      elsif consent_refused?
+        "consent_refused"
+      elsif consent_conflicts?
+        "consent_conflicts"
+      else
+        "added_to_session"
+      end
+    end
+
+    %w[
+      added_to_session
+      consent_given_triage_not_needed
+      consent_given_triage_needed
+      consent_refused
+      consent_conflicts
+      triaged_ready_to_vaccinate
+      triaged_do_not_vaccinate
+      triaged_kept_in_triage
+      unable_to_vaccinate
+      unable_to_vaccinate_not_assessed
+      unable_to_vaccinate_not_gillick_competent
+      delay_vaccination
+      vaccinated
+    ].each { |state| define_method("#{state}?") { self.state == state } }
+
+    def do_consent
+      nil
+    end
+    def do_consent!
+      nil
+    end
+
+    def do_triage
+      nil
+    end
+    def do_triage!
+      nil
+    end
+
+    def do_vaccination
+      nil
+    end
+
+    def do_vaccination!
+      nil
+    end
+
+    def may_do_consent?
+      true
+    end
+
+    def may_do_triage?
+      true
+    end
+
+    def may_do_vaccination?
+      true
+    end
+
+    def consent_given?
+      return false if no_consent?
+
+      latest_consents.all?(&:response_given?)
+    end
+
+    def consent_refused?
+      return false if no_consent?
+
+      latest_consents.all?(&:response_refused?)
+    end
+
+    def consent_conflicts?
+      return false if no_consent?
+
+      latest_consents.any?(&:response_refused?) &&
+        latest_consents.any?(&:response_given?)
+    end
+
+    def no_consent?
+      consents.recorded.empty? ||
+        consents.recorded.all?(&:response_not_provided?)
+    end
+
+    def triage_needed?
+      latest_consents.any?(&:triage_needed?)
+    end
+
+    def triage_not_needed?
+      !triage_needed?
+    end
+
+    def triage_ready_to_vaccinate?
+      triage.last&.ready_to_vaccinate?
+    end
+
+    def triage_keep_in_triage?
+      triage.last&.needs_follow_up?
+    end
+
+    def triage_do_not_vaccinate?
+      triage.last&.do_not_vaccinate?
+    end
+
+    def triage_delay_vaccination?
+      triage.last&.delay_vaccination?
+    end
+
+    def vaccination_administered?
+      vaccination_record&.administered?
+    end
+
+    def vaccination_not_administered?
+      vaccination_record&.administered == false
+    end
+
+    def not_gillick_competent?
+      gillick_competent == false
+    end
+
+    def vaccination_can_be_delayed?
+      vaccination_not_administered? &&
+        (
+          vaccination_record.not_well? ||
+            vaccination_record.contraindications? ||
+            vaccination_record.absent_from_session?
+        )
+    end
+
+    def next_step
+      if consent_given_triage_needed? || triaged_kept_in_triage?
+        :triage
+      elsif consent_given_triage_not_needed? || triaged_ready_to_vaccinate? ||
+            delay_vaccination?
+        :vaccinate
+      end
+    end
+  end
+end

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -49,6 +49,7 @@ module PatientSessionStateConcern
     def do_consent
       nil
     end
+
     def do_consent!
       nil
     end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -37,7 +37,7 @@ class PatientSession < ApplicationRecord
              foreign_key: :gillick_competence_assessor_user_id
 
   has_one :campaign, through: :session
-  has_many :triage
+  has_many :triage, -> { order(:updated_at) }
   has_many :vaccination_records
   has_many :consents,
            ->(patient) { Consent.submitted_for_campaign(patient.campaign) },

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -27,7 +27,7 @@ class PatientSession < ApplicationRecord
   audited
   has_associated_audits
 
-  include PatientSessionStateMachineConcern
+  include PatientSessionStateConcern
 
   belongs_to :patient
   belongs_to :session

--- a/spec/components/app_outcome_banner_component_spec.rb
+++ b/spec/components/app_outcome_banner_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AppOutcomeBannerComponent, type: :component do
 
     it { should have_css(".app-card--red") }
     it { should have_css(".nhsuk-card__heading", text: "Could not vaccinate") }
-    it { should have_text("Alya Merton had contraindications") }
+    it { should have_text("Alya Merton has already had the vaccine") }
     it { should have_text("Location#{patient_session.session.location.name}") }
   end
 

--- a/spec/components/app_patient_page_component_spec.rb
+++ b/spec/components/app_patient_page_component_spec.rb
@@ -2,9 +2,8 @@ require "rails_helper"
 
 RSpec.describe AppPatientPageComponent, type: :component do
   let(:component) do
-    described_class.new(patient_session:, route: "triage", triage:)
+    described_class.new(patient_session:, route: "triage", triage: nil)
   end
-  let(:triage) { nil }
   let!(:rendered) { render_inline(component) }
 
   subject { page }
@@ -17,7 +16,6 @@ RSpec.describe AppPatientPageComponent, type: :component do
         :session_in_progress
       )
     end
-    let(:triage) { FactoryBot.create(:triage, patient_session:) }
 
     it { should have_css(".nhsuk-card__heading", text: "Child details") }
     it { should have_css(".nhsuk-card__heading", text: "Consent") }

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -33,37 +33,30 @@ FactoryBot.define do
     session { create(:session, campaign:) }
 
     trait :added_to_session do
-      state { "added_to_session" }
       patient { create :patient, consents: [] }
     end
 
     trait :consent_given_triage_not_needed do
-      state { "consent_given_triage_not_needed" }
       patient { create :patient, :consent_given_triage_not_needed, session: }
     end
 
     trait :consent_given_triage_needed do
-      state { "consent_given_triage_needed" }
       patient { create :patient, :consent_given_triage_needed, session: }
     end
 
     trait :consent_refused do
-      state { "consent_refused" }
       patient { create :patient, :consent_refused, session: }
     end
 
     trait :consent_refused_with_notes do
-      state { "consent_refused" }
       patient { create :patient, :consent_refused_with_notes, session: }
     end
 
     trait :consent_conflicting do
-      state { "consent_conflicts" }
       patient { create :patient, :consent_conflicting, session: }
     end
 
     trait :triaged_ready_to_vaccinate do
-      state { "triaged_ready_to_vaccinate" }
       patient { create :patient, :consent_given_triage_needed, session: }
       triage do
         [create(:triage, status: :ready_to_vaccinate, notes: "Ok to vaccinate")]
@@ -71,19 +64,16 @@ FactoryBot.define do
     end
 
     trait :triaged_do_not_vaccinate do
-      state { "triaged_do_not_vaccinate" }
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :do_not_vaccinate, user:)] }
     end
 
     trait :triaged_kept_in_triage do
-      state { "triaged_kept_in_triage" }
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :needs_follow_up)] }
     end
 
     trait :delay_vaccination do
-      state { "delay_vaccination" }
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :delay_vaccination)] }
     end
@@ -93,7 +83,6 @@ FactoryBot.define do
     end
 
     trait :unable_to_vaccinate do
-      state { "unable_to_vaccinate" }
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
 
@@ -106,7 +95,6 @@ FactoryBot.define do
     end
 
     trait :vaccinated do
-      state { "vaccinated" }
       patient { create :patient, :consent_given_triage_needed, session: }
       triage { [create(:triage, status: :ready_to_vaccinate, user:)] }
 
@@ -129,7 +117,6 @@ FactoryBot.define do
     end
 
     trait :not_gillick_competent do
-      state { "unable_to_vaccinate_not_gillick_competent" }
       gillick_competent { false }
       gillick_competence_notes { "Assessed as not gillick competent" }
       gillick_competence_assessor { create :user }

--- a/spec/factories/patient_sessions.rb
+++ b/spec/factories/patient_sessions.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
 
       after :create do |patient_session|
         create :vaccination_record,
-               reason: :contraindications,
+               reason: :already_had,
                administered: false,
                patient_session:
       end

--- a/spec/factories/patients.rb
+++ b/spec/factories/patients.rb
@@ -161,29 +161,13 @@ FactoryBot.define do
     end
 
     factory :patient_with_consent_given_triage_not_needed do
-      patient_sessions do
-        [
-          build(
-            :patient_session,
-            session:,
-            state: "consent_given_triage_not_needed"
-          )
-        ]
-      end
+      patient_sessions { [build(:patient_session, session:)] }
 
       consents { [build(:consent, :given, campaign:, parent_relationship:)] }
     end
 
     factory :patient_with_consent_given_triage_needed do
-      patient_sessions do
-        [
-          build(
-            :patient_session,
-            session:,
-            state: "consent_given_triage_needed"
-          )
-        ]
-      end
+      patient_sessions { [build(:patient_session, session:)] }
 
       consents do
         [

--- a/spec/models/concerns/patient_session_state_concern_spec.rb
+++ b/spec/models/concerns/patient_session_state_concern_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe PatientSessionStateConcern do
+  let(:fake_state_machine_class) do
+    Class.new do
+      attr_accessor :state
+
+      include PatientSessionStateConcern
+    end
+  end
+
+  subject(:fsm) { fake_state_machine_class.new }
+
+  describe "#state" do
+    subject { fsm.state }
+
+    RSpec.shared_examples "it supports the state" do |state:, conditions:|
+      conditions_list = conditions.to_sentence
+
+      conditions_hash =
+        conditions.map { |condition| [:"#{condition}?", true] }.to_h
+
+      messages = {
+        consent_given?: false,
+        consent_refused?: false,
+        consent_conflicts?: false,
+        no_consent?: false,
+        not_gillick_competent?: false,
+        triage_needed?: false,
+        triage_not_needed?: false,
+        triage_ready_to_vaccinate?: false,
+        triage_do_not_vaccinate?: false,
+        triage_keep_in_triage?: false,
+        triage_delay_vaccination?: false,
+        vaccination_administered?: false,
+        vaccination_not_administered?: false,
+        vaccination_can_be_delayed?: false
+      }.merge(conditions_hash)
+
+      context "with conditions #{conditions_list}" do
+        before { allow(fsm).to receive_messages(**messages) }
+
+        it { should eq state.to_s }
+      end
+    end
+
+    it_behaves_like "it supports the state",
+                    state: :added_to_session,
+                    conditions: []
+
+    it_behaves_like "it supports the state",
+                    state: :consent_given_triage_needed,
+                    conditions: %i[consent_given triage_needed]
+
+    it_behaves_like "it supports the state",
+                    state: :consent_given_triage_not_needed,
+                    conditions: %i[consent_given triage_not_needed]
+
+    it_behaves_like "it supports the state",
+                    state: :consent_refused,
+                    conditions: [:consent_refused]
+
+    it_behaves_like "it supports the state",
+                    state: :consent_conflicts,
+                    conditions: [:consent_conflicts]
+
+    it_behaves_like "it supports the state",
+                    state: :unable_to_vaccinate_not_gillick_competent,
+                    conditions: [:not_gillick_competent]
+
+    it_behaves_like "it supports the state",
+                    state: :triaged_ready_to_vaccinate,
+                    conditions: [:triage_ready_to_vaccinate]
+
+    it_behaves_like "it supports the state",
+                    state: :triaged_do_not_vaccinate,
+                    conditions: [:triage_do_not_vaccinate]
+
+    it_behaves_like "it supports the state",
+                    state: :triaged_kept_in_triage,
+                    conditions: [:triage_keep_in_triage]
+
+    it_behaves_like "it supports the state",
+                    state: :delay_vaccination,
+                    conditions: [:triage_delay_vaccination]
+
+    it_behaves_like "it supports the state",
+                    state: :vaccinated,
+                    conditions: [:vaccination_administered]
+
+    it_behaves_like "it supports the state",
+                    state: :unable_to_vaccinate,
+                    conditions: [:vaccination_not_administered]
+
+    it_behaves_like "it supports the state",
+                    state: :delay_vaccination,
+                    conditions: [:vaccination_can_be_delayed]
+  end
+end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -25,6 +25,18 @@
 require "rails_helper"
 
 RSpec.describe PatientSession do
+  describe "#triage" do
+    it "returns the triage records in ascending order" do
+      later_triage = create(:triage)
+      earlier_triage = create(:triage, updated_at: 1.day.ago)
+
+      patient_sessions =
+        create :patient_session, triage: [earlier_triage, later_triage]
+
+      expect(patient_sessions.triage).to eq [earlier_triage, later_triage]
+    end
+  end
+
   describe "#vaccine_record" do
     it "returns the last non-draft vaccination record" do
       patient_session = create(:patient_session)


### PR DESCRIPTION
Now that we understand how states work better, and put all the states we need into the various objects connected to PatientSessions, it seems clear that the state machine isn't actually adding anything beyond additional hurdles and a false sense of comfort.

The new approach in this concern is something we discussed in the beginning; we "calculate" the PatientSession state by looking at the state of the various connected objects: consent, triage and vaccination_record. This was all being done in the state machine as it stands, anyway, the only additional complexity is the order in which we look at these objects. What's removed, really, are the transitions, and all the code to define, manage and test them.

Tasks remaining:
- [x] Some basic benchmarks, maybe even just benchmarking existing tests. The new approach requires a bigger database hit for each request cycle that looks at `PatientSession`, but this is unlikely to be an issue.
- [ ] Commit to this approach; remove state machine code for good.
- [ ] Remove `do_*` transition stub methods and calls to them
- [ ] Aspirational: See what tidying up we can do in `PatientSessionStateConcern` now that it doesn't conform to AASM.
- [ ] Aspirational: See if there's a way to tidy up `state` method. If we grouped together the vaccination_record, triage and consent checks, would that be better?