### PR TITLE
Improve performance of consent, triage and vaccination index pages

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -36,7 +36,7 @@ class ConsentsController < ApplicationController
       @session
         .patient_sessions
         .strict_loading
-        .includes(:campaign, :consents, :patient, :triage)
+        .includes(:campaign, :consents, :patient, :triage, :vaccination_records)
         .sort_by { |ps| ps.patient.full_name }
   end
 end

--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -161,7 +161,10 @@ class ManageConsentsController < ApplicationController
   end
 
   def set_consent
-    @consent = policy_scope(Consent).find(params[:consent_id])
+    @consent =
+      policy_scope(Consent).unscope(where: :recorded_at).find(
+        params[:consent_id]
+      )
   end
 
   def set_patient_session

--- a/app/controllers/patient_sessions_controller.rb
+++ b/app/controllers/patient_sessions_controller.rb
@@ -15,10 +15,13 @@ class PatientSessionsController < ApplicationController
 
   def set_patient_session
     @patient_session =
-      policy_scope(PatientSession).find_by!(
-        session_id: params.fetch(:session_id),
-        patient_id: params.fetch(:id)
-      )
+      policy_scope(PatientSession)
+        .includes(:patient, :session, :triage, :vaccination_records)
+        .preload(:consents)
+        .find_by!(
+          session_id: params.fetch(:session_id),
+          patient_id: params.fetch(:id)
+        )
   end
 
   def set_session

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,8 @@ class SessionsController < ApplicationController
       @session.patient_sessions.strict_loading.includes(
         :campaign,
         :consents,
-        :triage
+        :triage,
+        :vaccination_records
       )
 
     @counts =

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -15,7 +15,8 @@ class TriageController < ApplicationController
       @session
         .patient_sessions
         .strict_loading
-        .includes(:campaign, :patient, :triage)
+        .includes(:campaign, :patient, :triage, :vaccination_records)
+        .preload(:consents)
         .order("patients.first_name", "patients.last_name")
 
     tabs_to_states = {

--- a/app/controllers/vaccinations_controller.rb
+++ b/app/controllers/vaccinations_controller.rb
@@ -200,7 +200,9 @@ class VaccinationsController < ApplicationController
     @patient_sessions =
       @session
         .patient_sessions
-        .includes(:patient)
+        .strict_loading
+        .includes(:campaign, :patient, :triage, :vaccination_records)
+        .preload(:consents)
         .order("patients.first_name", "patients.last_name")
   end
 

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -113,19 +113,19 @@ module PatientSessionStateConcern
     end
 
     def triage_ready_to_vaccinate?
-      triage.last&.ready_to_vaccinate?
+      latest_triage&.ready_to_vaccinate?
     end
 
     def triage_keep_in_triage?
-      triage.last&.needs_follow_up?
+      latest_triage&.needs_follow_up?
     end
 
     def triage_do_not_vaccinate?
-      triage.last&.do_not_vaccinate?
+      latest_triage&.do_not_vaccinate?
     end
 
     def triage_delay_vaccination?
-      triage.last&.delay_vaccination?
+      latest_triage&.delay_vaccination?
     end
 
     def vaccination_administered?

--- a/app/models/concerns/patient_session_state_concern.rb
+++ b/app/models/concerns/patient_session_state_concern.rb
@@ -101,8 +101,7 @@ module PatientSessionStateConcern
     end
 
     def no_consent?
-      consents.recorded.empty? ||
-        consents.recorded.all?(&:response_not_provided?)
+      consents.empty? || consents.all?(&:response_not_provided?)
     end
 
     def triage_needed?

--- a/app/models/consent.rb
+++ b/app/models/consent.rb
@@ -49,9 +49,12 @@ class Consent < ApplicationRecord
              optional: true,
              foreign_key: :recorded_by_user_id
 
+  default_scope { recorded }
+
   scope :submitted_for_campaign,
         ->(campaign) { where(campaign:).where.not(recorded_at: nil) }
   scope :recorded, -> { where.not(recorded_at: nil) }
+  scope :draft, -> { rewhere(recorded_at: nil) }
 
   enum :parent_contact_method, %w[text voice other any], prefix: true
   enum :parent_relationship, %w[mother father guardian other], prefix: true

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -67,7 +67,6 @@ class PatientSession < ApplicationRecord
 
   def latest_consents
     consents
-      .recorded
       .group_by(&:name)
       .map { |_, consents| consents.max_by(&:recorded_at) }
   end

--- a/app/models/patient_session.rb
+++ b/app/models/patient_session.rb
@@ -37,7 +37,7 @@ class PatientSession < ApplicationRecord
              foreign_key: :gillick_competence_assessor_user_id
 
   has_one :campaign, through: :session
-  has_many :triage, -> { order(:updated_at) }
+  has_many :triage
   has_many :vaccination_records
   has_many :consents,
            ->(patient) { Consent.submitted_for_campaign(patient.campaign) },
@@ -57,7 +57,7 @@ class PatientSession < ApplicationRecord
   validates :gillick_competence_notes, length: { maximum: 1000 }
 
   def vaccination_record
-    vaccination_records.where.not(recorded_at: nil).last
+    vaccination_records.last
   end
 
   def able_to_vaccinate?
@@ -69,5 +69,9 @@ class PatientSession < ApplicationRecord
     consents
       .group_by(&:name)
       .map { |_, consents| consents.max_by(&:recorded_at) }
+  end
+
+  def latest_triage
+    triage.max_by(&:created_at)
   end
 end

--- a/spec/models/patient_session_spec.rb
+++ b/spec/models/patient_session_spec.rb
@@ -103,4 +103,17 @@ RSpec.describe PatientSession do
       end
     end
   end
+
+  describe "#latest_triage" do
+    it "returns the latest triage record" do
+      earlier_triage =
+        build :triage, status: :needs_follow_up, created_at: 1.day.ago
+      later_triage = build :triage, status: :ready_to_vaccinate
+
+      patient_session =
+        create :patient_session, triage: [earlier_triage, later_triage]
+
+      expect(patient_session.latest_triage).to eq later_triage
+    end
+  end
 end


### PR DESCRIPTION
This PR optmises our queries related to PatientSession and it's associations, `consents`, `triage` and `vaccination_records`. The primary issue was that N+1 queries were being generated, even for associations that were included in the original query, because we were using the `recorded` scope which discarded the already loaded objects and reloaded them again with a new query. Also some of the associations weren't being preloaded correctly.

The result was that before the new state concern, on my system, the Check consent, Triage or Vaccination pages would all take about 200ms for the request to complete according to Rails. With the original version of the new state refactoring, that ballooned up to around 400ms or more, but with these optimisations this has been brought down to 100ms or less, fasterr than the state machine version. :tada: