### PR TITLE
Reset common name if not used

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -47,6 +47,7 @@ class ConsentForm < ApplicationRecord
   include WizardFormConcern
   include AgeConcern
 
+  before_save :reset_common_name_if_not_used
   before_save :seed_health_questions_if_consent_given
   before_save :remove_health_questions_if_consent_refused
 
@@ -350,5 +351,9 @@ class ConsentForm < ApplicationRecord
   def remove_health_questions_if_consent_refused
     return unless consent_refused? || health_answers.empty?
     self.health_answers = []
+  end
+
+  def reset_common_name_if_not_used
+    self.common_name = nil unless use_common_name?
   end
 end

--- a/spec/components/app_patient_details_component_spec.rb
+++ b/spec/components/app_patient_details_component_spec.rb
@@ -80,7 +80,11 @@ RSpec.describe AppPatientDetailsComponent, type: :component do
 
   context "with a consent_form object" do
     let(:consent_form) do
-      FactoryBot.create(:consent_form, common_name: "Homer")
+      FactoryBot.create(
+        :consent_form,
+        common_name: "Homer",
+        use_common_name: true
+      )
     end
     let(:school) { FactoryBot.create(:location) }
     let(:component) { described_class.new(consent_form:, session:, school:) }

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -768,4 +768,12 @@ RSpec.describe ConsentForm, type: :model do
       expect(consent_form.summary_with_route).to eq("Consent refused (online)")
     end
   end
+
+  it "resets the common name when not used" do
+    consent_form =
+      build(:consent_form, common_name: "John", use_common_name: true)
+    consent_form.update!(use_common_name: false)
+
+    expect(consent_form.common_name).to be_nil
+  end
 end


### PR DESCRIPTION
This prevents a case where users change their mind on the common name field but it stays on the actual record.