### PR TITLE
Make triage tabs do page reloads

### DIFF
--- a/app/components/app_tab_component.rb
+++ b/app/components/app_tab_component.rb
@@ -21,10 +21,20 @@ class AppTabComponent < GovukComponent::Base
   class Tab < GovukComponent::Base
     attr_reader :label, :text
 
-    def initialize(label:, text: nil, id: nil, classes: [], html_attributes: {})
+    def initialize(
+      label:,
+      selected: nil,
+      link: nil,
+      text: nil,
+      id: nil,
+      classes: [],
+      html_attributes: {}
+    )
       @label = label
       @text = text
       @id = id || label.parameterize
+      @selected = selected
+      @link = link || id(prefix: "#")
 
       super(classes:, html_attributes:)
     end
@@ -33,21 +43,23 @@ class AppTabComponent < GovukComponent::Base
       [prefix, @id].join
     end
 
-    def hidden_class(tab_index = nil)
-      return [] if tab_index&.zero?
-
-      ["#{brand}-tabs__panel--hidden"]
+    def selected(tab_index = nil)
+      @selected.nil? ? tab_index.zero? : @selected
     end
 
-    def li_classes(tab_index = nil)
+    def hidden_class(tab_index)
+      selected(tab_index) ? [] : ["#{brand}-tabs__panel--hidden"]
+    end
+
+    def li_classes(tab_index)
       class_names(
         "#{brand}-tabs__list-item",
-        "#{brand}-tabs__list-item--selected" => tab_index&.zero?
+        "#{brand}-tabs__list-item--selected" => selected(tab_index)
       ).split
     end
 
     def li_link
-      link_to(label, id(prefix: "#"), class: "#{brand}-tabs__tab")
+      link_to(label, @link, class: "#{brand}-tabs__tab")
     end
 
     def default_attributes

--- a/app/controllers/triage_controller.rb
+++ b/app/controllers/triage_controller.rb
@@ -11,7 +11,7 @@ class TriageController < ApplicationController
   layout "two_thirds", except: %i[index]
 
   def index
-    patient_sessions =
+    all_patient_sessions =
       @session
         .patient_sessions
         .strict_loading
@@ -34,16 +34,16 @@ class TriageController < ApplicationController
       ]
     }
 
-    @tabs =
-      patient_sessions.group_by do |patient_session|
+    @current_tab = TAB_PATHS[:triage][params[:tab]]
+    tabs_to_states[@current_tab]
+    tab_patient_sessions =
+      all_patient_sessions.group_by do |patient_session|
         tabs_to_states
           .find { |_, states| patient_session.state.in? states }
           &.first
       end
-
-    # ensure all tabs are present
-    tabs_to_states.each_key { |tab| @tabs[tab] ||= [] }
-
+    @tab_counts = tab_patient_sessions.transform_values(&:count)
+    @patient_sessions = tab_patient_sessions[@current_tab] || []
     session[:current_section] = "triage"
   end
 

--- a/app/views/triage/index.html.erb
+++ b/app/views/triage/index.html.erb
@@ -11,31 +11,35 @@
 
 <%= h1 page_title, page_title: %>
 
-<% def consent_tab(slot, state, columns: %i[name dob])
+<% def tab_content(slot, state, tab_path, columns: %i[name dob])
   label = t("states.#{state}.label")
-  data = @tabs[state]
-  slot.with_tab(id: label.parameterize,
-                label: "#{label} (#{data.size})",
-                classes: 'nhsuk-tabs__panel') do
-    if data.size > 0
+  selected = state == @current_tab
+  path = triage_tab_session_path(@session, tab: tab_path)
+  count = @tab_counts[state]
+
+  slot.with_tab(
+    id: label.parameterize,
+    link: path,
+    label: "#{label} (#{count})",
+    classes: 'nhsuk-tabs__panel',
+    selected:
+  ) do
+    if selected && @patient_sessions.size > 0
       render AppPatientTableComponent.new(
-        patient_sessions: data,
+        patient_sessions: @patient_sessions,
         tab_id: label.parameterize,
         caption: t("states.#{state}.title"),
         columns:,
         route: :triage,
       )
     else
-      render AppEmptyListComponent.new(
-        title: t("states.#{state}.title"),
-        text: t("table.no_results")
-      )
+      ""
     end
   end
 end %>
 
 <%= render AppTabComponent.new title: "Consents", classes: 'nhsuk-tabs' do |slot|
-  consent_tab(slot, :needs_triage)
-  consent_tab(slot, :triage_complete)
-  consent_tab(slot, :no_triage_needed)
+  tab_content(slot, :needs_triage, :needed)
+  tab_content(slot, :triage_complete, :completed)
+  tab_content(slot, :no_triage_needed, :"not-needed")
 end %>

--- a/config/initializers/tabs.rb
+++ b/config/initializers/tabs.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/env ruby
+
+TAB_PATHS = {
+  triage: {
+    "needed" => :needs_triage,
+    "completed" => :triage_complete,
+    "not-needed" => :no_triage_needed
+  }
+}.with_indifferent_access

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,7 +80,15 @@ Rails.application.routes.draw do
         to: "consent_forms#unmatched_responses",
         on: :member,
         as: :unmatched_responses
-    get "triage", to: "triage#index", on: :member
+    get "triage",
+        to: redirect("/sessions/%{id}/triage/needed"),
+        as: :triage,
+        on: :member
+    get "triage/:tab",
+        to: "triage#index",
+        on: :member,
+        as: :triage_tab,
+        tab: /#{TAB_PATHS[:triage].keys.join("|")}/
     get "vaccinations", to: "vaccinations#index", on: :member
 
     resources :edit_sessions, only: %i[show update], path: "edit", as: :edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,19 @@ Rails.application.routes.draw do
   end
 
   resources :sessions, only: %i[create edit index show update] do
+    namespace :parent_interface, path: "/" do
+      resources :consent_forms, path: :consents, only: [:create] do
+        get "start", on: :collection
+        get "cannot-consent-school"
+        get "cannot-consent-responsibility"
+        get "deadline-passed", on: :collection
+        get "confirm"
+        put "record"
+
+        resources :edit, only: %i[show update], controller: "consent_forms/edit"
+      end
+    end
+
     get "consents", to: "consents#index", on: :member
     get "consents/unmatched-responses",
         to: "consent_forms#unmatched_responses",
@@ -74,19 +87,6 @@ Rails.application.routes.draw do
 
     constraints -> { Flipper.enabled?(:make_session_in_progress_button) } do
       put "make-in-progress", to: "sessions#make_in_progress", on: :member
-    end
-
-    namespace :parent_interface, path: "/" do
-      resources :consent_forms, path: :consents, only: [:create] do
-        get "start", on: :collection
-        get "cannot-consent-school"
-        get "cannot-consent-responsibility"
-        get "deadline-passed", on: :collection
-        get "confirm"
-        put "record"
-
-        resources :edit, only: %i[show update], controller: "consent_forms/edit"
-      end
     end
 
     resources :patients, only: [] do

--- a/spec/features/triage_delay_vaccination_spec.rb
+++ b/spec/features/triage_delay_vaccination_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe "Triage" do
 
     when_i_click_on_a_patient
     and_i_enter_a_note_and_delay_vaccination
-    then_i_see_the_patient_in_triage_completed
+    then_i_see_an_alert_saying_the_record_was_saved
+
+    when_i_go_to_the_triage_completed_tab
+    then_i_see_the_patient
 
     when_i_access_the_record_vaccinations_area
     then_i_see_the_patient_in_the_vaccinate_later_tab
@@ -53,9 +56,18 @@ RSpec.describe "Triage" do
     click_button "Save triage"
   end
 
-  def then_i_see_the_patient_in_triage_completed
-    expect(page).to have_content("Record saved for #{@patient.full_name}")
+  def then_i_see_an_alert_saying_the_record_was_saved
+    expect(page).to have_alert(
+      "Success",
+      text: "Record saved for #{@patient.full_name}"
+    )
+  end
 
+  def when_i_go_to_the_triage_completed_tab
+    click_link "Triage completed"
+  end
+
+  def then_i_see_the_patient
     within "div#triage-completed" do
       expect(page).to have_content(@patient.full_name)
     end

--- a/tests/nurse_consent_no_response.spec.ts
+++ b/tests/nurse_consent_no_response.spec.ts
@@ -113,7 +113,7 @@ async function then_the_consent_form_is_prefilled() {
 
 async function when_i_go_to_the_triage_completed_tab() {
   await p.goto("/sessions/1/triage");
-  await p.getByRole("tab", { name: "Triage completed" }).click();
+  await p.getByRole("link", { name: "Triage completed" }).click();
 }
 
 async function then_the_patient_is_triaged() {

--- a/tests/sign_in.spec.ts
+++ b/tests/sign_in.spec.ts
@@ -79,5 +79,5 @@ async function when_i_go_to_the_triage_page() {
 }
 
 async function then_i_should_see_the_triage_page() {
-  await expect(p).toHaveURL("/sessions/1/triage");
+  await expect(p).toHaveURL("/sessions/1/triage/needed");
 }

--- a/tests/triage.spec.ts
+++ b/tests/triage.spec.ts
@@ -74,7 +74,7 @@ async function and_i_enter_a_note_and_select_ready_to_vaccinate() {
 }
 
 async function when_i_click_on_the_triage_complete_tab() {
-  await p.getByRole("tab", { name: "Triage completed" }).click();
+  await p.getByRole("link", { name: "Triage completed" }).click();
 }
 const and_i_click_on_the_triage_complete_tab =
   when_i_click_on_the_triage_complete_tab;


### PR DESCRIPTION
Make the triage tabs do full page reloads instead of using JS to hide/show tabs.

Currently the consent, triage and vaccination sections load up all the tabs and use JS to switch between them. The current implementation has a couple downsides:

- back-buttons are harder to implement
- the page is a mess on mobile and non-JS
- and to a lesser extent, there will be performance risks as we have sessions with more users

This PR is the first step to changing them all to page reloads. Current issues with this implementation:

- nhsuk-frontend currently breaks because it depends on discovering the tab label by examining the link for the tab and using the fragment from it (see https://github.com/nhsuk/nhsuk-frontend/blob/main/packages/components/tabs/tabs.js#L306). This means that the `role` and other aria-related attributes are broken, although the behaviour seems to work
- scroll position is lost since, predictably, the page reload loses the position. Maybe this could be fixed if we implemented content-replacement?

Work remaining after this PR:
- [ ] convert consents and vaccinations sections
- [ ] move the patient pages into the new URL paths, e.g. `/sessions/1/triage/needed/patients/2` and change the back buttons to rely on the path instead of cookies
- [ ] re-implement the tabs themselves, these are being redesigned and we won't be able to use the govuk tabs components (see above issues)
