### PR TITLE
Adjust password input styling

### DIFF
--- a/app/assets/stylesheets/_password-input.scss
+++ b/app/assets/stylesheets/_password-input.scss
@@ -1,8 +1,56 @@
+$button-shadow-size: 2px;
+
+.nhsuk-password-input__input {
+  // IE 11 and Microsoft Edge comes with its own password reveal function. We
+  // want to hide it, so that there aren't two controls presented to the user
+  // that do the same thing but aren't in sync with one another. This doesn't
+  // affect the function that allows Edge users to toggle password visibility
+  // by pressing Alt+F8, which cannot be programmatically disabled.
+  &::-ms-reveal {
+    display: none;
+  }
+}
+
 .nhsuk-password-input__toggle {
-  height: 35px;
-  margin-bottom: 0;
-  margin-left: 5px;
-  padding-bottom: 0px;
-  padding-top: 3px;
-  width: 100px;
+  // Reduce shadow size to align with input border
+  box-shadow: 0 $button-shadow-size 0 $nhsuk-secondary-button-shadow-color;
+
+  // Reduce font weight
+  font-weight: normal;
+
+  // Adjust bottom margin to offset shadow size given flex-end alignment
+  margin-bottom: $button-shadow-size;
+
+  // Add margin to top so that button doesn’t obscure input’s focus style
+  margin-top: nhsuk-spacing(1);
+
+  // Adjust padding to match size of input
+  padding: #{nhsuk-spacing(1) + 2px};
+
+  // Make full width at smaller breakpoints
+  width: 100%;
+
+  &:active {
+    top: $button-shadow-size;
+  }
+
+  // Hide button by default, JS removes this attribute
+  &[hidden] {
+    display: none;
+  }
+
+  @include mq($from: mobile) {
+    flex: 1 0 5em;
+
+    // Move spacing from top to the left
+    margin-left: nhsuk-spacing(1);
+    margin-top: 0;
+
+    // Adjust padding to account for smaller shadow
+    padding-bottom: #{nhsuk-spacing(1) - $button-shadow-size};
+    padding-top: nhsuk-spacing(1);
+
+    // Reset width
+    width: auto;
+  }
 }

--- a/app/assets/stylesheets/_utilities.scss
+++ b/app/assets/stylesheets/_utilities.scss
@@ -14,6 +14,9 @@
   }
 }
 
+// Some govuk-frontend JS components dynamically insert content with the
+// govuk-visually-hidden class. So we need to shim both namespaces.
+.govuk-visually-hidden,
 .nhsuk-visually-hidden {
   @include visually-hidden();
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -57,9 +57,3 @@ $mq-breakpoints: (
 mark {
   background-color: $color_nhsuk-pale-yellow;
 }
-
-// Some govuk-frontend JS components dynamically insert content with the
-// govuk-visually-hidden class. So we need to shim it.
-.govuk-visually-hidden {
-  @extend .nhsuk-visually-hidden;
-}


### PR DESCRIPTION
- Incorporate relevant styling from upstream GOV.UK component
- Adjust design of button to work in this inline context (button shadow size, mainly)
- Move `govuk-visually-hidden` into same file as `nhsuk-visually-hidden`

## < 320px

![Screenshot of password input at < 320px.](https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/51fdf38b-aa40-4508-9fa4-5bd06450821e)

## <= 640px

![Screenshot of password input at <= 640px.](https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/dbe08f92-0348-48a0-911c-e0373b7d3376)

## > 640px

![Screenshot of password input at > 640px.](https://github.com/nhsuk/manage-childrens-vaccinations/assets/813383/5c7fa477-b6d0-4db9-bad0-4348154ea77a)
 