### PR TITLE
Quote args in bin/lint

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -2,7 +2,7 @@
 
 bin/bundle exec rubocop --autocorrect-all $*
 yarn prettier --write --list-different --ignore-unknown ${*:-'**/*'}
-if [ -z $* ]
+if [ -z "$*" ]
 then
    bin/bundle exec brakeman --quiet --no-summary --no-pager
 fi


### PR DESCRIPTION
Required when passing in multiple files.