### PR TITLE
Reset unused fields on ConsentForm when saving

### DIFF
--- a/app/models/consent_form.rb
+++ b/app/models/consent_form.rb
@@ -47,7 +47,7 @@ class ConsentForm < ApplicationRecord
   include WizardFormConcern
   include AgeConcern
 
-  before_save :reset_common_name_if_not_used
+  before_save :reset_unused_fields
   before_save :seed_health_questions_if_consent_given
   before_save :remove_health_questions_if_consent_refused
 
@@ -353,7 +353,15 @@ class ConsentForm < ApplicationRecord
     self.health_answers = []
   end
 
-  def reset_common_name_if_not_used
+  def reset_unused_fields
     self.common_name = nil unless use_common_name?
+
+    self.contact_method = nil unless ask_for_contact_method?
+    self.contact_method_other = nil unless contact_method_other?
+
+    self.reason = nil unless consent_refused?
+    self.reason_notes = nil unless consent_refused?
+
+    self.gp_name = nil unless gp_response_yes?
   end
 end

--- a/spec/models/consent_form_spec.rb
+++ b/spec/models/consent_form_spec.rb
@@ -769,11 +769,31 @@ RSpec.describe ConsentForm, type: :model do
     end
   end
 
-  it "resets the common name when not used" do
+  it "resets unused fields" do
     consent_form =
       build(:consent_form, common_name: "John", use_common_name: true)
     consent_form.update!(use_common_name: false)
-
     expect(consent_form.common_name).to be_nil
+
+    consent_form =
+      build(
+        :consent_form,
+        response: "refused",
+        reason: "contains_gelatine",
+        reason_notes: "I'm vegan"
+      )
+    consent_form.update!(response: "given")
+    expect(consent_form.reason).to be_nil
+    expect(consent_form.reason_notes).to be_nil
+
+    consent_form =
+      build(:consent_form, contact_method: "other", contact_method_other: "foo")
+    consent_form.update!(parent_phone: nil)
+    expect(consent_form.contact_method).to be_nil
+    expect(consent_form.contact_method_other).to be_nil
+
+    consent_form = build(:consent_form, gp_response: "yes", gp_name: "Dr. Foo")
+    consent_form.update!(gp_response: "no")
+    expect(consent_form.gp_name).to be_nil
   end
 end


### PR DESCRIPTION
Ensures that data stored in dynamic fields is not saved when the form is updated and those fields become irrelevant.