### PR TITLE
Fix back link on manage consents journey

### DIFF
--- a/app/controllers/manage_consents_controller.rb
+++ b/app/controllers/manage_consents_controller.rb
@@ -17,6 +17,9 @@ class ManageConsentsController < ApplicationController
   before_action :set_triage,
                 except: %i[create],
                 if: -> { step.in?(%w[questions confirm]) }
+  before_action :set_back_link,
+                only: %i[show],
+                if: -> { wizard_value(step).present? }
 
   def create
     @consent = Consent.create! create_params
@@ -69,8 +72,12 @@ class ManageConsentsController < ApplicationController
 
   private
 
+  def set_back_link
+    current_step # Set the current_step for the back link
+  end
+
   def current_step
-    wizard_value(step).to_sym
+    @current_step ||= wizard_value(step).to_sym
   end
 
   def finish_wizard_path

--- a/app/helpers/manage_consents_helper.rb
+++ b/app/helpers/manage_consents_helper.rb
@@ -10,4 +10,21 @@ module ManageConsentsHelper
   def include_clone_fields_for(consent)
     consent.recorded?
   end
+
+  # rubocop:disable Rails/HelperInstanceVariable
+  def back_link_path
+    if @consent.form_steps.first == @current_step
+      case @route
+      when "consents"
+        session_patient_consents_path(@session, @patient)
+      when "triage"
+        session_patient_triage_path(@session)
+      else
+        session_patient_vaccinations_path(@session)
+      end
+    else
+      previous_wizard_path
+    end
+  end
+  # rubocop:enable Rails/HelperInstanceVariable
 end

--- a/app/views/manage_consents/agree.html.erb
+++ b/app/views/manage_consents/agree.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
+    href: back_link_path,
     name: "contact details page",
   ) %>
 <% end %>

--- a/app/views/manage_consents/confirm.html.erb
+++ b/app/views/manage_consents/confirm.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
+    href: back_link_path,
     name: "previous page",
   ) %>
 <% end %>

--- a/app/views/manage_consents/gillick.html.erb
+++ b/app/views/manage_consents/gillick.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
+    href: back_link_path,
     name: "consent page",
   ) %>
 <% end %>

--- a/app/views/manage_consents/questions.html.erb
+++ b/app/views/manage_consents/questions.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
+    href: back_link_path,
     name: "consent page",
   ) %>
 <% end %>

--- a/app/views/manage_consents/reason.html.erb
+++ b/app/views/manage_consents/reason.html.erb
@@ -1,6 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: previous_wizard_path,
+    href: back_link_path,
     name: "consent page",
   ) %>
 <% end %>

--- a/app/views/manage_consents/who.html.erb
+++ b/app/views/manage_consents/who.html.erb
@@ -1,13 +1,6 @@
 <% content_for :before_main do %>
   <%= render AppBacklinkComponent.new(
-    href: case @route
-      when 'consents'
-        session_patient_consents_path(@session, @patient)
-      when "triage"
-        session_patient_triage_path(@session)
-      else
-        session_patient_vaccinations_path(@session)
-      end,
+    href: back_link_path,
     name: "patient page",
   ) %>
 <% end %>

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -11,7 +11,13 @@ feature "Verbal consent" do
     and_i_am_logged_in_as_a_nurse
 
     when_the_nurse_checks_the_consent_responses_given
-    and_i_call_the_parent_that_has_refused_consent
+    and_i_contact_the_parent_that_has_refused_consent
+    then_i_see_the_consent_question_page
+
+    when_i_go_back
+    then_i_see_the_patient_page
+
+    when_i_call_the_parent_that_has_refused_consent
     and_consent_is_given_verbally
     then_i_am_returned_to_the_check_consent_responses_page
     and_i_see_the_success_alert
@@ -43,9 +49,11 @@ feature "Verbal consent" do
     click_on @child.full_name
   end
 
-  def and_i_call_the_parent_that_has_refused_consent
+  def when_i_call_the_parent_that_has_refused_consent
     click_on "Contact #{@child.consents.first.parent_name}"
   end
+  alias_method :and_i_contact_the_parent_that_has_refused_consent,
+               :when_i_call_the_parent_that_has_refused_consent
 
   def and_consent_is_given_verbally
     choose "Yes, they agree"
@@ -76,5 +84,17 @@ feature "Verbal consent" do
     within "div#given" do
       expect(page).to have_content(@child.full_name)
     end
+  end
+
+  def then_i_see_the_consent_question_page
+    expect(page).to have_content("Do they agree")
+  end
+
+  def when_i_go_back
+    click_on "Back"
+  end
+
+  def then_i_see_the_patient_page
+    expect(page).to have_content(@child.full_name)
   end
 end


### PR DESCRIPTION
When nurses amend an existing consent, the link sends them to the middle of a consent wizard. `previous_wizard_path` links to the first step in the journey, which causes the back button to go into a loop, because the first step is the :agree one which the user is currently on.

This adds a special `back_link_path` helper that checks for this case and works around it by instead sending a user to the session path for their route. The code to do this is extracted from the :who step. This way, every step is now a possible "first step" depending on how the logic to handle the list of `form_steps` changes.

TODO:

- [x] Tests