### PR TITLE
Convert consents to page-load tabs

### DIFF
--- a/app/controllers/consents_controller.rb
+++ b/app/controllers/consents_controller.rb
@@ -1,23 +1,43 @@
 class ConsentsController < ApplicationController
   before_action :set_session
-  before_action :set_patient_sessions, only: %i[index]
 
   layout "two_thirds", except: :index
 
   def index
-    methods = %i[consent_given? consent_refused? consent_conflicts? no_consent?]
+    tab_conditions = {
+      consent_given: %i[consent_given?],
+      consent_refused: %i[consent_refused?],
+      conflicting_consent: %i[consent_conflicts?],
+      no_consent: %i[no_consent?]
+    }
+
+    all_patient_sessions =
+      @session
+        .patient_sessions
+        .strict_loading
+        .includes(:campaign, :consents, :patient, :triage, :vaccination_records)
+        .sort_by { |ps| ps.patient.full_name }
 
     @unmatched_record_counts =
-      SessionStats.new(patient_sessions: @patient_sessions, session: @session)[
+      SessionStats.new(
+        patient_sessions: all_patient_sessions,
+        session: @session
+      )[
         :unmatched_responses
       ]
 
-    @tabs =
-      @patient_sessions.group_by do |patient_session|
-        methods.find { |m| patient_session.send(m) }
-      end
+    @current_tab = TAB_PATHS[:consent][params[:tab]]
 
-    methods.each { |m| @tabs[m] ||= [] }
+    tab_patient_sessions =
+      all_patient_sessions.group_by do |patient_session|
+        tab_conditions
+          .find { |_, conditions| conditions.any? { patient_session.send(_1) } }
+          &.first
+      end
+    @tab_counts = tab_patient_sessions.transform_values(&:count)
+    tab_conditions.each_key { |tab| @tab_counts[tab] ||= 0 }
+
+    @patient_sessions = tab_patient_sessions[@current_tab] || []
 
     session[:current_section] = "consents"
   end
@@ -29,14 +49,5 @@ class ConsentsController < ApplicationController
       policy_scope(Session).find(
         params.fetch(:session_id) { params.fetch(:id) }
       )
-  end
-
-  def set_patient_sessions
-    @patient_sessions =
-      @session
-        .patient_sessions
-        .strict_loading
-        .includes(:campaign, :consents, :patient, :triage, :vaccination_records)
-        .sort_by { |ps| ps.patient.full_name }
   end
 end

--- a/app/views/consents/index.html.erb
+++ b/app/views/consents/index.html.erb
@@ -27,32 +27,36 @@
   <% end %>
 <% end %>
 
-<% def consent_tab(slot, state, columns: %i[name dob])
+<% def tab_content(slot, state, tab_path, columns: %i[name dob])
   label = t("states.#{state}.label")
-  data = @tabs[state]
-  slot.with_tab(id: label.parameterize,
-                label: "#{label} (#{data.size})",
-                classes: 'nhsuk-tabs__panel') do
-    if data.size > 0
+  selected = state == @current_tab
+  path = consents_tab_session_path(@session, tab: tab_path)
+  count = @tab_counts[state]
+
+  slot.with_tab(
+    id: label.parameterize,
+    link: path,
+    label: "#{label} (#{count})",
+    classes: 'nhsuk-tabs__panel',
+    selected:
+  ) do
+    if selected && @patient_sessions.size > 0
       render AppPatientTableComponent.new(
-        patient_sessions: data,
+        patient_sessions: @patient_sessions,
         tab_id: label.parameterize,
         caption: t("states.#{state}.title"),
         columns:,
-        route: :consent,
+        route: :consent
       )
     else
-      render AppEmptyListComponent.new(
-        title: t("states.#{state}.title"),
-        text: t("table.no_results")
-      )
+      ""
     end
   end
 end %>
 
 <%= render AppTabComponent.new title: "Consents", classes: 'nhsuk-tabs' do |slot|
-  consent_tab(slot, :no_consent?)
-  consent_tab(slot, :consent_given?)
-  consent_tab(slot, :consent_refused?, columns: %i[name dob reason])
-  consent_tab(slot, :consent_conflicts?)
+  tab_content(slot, :no_consent, :"no-consent")
+  tab_content(slot, :consent_given, :given)
+  tab_content(slot, :consent_refused, :refused, columns: %i[name dob reason])
+  tab_content(slot, :conflicting_consent, :conflicts)
 end %>

--- a/config/initializers/tabs.rb
+++ b/config/initializers/tabs.rb
@@ -1,6 +1,12 @@
 #!/usr/bin/env ruby
 
 TAB_PATHS = {
+  consent: {
+    "no-consent" => :no_consent,
+    "given" => :consent_given,
+    "refused" => :consent_refused,
+    "conflicts" => :conflicting_consent
+  },
   triage: {
     "needed" => :needs_triage,
     "completed" => :triage_complete,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,16 +21,16 @@ en:
     accessibility_statement: "Accessibility statement"
     privacy_policy: "Your privacy"
   states:
-    consent_given?:
+    consent_given:
       label: Given
       title: Children with consent given
-    consent_refused?:
+    consent_refused:
       label: Refused
       title: Children with consent refused
-    consent_conflicts?:
+    conflicting_consent:
       label: Conflicts
       title: Children with conflicting consent responses
-    no_consent?:
+    no_consent:
       label: No response
       title: Children with no consent response
     needs_triage:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,13 +75,25 @@ Rails.application.routes.draw do
       end
     end
 
-    get "consents", to: "consents#index", on: :member
+    get "consents",
+        to:
+          redirect(
+            "/sessions/%{id}/consents/#{TAB_PATHS[:consent].keys.first}"
+          ),
+        as: :consents,
+        on: :member
+
     get "consents/unmatched-responses",
         to: "consent_forms#unmatched_responses",
         on: :member,
         as: :unmatched_responses
+    get "consents/:tab",
+        to: "consents#index",
+        on: :member,
+        as: :consents_tab,
+        tab: /#{TAB_PATHS[:consent].keys.join("|")}/
     get "triage",
-        to: redirect("/sessions/%{id}/triage/needed"),
+        to: redirect("/sessions/%{id}/triage/#{TAB_PATHS[:triage].keys.first}"),
         as: :triage,
         on: :member
     get "triage/:tab",

--- a/spec/features/triage_during_consent_spec.rb
+++ b/spec/features/triage_during_consent_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Triage" do
   end
 
   def when_i_go_to_the_given_tab_of_the_consents_page
-    visit consents_session_path(@session, anchor: "given")
+    visit consents_tab_session_path(@session, tab: "given")
   end
 
   def and_i_go_to_the_patient_that_needs_triage

--- a/spec/features/verbal_consent_given_when_previously_refused_spec.rb
+++ b/spec/features/verbal_consent_given_when_previously_refused_spec.rb
@@ -21,7 +21,9 @@ feature "Verbal consent" do
     and_consent_is_given_verbally
     then_i_am_returned_to_the_check_consent_responses_page
     and_i_see_the_success_alert
-    and_i_see_them_in_the_consent_given_tab
+
+    when_i_click_on_the_consent_given_tab
+    then_i_see_the_child_has_consent_given
   end
 
   def given_an_hpv_campaign_is_underway
@@ -80,10 +82,12 @@ feature "Verbal consent" do
     )
   end
 
-  def and_i_see_them_in_the_consent_given_tab
-    within "div#given" do
-      expect(page).to have_content(@child.full_name)
-    end
+  def when_i_click_on_the_consent_given_tab
+    click_on "Given"
+  end
+
+  def then_i_see_the_child_has_consent_given
+    expect(page).to have_content(@child.full_name)
   end
 
   def then_i_see_the_consent_question_page

--- a/tests/nurse_consent_conflicting_consent.spec.ts
+++ b/tests/nurse_consent_conflicting_consent.spec.ts
@@ -35,7 +35,7 @@ async function given_i_am_checking_consent() {
 }
 
 async function when_i_select_a_child_with_conflicting_consent() {
-  await p.getByRole("tab", { name: "Conflicts" }).click();
+  await p.getByRole("link", { name: "Conflicts" }).click();
   await p
     .getByRole("link", { name: fixtures.patientWithConflictingConsent })
     .click();
@@ -85,7 +85,7 @@ async function then_i_see_the_success_banner() {
 }
 
 async function when_i_select_the_same_patient() {
-  await p.getByRole("tab", { name: "Given" }).click();
+  await p.getByRole("link", { name: "Given" }).click();
   await p
     .getByRole("link", { name: fixtures.patientWithConflictingConsent })
     .click();

--- a/tests/schools_match_response.spec.ts
+++ b/tests/schools_match_response.spec.ts
@@ -46,7 +46,7 @@ async function and_i_click_on_the_check_consent_responses_link() {
 }
 
 async function and_a_specific_cohort_record_is_not_present() {
-  await p.getByRole("tab", { name: "Given" }).click();
+  await p.getByRole("link", { name: "Given" }).click();
   await expect(
     p
       .locator(
@@ -131,7 +131,7 @@ async function and_i_link_the_response_with_the_record() {
 }
 
 async function and_the_matched_cohort_appears_in_the_consent_given_list() {
-  await p.getByRole("tab", { name: "Given" }).click();
+  await p.getByRole("link", { name: "Given" }).click();
   await expect(
     p
       .locator(


### PR DESCRIPTION
For the same reason why we did the triage tabs, this makes is easier for us to do some things like back buttons.

These commits have been split off of an existing branch to make reviewing easier. This other branch adds a concern to encapsulate methods to group patient_sessions.
